### PR TITLE
Donotskip

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -4486,6 +4486,7 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxxVideo()
 {
     Element_Name("Video");
 
+    int32u Junk;
     int16u Width, Height, Depth, ColorTableID;
     int8u  CompressorName_Size;
     Skip_B2(                                                    "Version");
@@ -4499,17 +4500,11 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxxVideo()
     Skip_B4(                                                    "Vertical resolution");
     Skip_B4(                                                    "Data size");
     Skip_B2(                                                    "Frame count");
-    Peek_B1(CompressorName_Size);
-    if (CompressorName_Size<32)
-    {
-        //This is pascal string
-        Skip_B1(                                                "Compressor name size");
-        Skip_Local(CompressorName_Size,                         "Compressor name");
-        Skip_XX(32-1-CompressorName_Size,                       "Padding");
-    }
-    else
-        //this is hard-coded 32-byte string
-        Skip_Local(32,                                          "Compressor name");
+    Get_B4 (Junk,                                               "Junk");
+    Get_B4 (Junk,                                               "Junk");
+    Get_B4 (Junk,                                               "Junk");
+    Get_B4 (Junk,                                               "Junk");
+
     Get_B2 (Depth,                                              "Depth");
     Get_B2 (ColorTableID,                                       "Color table ID");
     if ((Depth==2 || Depth==4 || Depth==8) && ColorTableID==0)

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -4512,8 +4512,22 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxxVideo()
         Skip_Local(32,                                          "Compressor name");
     Get_B2 (Depth,                                              "Depth");
     Get_B2 (ColorTableID,                                       "Color table ID");
-    if (ColorTableID==0 && Width && Height) //In one file, if Zero-filled, Color table is not present
-        Skip_XX(32,                                             "Color Table");
+    if ((Depth==2 || Depth==4 || Depth==8) && ColorTableID==0)
+    {
+        int32u ColorStart;
+        int16u ColorCount, ColorEnd;
+        Get_B4 (ColorStart,                                     "Color Start");
+        Get_B2 (ColorCount,                                     "Color Count");
+        Get_B2 (ColorEnd,                                       "Color End");
+        if (ColorStart<=255 && ColorEnd<=255) {
+            for (int j=ColorStart; j<=ColorEnd; j++) {
+                Skip_B2(                                        "Alpha");
+                Skip_B2(                                        "Red");
+                Skip_B2(                                        "Green");
+                Skip_B2(                                        "Blue");
+            }
+        }
+    }
 
     if (moov_trak_mdia_minf_stbl_stsd_Pos)
         return; //Handling only the first description


### PR DESCRIPTION
I did some analysis on the missing Width and Height properties not being reported for some quicktime files.
 
The problem seems to be located in the bitstream functions which check the size of the buffer before skipping it. However when they trigger a possible overrun, they return immediately (not increasing the buffer pointer) and raise a flag that the whole atom is "untrusted". Consequently the parsed values (even the correct ones, such as width and height) do not get propagated to the gui and just skipped.

What is available here is a "workaround" set that tries to use the 'get'-functions (rather than the 'skip'-) bitstream functions, which do not trigger this problem. Alternatively one could avoid touching those functions completely, and always write Width and Height, but I am not sure of unforeseen problems.