### PR TITLE
video/FFv1: Check the validy of the CRC in slice

### DIFF
--- a/Source/MediaInfo/Video/File_Ffv1.h
+++ b/Source/MediaInfo/Video/File_Ffv1.h
@@ -79,6 +79,7 @@ private :
     void FrameHeader();
     void slice(states &States);
     void slice_header(states &States);
+    int32u CRC_Compute(size_t Size);
     void plane(int16s quant_table[MAX_CONTEXT_INPUTS][256]);
     void line(states States[MAX_CONTEXT_INPUTS], int16s quant_table[MAX_CONTEXT_INPUTS][256], int16s *sample[2]);
     void read_quant_tables(int i);


### PR DESCRIPTION
When decoding a FFv1 slice, the CRC is verified.
If the slice is not valid, "NOK" is printed near the CRC value with the value computed.
Otherwise, the message "OK" is printed near the CRC.

Signed-off-by: Florent Tribouilloy <florent@mediaarea.net>