### PR TITLE
mediatrace updates

### DIFF
--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -2577,7 +2577,10 @@ void File__Analyze::Element_End_Common_Flush_Details()
                                                                                     item_Pos=0;
                                                                             }
                                                                             if (item_Pos!=string::npos)
-                                                                                Element[Element_Level].ToShow.Details.insert(Element[Element_Level].ToShow.Details.begin()+item_Pos+ToFind.size(), __T('s'));
+                                                                                {
+                                                                                    Element[Element_Level].ToShow.Details.erase(item_Pos+ToFind.size()-4, 4);
+                                                                                    Element[Element_Level].ToShow.Details.insert(item_Pos+ToFind.size()-4, __T("block"));
+                                                                                }
                                                                         }
                                                                         }
                                                                         break;

--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -2303,7 +2303,7 @@ Ztring Log_Offset (int64u OffsetToShow, MediaInfo_Config::trace_Format Config_Tr
     {
         case MediaInfo_Config::Trace_Format_Tree        : Pos2+=__T(' '); break;
         case MediaInfo_Config::Trace_Format_CSV         : Pos2+=__T(','); break;
-        case MediaInfo_Config::Trace_Format_XML         : Pos2+=__T("<item");
+        case MediaInfo_Config::Trace_Format_XML         : Pos2+=__T("<data");
                                                           if (OffsetToShow!=(int64u)-1)
                                                           {
                                                                Pos2+=__T(" offset=\"");
@@ -2329,8 +2329,8 @@ void File__Analyze::Element_Begin()
                                                                 {
                                                                 size_t Details_lt_Pos=Element[Element_Level].ToShow.Details.rfind(__T("<"));
                                                                 size_t Details_gt_Pos=Element[Element_Level].ToShow.Details.rfind(__T(">"));
-                                                                if (Details_lt_Pos!=string::npos && (Details_lt_Pos+1>=Element[Element_Level].ToShow.Details.size() || Details_gt_Pos==string::npos || (Details_lt_Pos>Details_gt_Pos && Element[Element_Level].ToShow.Details[Details_lt_Pos+1]!=__T('/')))) //else there is content like "</item> />"
-                                                                    Element[Element_Level].ToShow.Details+=__T(">")+Element[Element_Level].ToShow.Value+__T("</item>");
+                                                                if (Details_lt_Pos!=string::npos && (Details_lt_Pos+1>=Element[Element_Level].ToShow.Details.size() || Details_gt_Pos==string::npos || (Details_lt_Pos>Details_gt_Pos && Element[Element_Level].ToShow.Details[Details_lt_Pos+1]!=__T('/')))) //else there is content like "</data> />"
+                                                                    Element[Element_Level].ToShow.Details+=__T(">")+Element[Element_Level].ToShow.Value+__T("</data>");
                                                                 }
                                                                 Element[Element_Level].ToShow.Value.clear();
                                                                 break;
@@ -2377,8 +2377,8 @@ void File__Analyze::Element_Begin(const Ztring &Name)
                                                                 {
                                                                 size_t Details_lt_Pos=Element[Element_Level].ToShow.Details.rfind(__T("<"));
                                                                 size_t Details_gt_Pos=Element[Element_Level].ToShow.Details.rfind(__T(">"));
-                                                                if (Details_lt_Pos!=string::npos && (Details_lt_Pos+1>=Element[Element_Level].ToShow.Details.size() || Details_gt_Pos==string::npos || (Details_lt_Pos>Details_gt_Pos && Element[Element_Level].ToShow.Details[Details_lt_Pos+1]!=__T('/')))) //else there is content like "</item> />"
-                                                                    Element[Element_Level].ToShow.Details+=__T(">")+Element[Element_Level].ToShow.Value+__T("</item>");
+                                                                if (Details_lt_Pos!=string::npos && (Details_lt_Pos+1>=Element[Element_Level].ToShow.Details.size() || Details_gt_Pos==string::npos || (Details_lt_Pos>Details_gt_Pos && Element[Element_Level].ToShow.Details[Details_lt_Pos+1]!=__T('/')))) //else there is content like "</data> />"
+                                                                    Element[Element_Level].ToShow.Details+=__T(">")+Element[Element_Level].ToShow.Value+__T("</data>");
                                                                 }
                                                                 Element[Element_Level].ToShow.Value.clear();
                                                                 break;
@@ -2557,18 +2557,18 @@ void File__Analyze::Element_End_Common_Flush_Details()
                                                                         {
                                                                         size_t Details_lt_Pos=Element[Element_Level].ToShow.Details.rfind(__T("<"));
                                                                         size_t Details_gt_Pos=Element[Element_Level].ToShow.Details.rfind(__T(">"));
-                                                                        if (Details_lt_Pos!=string::npos && (Details_lt_Pos+1>=Element[Element_Level].ToShow.Details.size() || Details_gt_Pos==string::npos || (Details_lt_Pos>Details_gt_Pos && Element[Element_Level].ToShow.Details[Details_lt_Pos+1]!=__T('/')))) //else there is content like "</item> />"
-                                                                            Element[Element_Level].ToShow.Details+=__T(">")+Element[Element_Level].ToShow.Value+__T("</item>");
+                                                                        if (Details_lt_Pos!=string::npos && (Details_lt_Pos+1>=Element[Element_Level].ToShow.Details.size() || Details_gt_Pos==string::npos || (Details_lt_Pos>Details_gt_Pos && Element[Element_Level].ToShow.Details[Details_lt_Pos+1]!=__T('/')))) //else there is content like "</data> />"
+                                                                            Element[Element_Level].ToShow.Details+=__T(">")+Element[Element_Level].ToShow.Value+__T("</data>");
                                                                         Element[Element_Level].ToShow.Value.clear();
                                                                         //if (!Element_WantNextLevel)
                                                                         {
                                                                             Element[Element_Level].ToShow.Details+=Config_LineSeparator;
                                                                             Element[Element_Level].ToShow.Details.resize(Element[Element_Level].ToShow.Details.size()+(Element_Level_Base+Element_Level)*4, __T(' '));
-                                                                            Element[Element_Level].ToShow.Details+=__T("</items>");
+                                                                            Element[Element_Level].ToShow.Details+=__T("</block>");
                                                                             //Retrieving the beginning of the corresponding XML element
                                                                             Ztring ToFind=Config_LineSeparator;
                                                                             ToFind.resize(ToFind.size()+(Element_Level_Base+Element_Level)*4, __T(' '));
-                                                                            ToFind+=__T("<item");
+                                                                            ToFind+=__T("<data");
                                                                             size_t item_Pos=Element[Element_Level].ToShow.Details.rfind(ToFind);
                                                                             if (item_Pos==string::npos)
                                                                             {
@@ -2701,8 +2701,8 @@ void File__Analyze::Param(const Ztring& Parameter, const Ztring& Value)
                                                                 {
                                                                 size_t Details_lt_Pos=Element[Element_Level].ToShow.Details.rfind(__T("<"));
                                                                 size_t Details_gt_Pos=Element[Element_Level].ToShow.Details.rfind(__T(">"));
-                                                                if (Details_lt_Pos!=string::npos && (Details_lt_Pos+1>=Element[Element_Level].ToShow.Details.size() || Details_gt_Pos==string::npos || (Details_lt_Pos>Details_gt_Pos && Element[Element_Level].ToShow.Details[Details_lt_Pos+1]!=__T('/')))) //else there is content like "</item> />"
-                                                                    Element[Element_Level].ToShow.Details+=__T(">")+Element[Element_Level].ToShow.Value+__T("</item>");
+                                                                if (Details_lt_Pos!=string::npos && (Details_lt_Pos+1>=Element[Element_Level].ToShow.Details.size() || Details_gt_Pos==string::npos || (Details_lt_Pos>Details_gt_Pos && Element[Element_Level].ToShow.Details[Details_lt_Pos+1]!=__T('/')))) //else there is content like "</data> />"
+                                                                    Element[Element_Level].ToShow.Details+=__T(">")+Element[Element_Level].ToShow.Value+__T("</data>");
                                                                 Element[Element_Level].ToShow.Value=Value;
                                                                 }
                                                                 break;

--- a/Source/MediaInfo/MediaInfoList_Internal.cpp
+++ b/Source/MediaInfo/MediaInfoList_Internal.cpp
@@ -301,7 +301,7 @@ String MediaInfoList_Internal::Inform(size_t FilePos, size_t)
                 Retour+=+__T("<!-- Work in progress, not for production -->")+MediaInfoLib::Config.LineSeparator_Get();
             Retour+=__T('<');
             if (MediaInfoLib::Config.Trace_Format_Get()==MediaInfoLib::Config.Trace_Format_XML)
-                Retour+=__T("MediaTrace");
+                Retour+=__T("MediaTrace xmlns=\"http://www.mediaarea.net/mediatrace\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.mediaarea.net/mediatrace http://www.mediaarea.net/mediatrace/mediatrace.xsd\"");
             else
                 Retour+=__T("Mediainfo");
             Retour+=__T(" version=\"")+MediaInfoLib::Config.Info_Version_Get().SubString(__T(" v"), Ztring())+__T("\">")+MediaInfoLib::Config.LineSeparator_Get();

--- a/Source/MediaInfo/MediaInfoList_Internal.cpp
+++ b/Source/MediaInfo/MediaInfoList_Internal.cpp
@@ -297,8 +297,6 @@ String MediaInfoList_Internal::Inform(size_t FilePos, size_t)
         if (XML)
         {
             Retour+=__T("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")+MediaInfoLib::Config.LineSeparator_Get();
-            if (MediaInfoLib::Config.Trace_Format_Get()==MediaInfoLib::Config.Trace_Format_XML)
-                Retour+=+__T("<!-- Work in progress, not for production -->")+MediaInfoLib::Config.LineSeparator_Get();
             Retour+=__T('<');
             if (MediaInfoLib::Config.Trace_Format_Get()==MediaInfoLib::Config.Trace_Format_XML)
                 Retour+=__T("MediaTrace xmlns=\"http://www.mediaarea.net/mediatrace\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.mediaarea.net/mediatrace http://www.mediaarea.net/mediatrace/mediatrace.xsd\"");


### PR DESCRIPTION
This line https://github.com/dericed/MediaInfoLib/blob/master/Source/MediaInfo/File__Analyze.cpp#L2580 still needs an update to replace <data> with <block> rather than appending an 's' as it currently does