### PR TITLE
Matroska Statistics Tags Fix

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -216,7 +216,7 @@ void File_Mk::Streams_Finish()
 	//Ztring Duration_Temp;
 	bool Tags_Verified=false; 
 	Ztring TagsList=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_TAGS");
-	if (!TagsList.empty())
+	if (TagsList.size())
 	{
 		Clear(StreamKind_Last, StreamPos_Last, "_STATISTICS_TAGS");
 		if (Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_APP")==(Retrieve(Stream_General, 0, "Encoded_Application")) &&

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -3484,8 +3484,8 @@ void File_Mk::CodecID_Manage()
     else if (Format==__T("FFV1"))
     {
         Stream[TrackNumber].Parser=new File_Ffv1;
-        ((File_Ffv1*)Stream[TrackNumber].Parser)->Width=Retrieve(Stream_Video, StreamPos_Last, Video_Width).To_int64u();
-        ((File_Ffv1*)Stream[TrackNumber].Parser)->Height=Retrieve(Stream_Video, StreamPos_Last, Video_Height).To_int64u();
+        ((File_Ffv1*)Stream[TrackNumber].Parser)->Width=Retrieve(Stream_Video, StreamPos_Last, Video_Width).To_int32u();
+        ((File_Ffv1*)Stream[TrackNumber].Parser)->Height=Retrieve(Stream_Video, StreamPos_Last, Video_Height).To_int32u();
     }
     #endif
     #if defined(MEDIAINFO_HUFFYUV_YES)

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -264,7 +264,7 @@ void File_Mk::Streams_Finish()
 								else { CountParts=-1; break; }
 								Front++;
 							}
-							if (CountParts == 4)
+							if (CountParts == 4 && Front == TagValue.end())
 							{
 								int64u Hours = Parts[0].To_int64u(10);
 								int64u Minutes = Parts[1].To_int64u(10);
@@ -315,11 +315,11 @@ void File_Mk::Streams_Finish()
                 Temp->second.DisplayAspectRatio=((float32)16)/9;
             if (Temp->second.DisplayAspectRatio>=1.333 && Temp->second.DisplayAspectRatio<=1.334)
                 Temp->second.DisplayAspectRatio=((float32)4)/3;
-            Fill(Stream_Video, Temp->second.StreamPos, Video_DisplayAspectRatio, Temp->second.DisplayAspectRatio, 3, true);
-            int64u Width=Retrieve(Stream_Video, Temp->second.StreamPos, Video_Width).To_int64u();
-            int64u Height=Retrieve(Stream_Video, Temp->second.StreamPos, Video_Height).To_int64u();
+            Fill(Stream_Video, StreamPos_Last, Video_DisplayAspectRatio, Temp->second.DisplayAspectRatio, 3, true);
+            int64u Width=Retrieve(Stream_Video, StreamPos_Last, Video_Width).To_int64u();
+            int64u Height=Retrieve(Stream_Video, StreamPos_Last, Video_Height).To_int64u();
             if (Width)
-                Fill(Stream_Video, Temp->second.StreamPos, Video_PixelAspectRatio, Temp->second.DisplayAspectRatio*Height/Width, 3, true);
+                Fill(Stream_Video, StreamPos_Last, Video_PixelAspectRatio, Temp->second.DisplayAspectRatio*Height/Width, 3, true);
         }
 
         if (Temp->second.Parser)
@@ -435,12 +435,12 @@ void File_Mk::Streams_Finish()
                 Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Delay_Source), "Container");
             }
 
-            Ztring Codec_Temp=Retrieve(StreamKind_Last, Temp->second.StreamPos, Fill_Parameter(StreamKind_Last, Generic_Codec)); //We want to keep the 4CC;
+            Ztring Codec_Temp=Retrieve(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Codec)); //We want to keep the 4CC;
   	    //if (Duration_Temp.empty()) Duration_Temp=Retrieve(StreamKind_Last, Temp->second.StreamPos, Fill_Parameter(StreamKind_Last, Generic_Duration)); //Duration from stream is sometimes false
 	    //else Duration_Temp.clear();
 
             Finish(Temp->second.Parser);
-            Merge(*Temp->second.Parser, Temp->second.StreamKind, 0, Temp->second.StreamPos);
+            Merge(*Temp->second.Parser, StreamKind_Last, 0, StreamPos_Last);
             //if (!Duration_Temp.empty()) Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Duration), Duration_Temp, true);
             if (Temp->second.StreamKind==Stream_Video && !Codec_Temp.empty())
                 Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Codec), Codec_Temp, true);
@@ -472,12 +472,12 @@ void File_Mk::Streams_Finish()
             }
         }
 
-        if (Temp->second.FrameRate!=0 && Retrieve(Stream_Video, Temp->second.StreamPos, Video_FrameRate).empty())
-            Fill(Stream_Video, Temp->second.StreamPos, Video_FrameRate, Temp->second.FrameRate, 3);
+        if (Temp->second.FrameRate!=0 && Retrieve(Stream_Video, StreamPos_Last, Video_FrameRate).empty())
+            Fill(Stream_Video, StreamPos_Last, Video_FrameRate, Temp->second.FrameRate, 3);
 
         //Flags
-        Fill(Temp->second.StreamKind, Temp->second.StreamPos, "Default", Temp->second.Default?"Yes":"No");
-        Fill(Temp->second.StreamKind, Temp->second.StreamPos, "Forced", Temp->second.Forced?"Yes":"No");
+        Fill(StreamKind_Last, StreamPos_Last, "Default", Temp->second.Default?"Yes":"No");
+        Fill(StreamKind_Last, StreamPos_Last, "Forced", Temp->second.Forced?"Yes":"No");
     }
 
     //Chapters

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -265,14 +265,17 @@ void File_Mk::Streams_Finish()
 							}
 							if (CountParts == 4 && Front == TagValue.end())
 							{
-								int64u Hours = Parts[0].To_int64u(10);
 								int64u Minutes = Parts[1].To_int64u(10);
 								int64u Seconds = Parts[2].To_int64u(10);
-								Parts[3] = Parts[3].substr(0, 3);
-								int64u Milliseconds = Parts[3].To_int64u(10);							
-								TagValue.From_Number((((Hours * 3600) + (Minutes * 60) + Seconds) * 1000) + Milliseconds, 10);
-								Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Duration), TagValue, true);
-								//Duration_Temp = TagValue;
+								if (Minutes < 60 && Seconds < 60)
+								{
+									if (Parts[3].size() > 3) Parts[3] = Parts[3].substr(0, 3);
+									int64u Milliseconds = Parts[3].To_int64u(10);
+									TagValue.From_Number((((Parts[0].To_int64u(10) * 3600) + (Minutes * 60) + Seconds) * 1000) + Milliseconds, 10);
+									if (TagValue.To_int64u(10) <= Retrieve(Stream_General, 0, Generic_Duration).To_int64u(10))
+										Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Duration), TagValue, true);
+									//Duration_Temp = TagValue;
+								}
 							}
 						}
 						else

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -252,7 +252,7 @@ void File_Mk::Streams_Finish()
 			}
 		}
 
-		Ztring Duration_Temp;
+		//Ztring Duration_Temp;
 		if (Tags_Verified)
 		{
 			Ztring Tag_Temp = Retrieve(Temp->second.StreamKind, Temp->second.StreamPos, "*Track Duration/(HH:MM:SS.NNNNNNNNN)", Info_Text);
@@ -309,6 +309,8 @@ void File_Mk::Streams_Finish()
 				Clear(Temp->second.StreamKind, Temp->second.StreamPos, "*Track Size/(Bytes)");
 			}
 		}
+		//else
+		//	Duration_Temp=Retrieve(StreamKind_Last, Temp->second.StreamPos, Fill_Parameter(StreamKind_Last, Generic_Duration)); //Duration from stream is sometimes false
 
         if (Temp->second.DisplayAspectRatio!=0)
         {
@@ -437,7 +439,6 @@ void File_Mk::Streams_Finish()
                 Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Delay_Source), "Container");
             }
 
-            //Ztring Duration_Temp;
             Ztring Codec_Temp;
             //Duration_Temp=Retrieve(StreamKind_Last, Temp->second.StreamPos, Fill_Parameter(StreamKind_Last, Generic_Duration)); //Duration from stream is sometimes false
             Codec_Temp=Retrieve(StreamKind_Last, Temp->second.StreamPos, Fill_Parameter(StreamKind_Last, Generic_Codec)); //We want to keep the 4CC

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -215,29 +215,29 @@ void File_Mk::Streams_Finish()
 	//Tags
 	//Ztring Duration_Temp;
 	bool Tags_Verified=false; 
-	Ztring TagsList=Retrieve(StreamKind, StreamPos_Last, "_STATISTICS_TAGS", Info_Text);
+	Ztring TagsList=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_TAGS", Info_Text);
 	if (!TagsList.empty())
 	{
-		Clear(StreamKind, StreamPos_Last, "_STATISTICS_TAGS");
-		Ztring WritingApp=Retrieve(StreamKind, StreamPos_Last, "_STATISTICS_WRITING_APP", Info_Text);
-		Ztring WritingDate=Retrieve(StreamKind, StreamPos_Last, "_STATISTICS_WRITING_DATE_UTC", Info_Text);
+		Clear(StreamKind_Last, StreamPos_Last, "_STATISTICS_TAGS");
+		Ztring WritingApp=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_APP", Info_Text);
+		Ztring WritingDate=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_DATE_UTC", Info_Text);
 		WritingDate.insert(0, __T("UTC "));
 		if ((!WritingApp.compare(Retrieve(Stream_General, 0, "Encoded_Application", Info_Text))) && (!WritingDate.compare(Retrieve(Stream_General, 0, "Encoded_Date", Info_Text))))
-			{ Fill(StreamKind, StreamPos_Last, "*Statistics Tags Verified", "Yes");  Tags_Verified=true; }
+			{ Fill(StreamKind_Last, StreamPos_Last, "*Statistics Tags Verified", "Yes");  Tags_Verified=true; }
 		else
-			Fill(StreamKind, StreamPos_Last, "*Statistics Tags Verified", "No");
-		Clear(StreamKind, StreamPos_Last, "_STATISTICS_WRITING_APP");
-		Clear(StreamKind, StreamPos_Last, "_STATISTICS_WRITING_DATE_UTC");
+			Fill(StreamKind_Last, StreamPos_Last, "*Statistics Tags Verified", "No");
+		Clear(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_APP");
+		Clear(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_DATE_UTC");
 		Ztring::iterator Back = TagsList.begin();
 		Ztring TempTag;
 		while (true)
 		{
 			if ((Back == TagsList.end()) || (*Back == ' ') || (*Back == '\0'))
 			{
-				Ztring TagValue = Retrieve(StreamKind, StreamPos_Last, TempTag.To_Local().c_str(), Info_Text);
+				Ztring TagValue = Retrieve(StreamKind_Last, StreamPos_Last, TempTag.To_Local().c_str(), Info_Text);
 				if (!TagValue.empty())
 				{
-					Clear(StreamKind, StreamPos_Last, TempTag.To_Local().c_str());
+					Clear(StreamKind_Last, StreamPos_Last, TempTag.To_Local().c_str());
 					if (!TempTag.compare(__T("BPS")))
 					{
 						if (Tags_Verified)
@@ -296,7 +296,7 @@ void File_Mk::Streams_Finish()
 					else
 					{
 						TempTag.insert(0, __T("*"));
-						Fill(StreamKind, StreamPos_Last, TempTag.To_Local().c_str(), TagValue.To_Local().c_str());
+						Fill(StreamKind_Last, StreamPos_Last, TempTag.To_Local().c_str(), TagValue.To_Local().c_str());
 					}
 				}
 				if (Back == TagsList.end()) break;

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -2238,16 +2238,6 @@ void File_Mk::Segment_Tags_Tag_SimpleTag_TagString()
     if (Segment_Tag_SimpleTag_TagNames.empty())
         return;
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("BITSPS")) return; //Useless
-
-    if (Segment_Tag_SimpleTag_TagNames[0]==__T("BPS")) { Segment_Tag_SimpleTag_TagNames[0]=__T("Bit rate/(bps)"); }
-    if (Segment_Tag_SimpleTag_TagNames[0]==__T("DURATION")) { Segment_Tag_SimpleTag_TagNames[0]=__T("Track Duration/(HH:MM:SS.NNNNNNNNN)"); }
-    if (Segment_Tag_SimpleTag_TagNames[0]==__T("NUMBER_OF_FRAMES")) { Segment_Tag_SimpleTag_TagNames[0]=__T("Track Size/(Frames)"); }
-    if (Segment_Tag_SimpleTag_TagNames[0]==__T("NUMBER_OF_BYTES")) { Segment_Tag_SimpleTag_TagNames[0]=__T("Track Size/(Bytes)"); }
-
-    if (Segment_Tag_SimpleTag_TagNames[0]==__T("_STATISTICS_WRITING_APP")) { Segment_Tag_SimpleTag_TagNames[0]=__T("Security Writing Application"); }
-    if (Segment_Tag_SimpleTag_TagNames[0]==__T("_STATISTICS_WRITING_DATE_UTC")) { Segment_Tag_SimpleTag_TagNames[0]=__T("Security Writing Date"); TagString.insert(0, __T("UTC ")); }
-    if (Segment_Tag_SimpleTag_TagNames[0]==__T("_STATISTICS_TAGS")) { Segment_Tag_SimpleTag_TagNames[0]=__T("Security Tags List"); }
-
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("COMPATIBLE_BRANDS")) return; //QuickTime techinical info, useless
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("CREATION_TIME")) {Segment_Tag_SimpleTag_TagNames[0]=__T("Encoded_Date"); TagString.insert(0, __T("UTC "));}
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("DATE_DIGITIZED")) {Segment_Tag_SimpleTag_TagNames[0]=__T("Mastered_Date"); TagString.insert(0, __T("UTC "));}

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -219,10 +219,8 @@ void File_Mk::Streams_Finish()
 	if (!TagsList.empty())
 	{
 		Clear(StreamKind_Last, StreamPos_Last, "_STATISTICS_TAGS");
-		Ztring WritingApp=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_APP");
-		Ztring WritingDate=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_DATE_UTC");
-		WritingDate.insert(0, __T("UTC "));
-		if ((!WritingApp.compare(Retrieve(Stream_General, 0, "Encoded_Application"))) && (!WritingDate.compare(Retrieve(Stream_General, 0, "Encoded_Date"))))
+		if (!Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_APP").compare(Retrieve(Stream_General, 0, "Encoded_Application")) &&
+			!Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_DATE_UTC").compare(Retrieve(Stream_General, 0, "Encoded_Date").substr(4)))
 			{ Fill(StreamKind_Last, StreamPos_Last, "*Statistics Tags Verified", "Yes");  Tags_Verified=true; }
 		else
 			Fill(StreamKind_Last, StreamPos_Last, "*Statistics Tags Verified", "No");

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -250,16 +250,17 @@ void File_Mk::Streams_Finish()
 							Ztring::iterator Front = TagValue.begin();
 							Ztring Parts [4];
 							int CountParts = 0;
+							Char *t = __T("::.");
 							while (true)
 							{
-								if (Front == TagValue.end() || *Front == __T(':') || *Front == __T('.'))
+								if (Front == TagValue.end() || *Front == t[CountParts])
 								{
 									CountParts++;
 									if (Front==TagValue.end() || CountParts == 4) break;
 								}
 								else if (isdigit(*Front))
 									Parts[CountParts]+=*Front;
-								else { CountParts=-1; break; }
+								else { break; }
 								Front++;
 							}
 							if (CountParts == 4 && Front == TagValue.end())

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -3685,3 +3685,4 @@ void File_Mk::CodecPrivate_Manage()
 
 #endif //MEDIAINFO_MK_YES
 
+

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -215,29 +215,29 @@ void File_Mk::Streams_Finish()
 	//Tags
 	//Ztring Duration_Temp;
 	bool Tags_Verified=false; 
-	Ztring TagsList=Retrieve(Temp->second.StreamKind, Temp->second.StreamPos, "_STATISTICS_TAGS", Info_Text);
+	Ztring TagsList=Retrieve(StreamKind, StreamPos_Last, "_STATISTICS_TAGS", Info_Text);
 	if (!TagsList.empty())
 	{
-		Clear(Temp->second.StreamKind, Temp->second.StreamPos, "_STATISTICS_TAGS");
-		Ztring WritingApp=Retrieve(Temp->second.StreamKind, Temp->second.StreamPos, "_STATISTICS_WRITING_APP", Info_Text);
-		Ztring WritingDate=Retrieve(Temp->second.StreamKind, Temp->second.StreamPos, "_STATISTICS_WRITING_DATE_UTC", Info_Text);
+		Clear(StreamKind, StreamPos_Last, "_STATISTICS_TAGS");
+		Ztring WritingApp=Retrieve(StreamKind, StreamPos_Last, "_STATISTICS_WRITING_APP", Info_Text);
+		Ztring WritingDate=Retrieve(StreamKind, StreamPos_Last, "_STATISTICS_WRITING_DATE_UTC", Info_Text);
 		WritingDate.insert(0, __T("UTC "));
 		if ((!WritingApp.compare(Retrieve(Stream_General, 0, "Encoded_Application", Info_Text))) && (!WritingDate.compare(Retrieve(Stream_General, 0, "Encoded_Date", Info_Text))))
-			{ Fill(Temp->second.StreamKind, Temp->second.StreamPos, "*Statistics Tags Verified", "True");  Tags_Verified=true; }
+			{ Fill(StreamKind, StreamPos_Last, "*Statistics Tags Verified", "Yes");  Tags_Verified=true; }
 		else
-			Fill(Temp->second.StreamKind, Temp->second.StreamPos, "*Statistics Tags Verified", "False");
-		Clear(Temp->second.StreamKind, Temp->second.StreamPos, "_STATISTICS_WRITING_APP");
-		Clear(Temp->second.StreamKind, Temp->second.StreamPos, "_STATISTICS_WRITING_DATE_UTC");
+			Fill(StreamKind, StreamPos_Last, "*Statistics Tags Verified", "No");
+		Clear(StreamKind, StreamPos_Last, "_STATISTICS_WRITING_APP");
+		Clear(StreamKind, StreamPos_Last, "_STATISTICS_WRITING_DATE_UTC");
 		Ztring::iterator Back = TagsList.begin();
 		Ztring TempTag;
 		while (true)
 		{
 			if ((Back == TagsList.end()) || (*Back == ' ') || (*Back == '\0'))
 			{
-				Ztring TagValue = Retrieve(Temp->second.StreamKind, Temp->second.StreamPos, TempTag.To_Local().c_str(), Info_Text);
+				Ztring TagValue = Retrieve(StreamKind, StreamPos_Last, TempTag.To_Local().c_str(), Info_Text);
 				if (!TagValue.empty())
 				{
-					Clear(Temp->second.StreamKind, Temp->second.StreamPos, TempTag.To_Local().c_str());
+					Clear(StreamKind, StreamPos_Last, TempTag.To_Local().c_str());
 					if (!TempTag.compare(__T("BPS")))
 					{
 						if (Tags_Verified)
@@ -261,6 +261,7 @@ void File_Mk::Streams_Finish()
 								}
 								else if (isdigit(*Front))
 									Parts[CountParts]+=*Front;
+								else { CountParts=-1; break; }
 								Front++;
 							}
 							if (CountParts == 4)
@@ -276,7 +277,7 @@ void File_Mk::Streams_Finish()
 							}
 						}
 						else
-							Fill(StreamKind_Last, StreamPos_Last, "Track Duration/(HH:MM:SS.NNNNNNNNN)", TagValue.To_Local().c_str());
+							Fill(StreamKind_Last, StreamPos_Last, "*Track Duration/(HH:MM:SS.NNNNNNNNN)", TagValue.To_Local().c_str());
 					}
 					else if (!TempTag.compare(__T("NUMBER_OF_FRAMES")))
 					{
@@ -295,7 +296,7 @@ void File_Mk::Streams_Finish()
 					else
 					{
 						TempTag.insert(0, __T("*"));
-						Fill(Temp->second.StreamKind, Temp->second.StreamPos, TempTag.To_Local().c_str(), TagValue.To_Local().c_str());
+						Fill(StreamKind, StreamPos_Last, TempTag.To_Local().c_str(), TagValue.To_Local().c_str());
 					}
 				}
 				if (Back == TagsList.end()) break;

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -215,14 +215,14 @@ void File_Mk::Streams_Finish()
 	//Tags
 	//Ztring Duration_Temp;
 	bool Tags_Verified=false; 
-	Ztring TagsList=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_TAGS", Info_Text);
+	Ztring TagsList=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_TAGS");
 	if (!TagsList.empty())
 	{
 		Clear(StreamKind_Last, StreamPos_Last, "_STATISTICS_TAGS");
-		Ztring WritingApp=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_APP", Info_Text);
-		Ztring WritingDate=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_DATE_UTC", Info_Text);
+		Ztring WritingApp=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_APP");
+		Ztring WritingDate=Retrieve(StreamKind_Last, StreamPos_Last, "_STATISTICS_WRITING_DATE_UTC");
 		WritingDate.insert(0, __T("UTC "));
-		if ((!WritingApp.compare(Retrieve(Stream_General, 0, "Encoded_Application", Info_Text))) && (!WritingDate.compare(Retrieve(Stream_General, 0, "Encoded_Date", Info_Text))))
+		if ((!WritingApp.compare(Retrieve(Stream_General, 0, "Encoded_Application"))) && (!WritingDate.compare(Retrieve(Stream_General, 0, "Encoded_Date"))))
 			{ Fill(StreamKind_Last, StreamPos_Last, "*Statistics Tags Verified", "Yes");  Tags_Verified=true; }
 		else
 			Fill(StreamKind_Last, StreamPos_Last, "*Statistics Tags Verified", "No");
@@ -234,7 +234,7 @@ void File_Mk::Streams_Finish()
 		{
 			if ((Back == TagsList.end()) || (*Back == ' ') || (*Back == '\0'))
 			{
-				Ztring TagValue = Retrieve(StreamKind_Last, StreamPos_Last, TempTag.To_Local().c_str(), Info_Text);
+				Ztring TagValue = Retrieve(StreamKind_Last, StreamPos_Last, TempTag.To_Local().c_str());
 				if (!TagValue.empty())
 				{
 					Clear(StreamKind_Last, StreamPos_Last, TempTag.To_Local().c_str());


### PR DESCRIPTION
It shouldn't be that hard to modify to simply remove any trace of statistics tags from display.

I've modified the default track duration method to only be applied if the duration tag isn't present in case you want to keep it, but I've commented it out.  Of course, if you're going to do a full pass-through of the file that might be good enough to override the tag.

If you think there might be any lone BPS tags out there somewhere that you don't want, you might add some extra clean-up code in the stream finish section to deal with it, or with any other lonely stats tags.

I've left it to display any unknown Stat Tags (or any with an incorrect security tag) with an asterisk before them, if you just want to remove them completely that shouldn't be hard.  Or you could go the other way and display the security tags when they don't match, just to give the user some idea as to why.

Is it necessary to add code to better scrutinise the values being given?  If BPS + Duration is more than the size of the file or the duration is one hour and eighty eight minutes?  ...Or would that be overkill?