### PR TITLE
x Fixed compilation issues with some #defines

### DIFF
--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -246,19 +246,26 @@ Ztring MediaInfo_Internal::Inform()
     bool XML_0_7_78_MA=false;
     bool XML_0_7_78_MI=false;
     bool CSV=false;
+    #if defined(MEDIAINFO_HTML_YES)
     if (MediaInfoLib::Config.Inform_Get()==__T("HTML"))
         HTML=true;
+    #endif //defined(MEDIAINFO_HTML_YES)
+    #if defined(MEDIAINFO_XML_YES)
     if (MediaInfoLib::Config.Inform_Get()==__T("XML"))
         XML=true;
     if (MediaInfoLib::Config.Inform_Get()==__T("MAXML"))
         XML_0_7_78_MA=true;
     if (MediaInfoLib::Config.Inform_Get()==__T("MIXML"))
         XML_0_7_78_MI=true;
+    #endif //defined(MEDIAINFO_XML_YES)
+    #if defined(MEDIAINFO_CSV_YES)
     if (MediaInfoLib::Config.Inform_Get()==__T("CSV"))
         CSV=true;
+    #endif //defined(MEDIAINFO_CSV_YES)
 
     if (HTML)
         Retour+=__T("<html>\n\n<head>\n<META http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" /></head>\n<body>\n");
+    #if defined(MEDIAINFO_XML_YES)
     if (XML_0_7_78_MA || XML_0_7_78_MI)
     {
         size_t Modified;
@@ -268,6 +275,7 @@ Ztring MediaInfo_Internal::Inform()
         Retour+=__T("<MediaInfo xmlns=\"https://mediaarea.net/mediainfo\" version=\"2.0beta1\">\n");
     if (XML)
         Retour+=__T("<File>\n");
+    #endif //defined(MEDIAINFO_XML_YES)
 
     for (size_t StreamKind=(size_t)Stream_General; StreamKind<Stream_Max; StreamKind++)
     {
@@ -412,6 +420,7 @@ Ztring MediaInfo_Internal::Inform (stream_t StreamKind, size_t StreamPos, bool I
             //Ztring A=Get((stream_t)4, 2, 0, Info_Measure_Text); // TODO Bug sinon? voir Ztring
             Ztring A=Get((stream_t)StreamKind, StreamPos, Champ_Pos, Info_Measure_Text); // TODO Bug sinon? voir Ztring
             bool Shouldshow=false;
+            #if defined(MEDIAINFO_XML_YES)
             if (XML_0_7_78)
             {
                 if (Champ_Pos>=Stream[StreamKind][StreamPos].size())
@@ -423,19 +432,28 @@ Ztring MediaInfo_Internal::Inform (stream_t StreamKind, size_t StreamPos, bool I
                     Shouldshow=true;
                 }
             }
-            else if ((MediaInfoLib::Config.Complete_Get() || Get((stream_t)StreamKind, StreamPos, Champ_Pos, Info_Options)[InfoOption_ShowInInform]==__T('Y')))
+            else
+            #endif //defined(MEDIAINFO_XML_YES
+            if ((MediaInfoLib::Config.Complete_Get() || Get((stream_t)StreamKind, StreamPos, Champ_Pos, Info_Options)[InfoOption_ShowInInform]==__T('Y')))
                 Shouldshow=true;
             if (Shouldshow && !Get((stream_t)StreamKind, StreamPos, Champ_Pos, Info_Text).empty())
             {
+                #if defined(MEDIAINFO_XML_YES)
                 //Extra
                 if (XML_0_7_78 && !IsExtra && Champ_Pos>=Stream[StreamKind][StreamPos].size())
                 {
                      Retour+=__T("<extra>\n");
                      IsExtra=true;
                 }
+                #endif //defined(MEDIAINFO_XML_YES
                     
                 Ztring Nom=Get((stream_t)StreamKind, StreamPos, Champ_Pos, Info_Name_Text);
+                #if defined(MEDIAINFO_XML_YES)
                 if (Nom.empty() || XML_0_7_78)
+                #else
+                if (Nom.empty())
+                #endif //defined(MEDIAINFO_XML_YES
+
                     Nom=Get((stream_t)StreamKind, StreamPos, Champ_Pos, Info_Name); //Texte n'existe pas
                 #if defined(MEDIAINFO_TEXT_YES) && (defined(MEDIAINFO_HTML_YES) || defined(MEDIAINFO_XML_YES) || defined(MEDIAINFO_CSV_YES))
                 if (Text)

--- a/Source/MediaInfo/Text/File_Cdp.cpp
+++ b/Source/MediaInfo/Text/File_Cdp.cpp
@@ -22,12 +22,10 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/Text/File_Cdp.h"
+#include "MediaInfo/MediaInfo_Config_MediaInfo.h"
 #if defined(MEDIAINFO_EIA608_YES)
     #include "MediaInfo/Text/File_Eia608.h"
 #endif
-#if MEDIAINFO_ADVANCED
-    #include "MediaInfo/MediaInfo_Config_MediaInfo.h"
-#endif //MEDIAINFO_ADVANCED
 #if MEDIAINFO_EVENTS
     #include "MediaInfo/MediaInfo_Events.h"
 #endif //MEDIAINFO_EVENTS

--- a/Source/MediaInfo/Text/File_DtvccTransport.cpp
+++ b/Source/MediaInfo/Text/File_DtvccTransport.cpp
@@ -28,9 +28,9 @@
 #if defined(MEDIAINFO_EIA708_YES)
     #include "MediaInfo/Text/File_Eia708.h"
 #endif
-#if MEDIAINFO_ADVANCED
+#if MEDIAINFO_ADVANCED || defined(MEDIAINFO_EIA608_YES) || defined(MEDIAINFO_EIA708_YES)
     #include "MediaInfo/MediaInfo_Config_MediaInfo.h"
-#endif //MEDIAINFO_ADVANCED
+#endif
 #if MEDIAINFO_EVENTS
     #include "MediaInfo/MediaInfo_Events.h"
 #endif //MEDIAINFO_EVENTS


### PR DESCRIPTION
Compilation currently fail when MEDIAINFO_XML_YES and/or MEDIAINFO_ADVANCED is not defined.