### PR TITLE
Please look at this patches and accept if possible

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -2365,7 +2365,6 @@ void File_Mk::Segment_Tags_Tag_SimpleTag_TagString()
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("MAJOR_BRAND")) return; //QuickTime techinical info, useless
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("MINOR_VERSION")) return; //QuickTime techinical info, useless
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("PART_NUMBER")) Segment_Tag_SimpleTag_TagNames[0]=__T("Track/Position");
-    if (Segment_Tag_SimpleTag_TagNames[0]==__T("ORIGINAL") && Segment_Tag_SimpleTag_TagNames.size()==2 && Segment_Tag_SimpleTag_TagNames[1]==__T("URL")) return; //Useless
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("ORIGINAL_MEDIA_TYPE")) Segment_Tag_SimpleTag_TagNames[0]=__T("OriginalSourceForm");
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("SAMPLE") && Segment_Tag_SimpleTag_TagNames.size()==2 && Segment_Tag_SimpleTag_TagNames[1]==__T("PART_NUMBER")) return; //Useless
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("SAMPLE") && Segment_Tag_SimpleTag_TagNames.size()==2 && Segment_Tag_SimpleTag_TagNames[1]==__T("TITLE")) {Segment_Tag_SimpleTag_TagNames.resize(1); Segment_Tag_SimpleTag_TagNames[0]=__T("Title_More");}

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -3175,7 +3175,12 @@ void File_Mk::Segment_Tracks_TrackEntry_Video_PixelCropBottom()
     Element_Name("PixelCropBottom");
 
     //Parsing
-    UInteger_Info();
+    int64u UInteger=UInteger_Get();
+    
+    //Filling
+    FILLING_BEGIN();
+        Fill(Stream_Video, StreamPos_Last, "PixelCropBottom", UInteger, 10, true);
+    FILLING_END();
 }
 
 //---------------------------------------------------------------------------
@@ -3184,7 +3189,12 @@ void File_Mk::Segment_Tracks_TrackEntry_Video_PixelCropLeft()
     Element_Name("PixelCropLeft");
 
     //Parsing
-    UInteger_Info();
+    int64u UInteger=UInteger_Get();
+    
+    //Filling
+    FILLING_BEGIN();
+        Fill(Stream_Video, StreamPos_Last, "PixelCropLeft", UInteger, 10, true);
+    FILLING_END();
 }
 
 //---------------------------------------------------------------------------
@@ -3193,7 +3203,12 @@ void File_Mk::Segment_Tracks_TrackEntry_Video_PixelCropRight()
     Element_Name("PixelCropRight");
 
     //Parsing
-    UInteger_Info();
+    int64u UInteger=UInteger_Get();
+    
+    //Filling
+    FILLING_BEGIN();
+        Fill(Stream_Video, StreamPos_Last, "PixelCropRight", UInteger, 10, true);
+    FILLING_END();
 }
 
 //---------------------------------------------------------------------------
@@ -3202,7 +3217,12 @@ void File_Mk::Segment_Tracks_TrackEntry_Video_PixelCropTop()
     Element_Name("PixelCropTop");
 
     //Parsing
-    UInteger_Info();
+    int64u UInteger=UInteger_Get();
+    
+    //Filling
+    FILLING_BEGIN();
+        Fill(Stream_Video, StreamPos_Last, "PixelCropTop", UInteger, 10, true);
+    FILLING_END();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Text/File_TimedText.cpp
+++ b/Source/MediaInfo/Text/File_TimedText.cpp
@@ -84,7 +84,13 @@ void File_TimedText::Data_Parse()
                 {
                     Stream_Prepare(Stream_Text);
                 }
-            Fill(StreamKind_Last, 0, Fill_Parameter(StreamKind_Last, Generic_Format), "Timed Text");
+            Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Format), "Timed Text");
+            
+            #ifdef MEDIAINFO_MPEG4_YES
+                if (IsChapter)
+                    Fill(StreamKind_Last, StreamPos_Last, Menu_Chapters_Pos_Begin, Count_Get(StreamKind_Last, StreamPos_Last), 10, true);
+            #endif //MEDIAINFO_MPEG4_YES
+
         }
         #ifdef MEDIAINFO_MPEG4_YES
             if (IsChapter)
@@ -98,7 +104,10 @@ void File_TimedText::Data_Parse()
 
         #ifdef MEDIAINFO_MPEG4_YES
             if (IsChapter && FrameInfo.DTS!=(int64u)-1 && Buffer_Offset==2)
-                Fill(Stream_Menu, 0, Ztring().Duration_From_Milliseconds(FrameInfo.DTS/1000000).To_UTF8().c_str(), Value);
+            {
+                Fill(Stream_Menu, StreamPos_Last, Ztring().Duration_From_Milliseconds(FrameInfo.DTS/1000000).To_UTF8().c_str(), Value);
+                Fill(Stream_Menu, StreamPos_Last, Menu_Chapters_Pos_End, Count_Get(Stream_Menu, StreamPos_Last), 10, true);
+            }
         #endif //MEDIAINFO_MPEG4_YES
     FILLING_END();
 


### PR DESCRIPTION
Description of patches

1. Number of chapters of Timed Text 
On some MPEG-4 movies MediaInfo shows a menu of "Timed Text" format (codec id "text") with defined Duration.
But such menu has no Menu_Chapters_Pos_End and Menu_Chapters_Pos_Begin tags, so I added it.
Some description and sample - https://sourceforge.net/p/mediainfo/bugs/914/

2. Matrsoka: ORIGINAL/URL is not useless
Last updates of MI had removed a ORIGINAL/URL tags from Matroska files as useless.
I add it back as is. Sample file ( https://sourceforge.net/projects/matroska/files/test_files/cover_art.mkv/download )
has a link to youtube in this tag.

3. Matroska: add PixelCrop tags
I added Matroska PixelCrop tags, sample is in this request - https://sourceforge.net/p/mediainfo/feature-requests/446/
