### PR TITLE
MXF ElementNumber

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mxf.h
+++ b/Source/MediaInfo/Multiple/File_Mxf.h
@@ -725,6 +725,7 @@ protected :
     };
     typedef std::map<int32u, essence> essences; //Key is TrackNumber
     essences Essences;
+    bitset<Stream_Max+1> StreamPos_StartAtZero; //information about the base of StreamPos (0 or 1, 1 is found in 1 file) TODO: per Essence code (last 4 bytes of the Essence header 0xTTXXTTXX)
 
     //Descriptor
     struct descriptor
@@ -1109,7 +1110,6 @@ protected :
     mxftimecode MxfTimeCodeForDelay;
     mxftimecode MxfTimeCodeMaterial;
     float64 DTS_Delay; //In seconds
-    bool   StreamPos_StartAtOne; //information about the base of StreamPos (0 or 1, 1 is found in 1 file)
     TimeCode            SDTI_TimeCode_StartTimecode;
     size_t              SDTI_TimeCode_RepetitionCount;
     TimeCode            SDTI_TimeCode_Previous;


### PR DESCRIPTION
x MXF: Handling of MXF files having e.g. first Element Number 1 for video essences and 0 for audio essences.

TODO: we should do also per Item Type / Element Type