### PR TITLE
x Matroska: CRC-32 element was skipped for all levels during CRC-32 c…

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -1366,7 +1366,7 @@ void File_Mk::Data_Parse()
         ATOM_END_MK
     DATA_END
 
-    if (Element_Code!=Elements::CRC32 && !CRC32Compute.empty())
+    if (!CRC32Compute.empty())
         CRC32_Check();
 }
 
@@ -1404,6 +1404,7 @@ void File_Mk::CRC32()
             Param_Info(__T("Not tested ")+Ztring::ToZtring(Element_Level-1)+__T(' ')+Ztring::ToZtring(CRC32Compute[Element_Level-1].Expected));
             CRC32Compute[Element_Level-1].Computed=0xFFFFFFFF;
             CRC32Compute[Element_Level-1].Pos = File_Offset + Buffer_Offset;
+            CRC32Compute[Element_Level-1].From = File_Offset + Buffer_Offset + Element_Size;
             CRC32Compute[Element_Level-1].UpTo = File_Offset + Buffer_Offset + Element_TotalSize_Get(1);
         }
     }
@@ -4235,7 +4236,7 @@ void File_Mk::TestMultipleInstances (size_t* Instances)
 void File_Mk::CRC32_Check ()
 {
     for (size_t i = 0; i<CRC32Compute.size(); i++)
-        if (CRC32Compute[i].UpTo)
+        if (CRC32Compute[i].UpTo && File_Offset + Buffer_Offset - (size_t)Header_Size >= CRC32Compute[i].From)
         {
             CRC32_Compute(CRC32Compute[i].Computed, Buffer + Buffer_Offset - (size_t)Header_Size, Buffer + Buffer_Offset + (size_t)(Element_WantNextLevel?Element_Offset:Element_Size));
             if (File_Offset + Buffer_Offset + (Element_WantNextLevel?Element_Offset:Element_Size) >= CRC32Compute[i].UpTo)

--- a/Source/MediaInfo/Multiple/File_Mk.h
+++ b/Source/MediaInfo/Multiple/File_Mk.h
@@ -326,6 +326,7 @@ private :
     struct crc32
     {
         int64u  Pos;
+        int64u  From;
         int64u  UpTo;
         int32u  Computed;
         int32u  Expected;


### PR DESCRIPTION
…omputed, which is wrong (only the last level must exclude CRC-32 data)