### PR TITLE
+ Matroska: support of padding/junk at the start of a segment

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.h
+++ b/Source/MediaInfo/Multiple/File_Mk.h
@@ -306,6 +306,7 @@ private :
     int64u   TrackType;
 
     //Temp
+    int8u   InvalidByteMax;
     int64u  Format_Version;
     int64u  TimecodeScale;
     float64 Duration;


### PR DESCRIPTION
Comparing to illegal byte values, depending of EBMLMaxSizeLength