### PR TITLE
x Fix parsing of DCP MXF files when input file is not an absolute path

### DIFF
--- a/Source/MediaInfo/Multiple/File_DcpAm.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpAm.cpp
@@ -229,7 +229,10 @@ bool File_DcpAm::FileHeader_Begin()
         MI.Option(__T("ParseSpeed"), __T("0"));
         MI.Option(__T("Demux"), Ztring());
         MI.Option(__T("File_IsReferenced"), __T("1"));
-        size_t MiOpenResult=MI.Open(Directory.Path_Get()+PathSeparator+PKL_FileName);
+        Ztring DirPath = Directory.Path_Get();
+        if (!DirPath.empty())
+            DirPath += PathSeparator;
+        size_t MiOpenResult=MI.Open(DirPath+PKL_FileName);
         MI.Option(__T("ParseSpeed"), ParseSpeed_Save); //This is a global value, need to reset it. TODO: local value
         MI.Option(__T("Demux"), Demux_Save); //This is a global value, need to reset it. TODO: local value
         if (MiOpenResult

--- a/Source/MediaInfo/Multiple/File_DcpCpl.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpCpl.cpp
@@ -300,7 +300,10 @@ bool File_DcpCpl::FileHeader_Begin()
 
     //Getting files names
     FileName Directory(File_Name);
-    Ztring Assetmap_FileName=Directory.Path_Get()+PathSeparator+__T("ASSETMAP.xml");
+    Ztring DirPath = Directory.Path_Get();
+    if (!DirPath.empty())
+        DirPath += PathSeparator;
+    Ztring Assetmap_FileName=DirPath+__T("ASSETMAP.xml");
     bool IsOk=false;
     if (File::Exists(Assetmap_FileName))
         IsOk=true;

--- a/Source/MediaInfo/Multiple/File_DcpPkl.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpPkl.cpp
@@ -191,7 +191,10 @@ bool File_DcpPkl::FileHeader_Begin()
     if (!Config->File_IsReferenced_Get())
     {
         FileName Directory(File_Name);
-        Ztring Assetmap_FileName=Directory.Path_Get()+PathSeparator+__T("ASSETMAP.xml");
+        Ztring DirPath = Directory.Path_Get();
+        if (!DirPath.empty())
+            DirPath += PathSeparator;
+        Ztring Assetmap_FileName=DirPath+__T("ASSETMAP.xml");
         bool IsOk=false;
         if (File::Exists(Assetmap_FileName))
             IsOk=true;


### PR DESCRIPTION
GitHub issue #100

Previously, when an ASSETMAP/CPL/PKL file was given as a relative path,
MediaInfo would look for related assets in the wrong place because the
'directory' was empty yet it prepended a path separator anyway.

Where dirname is empty, we need to drop the path separator.

Signed-off-by: Peter Chapman <pchapman@vidcheck.com>