### PR TITLE
IMF: Ignore MarkerSequence whatever namespace prefix is used

### DIFF
--- a/Source/MediaInfo/Multiple/File_DcpCpl.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpCpl.cpp
@@ -229,7 +229,7 @@ bool File_DcpCpl::FileHeader_Begin()
                                 //File
                                 //if ((IsDcp && (!strcmp(AssetList_Item->Value(), "MainPicture") || !strcmp(AssetList_Item->Value(), "MainSound")))
                                 // || (IsImf && (!strcmp(AssetList_Item->Value(), "cc:MainImageSequence") || !strcmp(AssetList_Item->Value(), "cc:MainImage"))))
-                                if (strcmp(AssetList_Item->Value(), "cc:MarkerSequence")) //Ignoring MarkerSequence for the moment. TODO: check what to do with MarkerSequence
+                                if (strcmp(AlItemName, "MarkerSequence")) //Ignoring MarkerSequence for the moment. TODO: check what to do with MarkerSequence
                                 {
                                     sequence* Sequence=new sequence;
                                     Ztring Asset_Id;


### PR DESCRIPTION
Hi again Jérôme,

Suggested change to remove assumption about what namespace prefix is used for MarkerSequence.