### PR TITLE
Remove 0 at the end of libmediainfo package for Fedora and RHEL/CentO…

### DIFF
--- a/Project/GNU/libmediainfo.spec
+++ b/Project/GNU/libmediainfo.spec
@@ -2,16 +2,31 @@
 %define libzen_version            0.4.33
 %define debug_package %{nil}
 
-Name:           libmediainfo
+
+%if 0%{?fedora} || 0%{?centos_version} >= 600 || 0%{?rhel_version} >= 600
+%define package_with_0_ending 0
+%define libmediainfo_name libmediainfo
+%else
+%define package_with_0_ending 1
+%define libmediainfo_name libmediainfo0
+%endif
+
+%define name_without_0_ending libmediainfo
+
+Name:           %{libmediainfo_name}
 Version:        %{libmediainfo_version}
 Release:        1
-Summary:        Most relevant technical and tag data for video and audio files
+Summary:        Most relevant technical and tag data for video and audio files -- runtime
 
 Group:          System/Libraries
 License:        BSD-2-Clause
 URL:            http://MediaArea.net/MediaInfo
 Packager:       MediaArea.net SARL <info@mediaarea.net>
-Source0:        %{name}_%{version}.tar.gz
+Source0:        %{name_without_0_ending}_%{version}.tar.gz
+%if !%{package_with_0_ending}
+Provides:       %{name_without_0_ending}0 = %{version}
+Obsoletes:      %{name_without_0_ending}0 < %{version}
+%endif
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires:  gcc-c++
@@ -56,41 +71,17 @@ What format (container) does MediaInfo support?
 * Audio: OGG, MP3, WAV, RA, AC3, DTS, AAC, M4A, AU, AIFF
 * Subtitles: SRT, SSA, ASS, SAMI
 
-%package -n %{name}0
-Summary:        Most relevant technical and tag data for video and audio files -- runtime
-Group:          System/Libraries
-
-%description -n %{name}0
-MediaInfo is a convenient unified display of the most relevant technical
-and tag data for video and audio files.
-
-What information can I get from MediaInfo?
-* General: title, author, director, album, track number, date, duration...
-* Video: codec, aspect, fps, bitrate...
-* Audio: codec, sample rate, channels, language, bitrate...
-* Text: language of subtitle
-* Chapters: number of chapters, list of chapters
-
-DivX, XviD, H263, H.263, H264, x264, ASP, AVC, iTunes, MPEG-1,
-MPEG1, MPEG-2, MPEG2, MPEG-4, MPEG4, MP4, M4A, M4V, QuickTime,
-RealVideo, RealAudio, RA, RM, MSMPEG4v1, MSMPEG4v2, MSMPEG4v3,
-VOB, DVD, WMA, VMW, ASF, 3GP, 3GPP, 3GP2
-
-What format (container) does MediaInfo support?
-* Video: MKV, OGM, AVI, DivX, WMV, QuickTime, Real, MPEG-1,
-  MPEG-2, MPEG-4, DVD (VOB) (Codecs: DivX, XviD, MSMPEG4, ASP,
-  H.264, AVC...)
-* Audio: OGG, MP3, WAV, RA, AC3, DTS, AAC, M4A, AU, AIFF
-* Subtitles: SRT, SSA, ASS, SAMI
-
 This package contains the shared library for MediaInfo.
 
-%package        doc
+%package        -n %{name_without_0_ending}-doc
 Summary:        Most relevant technical and tag data for video and audio files -- documentation
 Group:          Development/Libraries
-Requires:       %{name}0 = %{version}
+Requires:       %{name} = %{version}
+%if !0%{?suse_version} || 0%{?suse_version} >= 1200
+BuildArch:      noarch
+%endif
 
-%description    doc
+%description    -n %{name_without_0_ending}-doc
 MediaInfo is a convenient unified display of the most relevant technical
 and tag data for video and audio files.
 
@@ -115,13 +106,13 @@ What format (container) does MediaInfo support?
 
 This package contains the documentation
 
-%package        devel
+%package        -n %{name_without_0_ending}-devel
 Summary:        Most relevant technical and tag data for video and audio files -- development
 Group:          Development/Libraries
-Requires:       %{name}0%{?_isa} = %{version}
+Requires:       %{name}%{?_isa} = %{version}
 Requires:       libzen-devel%{?_isa} >= %{libzen_version}
 
-%description    devel
+%description    -n %{name_without_0_ending}-devel
 MediaInfo is a convenient unified display of the most relevant technical
 and tag data for video and audio files.
 
@@ -151,10 +142,9 @@ for development.
 %setup -q -n MediaInfoLib
 cp           Release/ReadMe_DLL_Linux.txt ReadMe.txt
 mv           History_DLL.txt History.txt
-sed -i 's/.$//' *.txt Source/Example/* 
+sed -i 's/.$//' *.txt Source/Example/*
 
-find Source -type f -exec chmod 644 {} ';'
-chmod 644 *.txt License.html
+find . -type f -exec chmod 644 {} ';'
 
 pushd Project/GNU/Library
     autoreconf -i
@@ -166,6 +156,7 @@ export CPPFLAGS="%{optflags}"
 export CXXFLAGS="%{optflags}"
 
 pushd Source/Doc/
+    doxygen -u Doxyfile
     doxygen Doxyfile
 popd
 cp Source/Doc/*.html ./
@@ -208,31 +199,36 @@ install -m 644 Source/MediaInfoDLL/MediaInfoDLL.JNative.java %{buildroot}%{_incl
 install -m 644 Source/MediaInfoDLL/MediaInfoDLL.py %{buildroot}%{_includedir}/MediaInfoDLL
 install -m 644 Source/MediaInfoDLL/MediaInfoDLL3.py %{buildroot}%{_includedir}/MediaInfoDLL
 
-sed -i -e 's|Version: |Version: %{version}|g' Project/GNU/Library/libmediainfo.pc
+sed -i -e 's|Version: |Version: %{version}|g' Project/GNU/Library/%{name_without_0_ending}.pc
 install -dm 755 %{buildroot}%{_libdir}/pkgconfig
-install -m 644 Project/GNU/Library/libmediainfo.pc %{buildroot}%{_libdir}/pkgconfig
+install -m 644 Project/GNU/Library/%{name_without_0_ending}.pc %{buildroot}%{_libdir}/pkgconfig
 
-rm -f %{buildroot}%{_libdir}/%{name}.la
+rm -f %{buildroot}%{_libdir}/%{name_without_0_ending}.la
 
 
-%post -n %{name}0 -p /sbin/ldconfig
+%post
 
-%postun -n %{name}0 -p /sbin/ldconfig
+%postun
 
-%files -n %{name}0
+%files
 %defattr(-,root,root,-)
-%doc History.txt License.html ReadMe.txt
-%{_libdir}/%{name}.so.*
+%doc History.txt ReadMe.txt
+%if 0%{?fedora} || 0%{?centos_version} >= 700 || 0%{?rhel_version} >= 700
+%license License.html
+%else
+%doc License.html
+%endif
+%{_libdir}/%{name_without_0_ending}.so.*
 
-%files    doc
+%files     -n %{name_without_0_ending}-doc
 %defattr(-,root,root,-)
 %doc Changes.txt Documentation.html Doc Source/Example
 
-%files    devel
+%files     -n %{name_without_0_ending}-devel
 %defattr(-,root,root,-)
 %{_includedir}/MediaInfo
 %{_includedir}/MediaInfoDLL
-%{_libdir}/%{name}.so
+%{_libdir}/%{name_without_0_ending}.so
 %{_libdir}/pkgconfig/*.pc
 
 %changelog


### PR DESCRIPTION
…S >= 6 to follow their guidelines

Upstream some .spec file changes from Fedora maintainer @Vascom

Signed-off-by: Guillaume Roques <guillaume.roques@gmail.com>