### PR TITLE
Don't include the SourceDir when adding a DASH segment file to the sequence.

### DIFF
--- a/Source/MediaInfo/Multiple/File_DashMpd.cpp
+++ b/Source/MediaInfo/Multiple/File_DashMpd.cpp
@@ -380,10 +380,12 @@ void template_generic::Decode()
                         Media_Name_Temp.insert(Time_Pos, Index);
 
                     Ztring File_Name;
+                    Ztring File_Name_With_Path;
                     if (!SourceDir.empty())
-                        File_Name+=SourceDir+PathSeparator;
+                        File_Name_With_Path+=SourceDir+PathSeparator;
                     File_Name+=BaseURL+Media_Name_Temp;
-                    if (!File::Exists(File_Name))
+                    File_Name_With_Path+=BaseURL+Media_Name_Temp;
+                    if (!File::Exists(File_Name_With_Path))
                         break;
                     Sequence->AddFileName(File_Name);
                     Index_Pos_Temp++;


### PR DESCRIPTION
The segment filename will get 'configured' later to include the SourceDir anyway, and that would duplicate the SourceDir in the path, so just include the base filename in the sequence instead.