### PR TITLE
FFV1 correct handling of width/height

### DIFF
--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -12,6 +12,7 @@ Version 0.7.86
 --------------
 x #I144, Python binding: Python 2 on Linux does not automatically provide the locale to the shared object
 x HTML output: don't escape carriage returns from the input file
+x FFV1: some streams were rejected despite the fact they are valid
 
 Version 0.7.85, 2016-04-29
 --------------

--- a/Source/MediaInfo/Video/File_Ffv1.cpp
+++ b/Source/MediaInfo/Video/File_Ffv1.cpp
@@ -560,7 +560,8 @@ void File_Ffv1::Read_Buffer_Continue()
         for (size_t Pos = 0; Pos < Slices_BufferSizes.size(); Pos++)
         {
             Element_Begin1("Slice");
-            int64u End=Element_Offset+Slices_BufferSizes[Pos]-tail;
+            int64u Element_Size_Save=Element_Size;
+            Element_Size=Element_Offset+Slices_BufferSizes[Pos]-tail;
             int32u crc_left=0;
 
             if (error_correction == 1)
@@ -591,9 +592,10 @@ void File_Ffv1::Read_Buffer_Continue()
                 }
             #endif //MEDIAINFO_TRACE
 
-            if (Element_Offset!=End)
-                Skip_XX(End-Element_Offset,                         "Other data");
-            Skip_B3(                                                "slice_size");
+            if (Element_Offset<Element_Size)
+                Skip_XX(Element_Size-Element_Offset,                    "Other data");
+            Element_Size=Element_Size_Save;
+            Skip_B3(                                                    "slice_size");
             if (error_correction == 1)
             {
                 Skip_B1(                                                "error_status");

--- a/Source/MediaInfo/Video/File_Ffv1.cpp
+++ b/Source/MediaInfo/Video/File_Ffv1.cpp
@@ -926,10 +926,11 @@ int File_Ffv1::slice_header(states &States)
 
     current_slice = &slices[slice_x + slice_y * num_h_slices];
 
-    current_slice->w = (slice_width_minus1 + 1) * (Width / num_h_slices);
-    current_slice->h = (slice_height_minus1 + 1) * (Height / num_v_slices);
-    current_slice->x = slice_x * current_slice->w;
-    current_slice->y = slice_y * current_slice->h;
+    //Computing boundaries, being careful about how are computed boundaries when there is not an integral number for Width  / num_h_slices or Height / num_v_slices (the last slice has more pixels)
+    current_slice->x = slice_x  * Width  / num_h_slices;
+    current_slice->y = slice_y  * Height / num_v_slices;
+    current_slice->w = slice_x2 * Width  / num_h_slices - current_slice->x;
+    current_slice->h = slice_y2 * Height / num_v_slices - current_slice->y;
 
 
     int8u plane_count=1+(alpha_plane?1:0);


### PR DESCRIPTION
In case of e.g. a 5x5 4:2:0 stream, slice pixels sizes for all planes (luma and chroma) are not correctly handled.

You can test with such file:
ffmpeg -y -f lavfi -i "color=c=white" -t 1 -filter:v scale="5:5" -vcodec ffv1 -level 3 5x5.mkv