### PR TITLE
mediainfodll - python usage on linux

### DIFF
--- a/Source/MediaInfoDLL/MediaInfoDLL.py
+++ b/Source/MediaInfoDLL/MediaInfoDLL.py
@@ -180,7 +180,6 @@ class MediaInfo:
     MediaInfo_Count_Get.restype = c_size_t
 
     Handle = c_void_p(0)
-    MustUseAnsi = 0
 
     #Handling
     def __init__(self):

--- a/Source/MediaInfoDLL/MediaInfoDLL.py
+++ b/Source/MediaInfoDLL/MediaInfoDLL.py
@@ -36,7 +36,7 @@ elif sys.platform == "darwin":
     MustUseAnsi = 1
 else:
     MediaInfoDLL_Handler = CDLL("libmediainfo.so.0")
-    MustUseAnsi = 1
+    MustUseAnsi = 0
 
 
 # types --> C Python:


### PR DESCRIPTION
Fix for usage on my machine (Ubuntu 16.04).

Without I get
```
Get with Stream=General and Parameter='FileSize'
Traceback (most recent call last):
  File "../Example/HowToUse_Dll.py", line 65, in <module>
    print(MI.Get(Stream.General, 0, "FileSize"))
  File "/srv/MediaInfoLib/Source/MediaInfoDLL/MediaInfoDLL.py", line 212, in Get
    return self.MediaInfoA_Get(self.Handle, StreamKind, StreamNumber, Parameter.encode("utf-8"), InfoKind, SearchKind).decode("utf_8", 'ignore')
ctypes.ArgumentError: argument 4: <class 'TypeError'>: wrong type
```
with python3  and python2 returns an empty string.
