### PR TITLE
Python Get() API with Python3 on Linux/Mac.

### DIFF
--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -13,6 +13,7 @@ Version 0.7.86
 x #I144, Python binding: Python 2 on Linux does not automatically provide the locale to the shared object
 x HTML output: don't escape carriage returns from the input file
 x FFV1: some streams were rejected despite the fact they are valid
+x Python binding: some errors during call of Get() API with Python3 on Linux/Mac
 
 Version 0.7.85, 2016-04-29
 --------------

--- a/Source/MediaInfoDLL/MediaInfoDLL.py
+++ b/Source/MediaInfoDLL/MediaInfoDLL.py
@@ -180,7 +180,6 @@ class MediaInfo:
     MediaInfo_Count_Get.restype = c_size_t
 
     Handle = c_void_p(0)
-    MustUseAnsi = 0
 
     #Handling
     def __init__(self):

--- a/Source/MediaInfoDLL/MediaInfoDLL.py
+++ b/Source/MediaInfoDLL/MediaInfoDLL.py
@@ -137,7 +137,7 @@ class MediaInfo:
     MediaInfo_Get.argtypes = [c_void_p, c_size_t, c_size_t, c_wchar_p, c_size_t, c_size_t]
     MediaInfo_Get.restype = c_wchar_p
     MediaInfoA_Get = MediaInfoDLL_Handler.MediaInfoA_Get
-    MediaInfoA_Get.argtypes = [c_void_p, c_size_t, c_size_t, c_wchar_p, c_size_t, c_size_t]
+    MediaInfoA_Get.argtypes = [c_void_p, c_size_t, c_size_t, c_char_p, c_size_t, c_size_t]
     MediaInfoA_Get.restype = c_char_p
 
     #/** @brief Wrapper for MediaInfoLib::MediaInfo::Set */
@@ -146,7 +146,7 @@ class MediaInfo:
     MediaInfo_SetI.argtypes = [c_void_p, c_wchar_p, c_size_t, c_size_t, c_size_t, c_wchar_p]
     MediaInfo_SetI.restype = c_void_p
     MediaInfoA_SetI = MediaInfoDLL_Handler.MediaInfoA_SetI
-    MediaInfoA_SetI.argtypes = [c_void_p, c_char_p, c_size_t, c_size_t, c_size_t, c_wchar_p]
+    MediaInfoA_SetI.argtypes = [c_void_p, c_char_p, c_size_t, c_size_t, c_size_t, c_char_p]
     MediaInfoA_SetI.restype = c_void_p
 
     #/** @brief Wrapper for MediaInfoLib::MediaInfo::Set */
@@ -155,7 +155,7 @@ class MediaInfo:
     MediaInfo_Set.argtypes = [c_void_p, c_wchar_p, c_size_t, c_size_t, c_wchar_p, c_wchar_p]
     MediaInfo_Set.restype = c_size_t
     MediaInfoA_Set = MediaInfoDLL_Handler.MediaInfoA_Set
-    MediaInfoA_Set.argtypes = [c_void_p, c_char_p, c_size_t, c_size_t, c_wchar_p, c_wchar_p]
+    MediaInfoA_Set.argtypes = [c_void_p, c_char_p, c_size_t, c_size_t, c_char_p, c_char_p]
     MediaInfoA_Set.restype = c_size_t
 
     #/** @brief Wrapper for MediaInfoLib::MediaInfo::Option */


### PR DESCRIPTION
Python binding: some errors during call of Get() API with Python3 on Linux/Mac.