### PR TITLE
x Duration: fixed regression in last release

### DIFF
--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -8,9 +8,11 @@ bug reports and feature request are here:
 https://sourceforge.net/p/mediainfo/_list/tickets
 
 
-Version 0.7.88
+Version 0.7.88, 2016-08-31
 --------------
 + MediaInfo distributed with HTTP/HTTPS support: support of Amazon S3 with Signature Version 4
++ FFV1: parsing speed slight improvement
+x Duration: fixed regression in last release, sometimes duration was displayed with only count of minutes
 
 Version 0.7.87, 2016-06-30
 --------------

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -1773,14 +1773,12 @@ void File__Analyze::Duration_Duration123(stream_t StreamKind, size_t StreamPos, 
             if (DurationString1.size()>0)
                 DurationString1+=__T(" ");
             DurationString1+=Ztring::ToZtring(Sec)+MediaInfoLib::Config.Language_Get(__T("s"));
-            if (DurationString2.size()<5)
+            if (HH==0)
             {
                 if (DurationString2.size()>0)
                     DurationString2+=__T(" ");
                 DurationString2+=Ztring::ToZtring(Sec)+MediaInfoLib::Config.Language_Get(__T("s"));
             }
-            else if (DurationString2.size()==0)
-                DurationString2+=Ztring::ToZtring(Sec)+MediaInfoLib::Config.Language_Get(__T("s"));
             if (Sec<10)
                 DurationString3+=Ztring(__T("0"))+Ztring::ToZtring(Sec)+__T(".");
             else
@@ -1798,7 +1796,7 @@ void File__Analyze::Duration_Duration123(stream_t StreamKind, size_t StreamPos, 
             if (DurationString1.size()>0)
                 DurationString1+=__T(" ");
             DurationString1+=Ztring::ToZtring(MS)+MediaInfoLib::Config.Language_Get(__T("ms"));
-            if (DurationString2.size()<5)
+            if (HH==0 && MM==0)
             {
                 if (DurationString2.size()>0)
                     DurationString2+=__T(" ");


### PR DESCRIPTION
Sometimes duration was displayed with only count of minutes