### PR TITLE
+ I242, AVI/Matroska: mapping of mjp2 to JPEG 2000 format name

### DIFF
--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -17,6 +17,7 @@ Version 0.7.89, 2016
 + Matroska: support of video FieldOrder, MatrixCoefficients, BitsPerChannel, Range, TransferCharacteristics, Primaries
 + Acquisition Metadata: support of more elements (IrisTNumber, IrisRingPosition, FocusRingPosition, ZoomRingPosition, ColorMatrix)
 + Add stream counts to MIXML output
++ I242, AVI/Matroska: mapping of mjp2 to JPEG 2000 format name
 x Acquisition Metadata: IrisFNumber, FocusPosition, LensZoom were not correctly reported
 
 Version 0.7.88, 2016-08-31

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -1980,6 +1980,7 @@ void MediaInfo_Config_CodecID_Video_Riff (InfoMap &Info)
     "MHFY;YUV;;A.M.Paredes mhuffyYUV (LossLess);http://mirror01.iptelecom.net.ua/~video/codecs/Pinnacle.ReelTime.v2.5.software.only.codec.exe;;;YUV\n"
     "MJ2C;JPEG 2000;;Morgan Multimedia JPEG 2000 Compression;http://mirror01.iptelecom.net.ua/~video/codecs/Pinnacle.ReelTime.v2.5.software.only.codec.exe;;;\n"
     "MJPA;JPEG;Pinacle;Pinnacle ReelTime MJPG hardware;http://mediaxw.sourceforge.net;;;YUV\n"
+    "mjp2;JPEG 2000;;;;;;\n"
     "MJPB;JPEG;Pinacle B;;;;;YUV\n"
     "MJPG;JPEG;;;;;;YUV\n"
     "mJPG;JPEG;IBM;Including Huffman Tables;;;;YUV\n"

--- a/Source/Resource/Text/DataBase/CodecID_Video_Riff.csv
+++ b/Source/Resource/Text/DataBase/CodecID_Video_Riff.csv
@@ -343,6 +343,7 @@ MDVF;DV;Pinnacle;Pinnacle DV/DV50/DVHD100;;;;YUV;
 MHFY;YUV;;A.M.Paredes mhuffyYUV (LossLess);http://mirror01.iptelecom.net.ua/~video/codecs/Pinnacle.ReelTime.v2.5.software.only.codec.exe;;;YUV;
 MJ2C;JPEG 2000;;Morgan Multimedia JPEG 2000 Compression;http://mirror01.iptelecom.net.ua/~video/codecs/Pinnacle.ReelTime.v2.5.software.only.codec.exe;;;;
 MJPA;JPEG;Pinacle;Pinnacle ReelTime MJPG hardware;http://mediaxw.sourceforge.net;;;YUV
+mjp2;JPEG 2000;;;;;;
 MJPB;JPEG;Pinacle B;;;;;YUV
 MJPG;JPEG;;;;;;YUV
 mJPG;JPEG;IBM;Including Huffman Tables;;;;YUV


### PR DESCRIPTION
https://github.com/MediaArea/MediaInfoLib/issues/242