### PR TITLE
+ #M94, WAV: support of file with a buggy RIFF header

### DIFF
--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -3,13 +3,14 @@
 + Added
 - Deleted
 x Correction
-#number is the identifier of SourceForge bug report (B), requested feature (F) or patch (P), or GitHub issue (I)
+#number is the identifier of SourceForge bug report (B), requested feature (F) or patch (P), MediaInfoLib GitHub issue (I), or MediaInfo GitHub issue (M)
 bug reports and feature request are here:
 https://sourceforge.net/p/mediainfo/_list/tickets
 
 
 Version 0.7.90
 --------------
++ #M94, WAV: support of file with a buggy RIFF header
 + MXF: detection of some incoherences between header and footer
 + MXF: display of Locked information
 + N19/STL: support of 48/50/60 fps content

--- a/Source/MediaInfo/Multiple/File_Riff.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff.cpp
@@ -935,6 +935,13 @@ void File_Riff::Header_Parse()
         if (Name==Elements::RF64)
             IsRIFF64=true;
         Get_C4 (Name,                                           "Real Name");
+
+        //Handling buggy files
+        if (Size_Complete>=8 && Size_Complete<12) //Not possible (would contain only the name of the RIFF block + the name of the sub-element, no size)
+        {
+            Size_Complete=Element_TotalSize_Get()-8;
+            Fill(Stream_General, 0, "BuggyHeader", Ztring().From_CC4(Name));
+        }
     }
 
     //Integrity


### PR DESCRIPTION
Resolves https://github.com/MediaArea/MediaInfo/issues/94