### PR TITLE
Fix  #endif MEDIAINFO_%

### DIFF
--- a/Source/MediaInfo/MediaInfo_Internal.cpp
+++ b/Source/MediaInfo/MediaInfo_Internal.cpp
@@ -935,7 +935,7 @@ size_t MediaInfo_Internal::Open_Buffer_Finalize ()
         {
             delete Config.Config_PerPackage; Config.Config_PerPackage=NULL;
         }
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 
     EXECUTE_SIZE_T(1, Debug+=__T("Open_Buffer_Finalize, will return 1"))
 }

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -2323,7 +2323,7 @@ bool File_Mpeg4::BookMark_Needed()
                             // Hash can not be computed with jumps.
                             delete Hash; Hash=NULL;
                         }
-                    #endif MEDIAINFO_HASH
+                    #endif //MEDIAINFO_HASH
                 }
             }
         #endif // MEDIAINFO_DEMUX

--- a/Source/MediaInfo/Text/File_AribStdB24B37.cpp
+++ b/Source/MediaInfo/Text/File_AribStdB24B37.cpp
@@ -342,7 +342,7 @@ File_AribStdB24B37::File_AribStdB24B37()
     IsAncillaryData=false;
     #if MEDIAINFO_EVENTS
         MuxingMode=(int8u)-1;
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 
     //Config
     Caption_conversion_type=(int8u)-1;
@@ -750,7 +750,7 @@ void File_AribStdB24B37::caption_statement() //caption_data()
             Event.Row_Values=NULL;
             Event.Row_Attributes=NULL;
         EVENT_END   ()
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 
     Frame_Count++;
     Frame_Count_NotParsedIncluded++;

--- a/Source/MediaInfo/Text/File_AribStdB24B37.h
+++ b/Source/MediaInfo/Text/File_AribStdB24B37.h
@@ -39,7 +39,7 @@ public :
     bool    IsAncillaryData;
     #if MEDIAINFO_EVENTS
         int8u   MuxingMode;
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 
     //enums
     enum graphic_set

--- a/Source/MediaInfo/Text/File_Eia608.cpp
+++ b/Source/MediaInfo/Text/File_Eia608.cpp
@@ -76,7 +76,7 @@ File_Eia608::File_Eia608()
     cc_type=(int8u)-1;
     #if MEDIAINFO_EVENTS
         MuxingMode=(int8u)-1;
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 
     //Temp
     XDS_Level=(size_t)-1;
@@ -242,7 +242,7 @@ void File_Eia608::Read_Buffer_Init()
             if (StreamIDs_Size>=3 && ParserIDs[StreamIDs_Size-3]==MediaInfo_Parser_Mpeg4 && ParserIDs[StreamIDs_Size-2]==MediaInfo_Parser_Mpeg4)
                 MuxingMode=14; //Final Cut / cdat
         }
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 }
 
 //---------------------------------------------------------------------------
@@ -1137,7 +1137,7 @@ void File_Eia608::HasChanged()
                     Event.Row_Values[Pos_Y][32]=L'\0';
                 }
             EVENT_END   ()
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Text/File_Eia608.h
+++ b/Source/MediaInfo/Text/File_Eia608.h
@@ -37,7 +37,7 @@ public :
     int8u   cc_type;
     #if MEDIAINFO_EVENTS
         int8u   MuxingMode;
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 
     //Constructor/Destructor
     File_Eia608();

--- a/Source/MediaInfo/Text/File_Eia708.cpp
+++ b/Source/MediaInfo/Text/File_Eia708.cpp
@@ -50,7 +50,7 @@ File_Eia708::File_Eia708()
     AspectRatio=((float32)4)/3; //Default to 4:3
     #if MEDIAINFO_EVENTS
         MuxingMode=(int8u)-1;
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
     ParserName="EIA-708";
 
     //Stream
@@ -181,7 +181,7 @@ void File_Eia708::Read_Buffer_Init()
             if (StreamIDs_Size>=2 && ParserIDs[StreamIDs_Size-2]==MediaInfo_Parser_Scc)
                 MuxingMode=7; //SCC
         }
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 }
 
 //---------------------------------------------------------------------------
@@ -1502,7 +1502,7 @@ void File_Eia708::Window_HasChanged()
             for (size_t Pos_Y=Window->Minimal.CC.size(); Pos_Y<15; Pos_Y++)
                 Event.Row_Values[Pos_Y][0]=L'\0';
         EVENT_END   ()
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 }
 
 //---------------------------------------------------------------------------
@@ -1522,7 +1522,7 @@ void File_Eia708::HasChanged()
                 Event.Row_Values[Pos_Y][(size_t)(24*AspectRatio)]=L'\0';
             }
         EVENT_END   ()
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Text/File_Eia708.h
+++ b/Source/MediaInfo/Text/File_Eia708.h
@@ -36,7 +36,7 @@ public :
     float64 AspectRatio;
     #if MEDIAINFO_EVENTS
         int8u   MuxingMode;
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 
     //Constructor/Destructor
     File_Eia708();

--- a/Source/MediaInfo/Text/File_SubRip.cpp
+++ b/Source/MediaInfo/Text/File_SubRip.cpp
@@ -288,7 +288,7 @@ void File_SubRip::Read_Buffer_Continue()
 
             Frame_Count++;
         }
-    #endif MEDIAINFO_EVENTS
+    #endif //MEDIAINFO_EVENTS
 
     Buffer_Offset=Buffer_Size;
 }


### PR DESCRIPTION
In file included from ../../../Source/MediaInfo/File__MultipleParsing.cpp:258:0:
../../../Source/MediaInfo/Text/File_Eia608.h:40:12: warning: extra tokens at end of #endif directive [enabled by default]
     #endif MEDIAINFO_EVENTS
            ^