### PR TITLE
Fix const T -> const T& for private functions

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac.h
+++ b/Source/MediaInfo/Audio/File_Aac.h
@@ -256,7 +256,7 @@ protected :
     void sbr_envelope                       (bool ch, bool bs_coupling);
     void sbr_noise                          (bool ch, bool bs_coupling);
     void sbr_sinusoidal_coding              (bool ch);
-    int16u sbr_huff_dec                     (sbr_huffman Table, const char* Name);
+    int16u sbr_huff_dec                     (const sbr_huffman& Table, const char* Name);
 
     //Elements - SBR - PS
     void ps_data                            (size_t End);

--- a/Source/MediaInfo/Audio/File_Aac_GeneralAudio_Sbr.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_GeneralAudio_Sbr.cpp
@@ -132,11 +132,11 @@ bool Aac_f_master_Compute_0(int8u &num_env_bands_Master, int8u* f_Master, sbr_ha
 //---------------------------------------------------------------------------
 // Master frequency band table
 // Computing for bs_freq_scale != 0
-int int8u_cmp(const void *a, const void *b)
+static int int8u_cmp(const void *a, const void *b)
 {
     return ((int8u)(*(int8u*)a - *(int8u*)b));
 }
-bool Aac_f_master_Compute(int8u &num_env_bands_Master, int8u* f_Master, sbr_handler *sbr, int8u  k0, int8u  k2)
+static bool Aac_f_master_Compute(int8u &num_env_bands_Master, int8u* f_Master, sbr_handler *sbr, int8u  k0, int8u  k2)
 {
     int8u temp1[]={6, 5, 4 };
     int8u bands=temp1[sbr->bs_freq_scale-1];
@@ -233,7 +233,7 @@ bool Aac_f_master_Compute(int8u &num_env_bands_Master, int8u* f_Master, sbr_hand
 
 //---------------------------------------------------------------------------
 // Derived frequency border tables
-bool Aac_bands_Compute(int8u &num_env_bands_Master, int8u* f_Master, sbr_handler *sbr, int8u  k2)
+static bool Aac_bands_Compute(const int8u &num_env_bands_Master, int8u* f_Master, sbr_handler *sbr, int8u  k2)
 {
     sbr->num_env_bands[1]=num_env_bands_Master-sbr->bs_xover_band;
     sbr->num_env_bands[0]=(sbr->num_env_bands[1]>>1)+(sbr->num_env_bands[1]-((sbr->num_env_bands[1]>>1)<<1));
@@ -254,7 +254,7 @@ bool Aac_bands_Compute(int8u &num_env_bands_Master, int8u* f_Master, sbr_handler
 }
 
 //---------------------------------------------------------------------------
-bool Aac_Sbr_Compute(sbr_handler *sbr, int8u extension_sampling_frequency_index)
+static bool Aac_Sbr_Compute(sbr_handler *sbr, int8u extension_sampling_frequency_index)
 {
     if (extension_sampling_frequency_index>=9)
         return 0; //Not supported
@@ -296,7 +296,7 @@ bool Aac_Sbr_Compute(sbr_handler *sbr, int8u extension_sampling_frequency_index)
 }
 
 //---------------------------------------------------------------------------
-int16u File_Aac::sbr_huff_dec(sbr_huffman Table, const char* Name)
+int16u File_Aac::sbr_huff_dec(const sbr_huffman& Table, const char* Name)
 {
     int8u bit;
     int16s index = 0;

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -1035,7 +1035,7 @@ static const char* Mxf_EssenceCompression(const int128u EssenceCompression)
 }
 
 //---------------------------------------------------------------------------
-static const char* Mxf_EssenceCompression_Profile(const int128u EssenceCompression)
+static const char* Mxf_EssenceCompression_Profile(const int128u& EssenceCompression)
 {
     int8u Code2=(int8u)((EssenceCompression.lo&0x00FF000000000000LL)>>48);
     int8u Code3=(int8u)((EssenceCompression.lo&0x0000FF0000000000LL)>>40);
@@ -1089,7 +1089,7 @@ static const char* Mxf_EssenceCompression_Profile(const int128u EssenceCompressi
     }
 }
 //---------------------------------------------------------------------------
-static const char* Mxf_EssenceCompression_Version(const int128u EssenceCompression)
+static const char* Mxf_EssenceCompression_Version(const int128u& EssenceCompression)
 {
     int8u Code2=(int8u)((EssenceCompression.lo&0x00FF000000000000LL)>>48);
     int8u Code3=(int8u)((EssenceCompression.lo&0x0000FF0000000000LL)>>40);
@@ -1319,7 +1319,7 @@ static const char* Mxf_ChannelAssignment_ChannelPositions(const int128u ChannelL
 }
 
 //---------------------------------------------------------------------------
-static const char* Mxf_ChannelAssignment_ChannelPositions2(const int128u ChannelLayout, int32u ChannelsCount=(int32u)-1)
+static const char* Mxf_ChannelAssignment_ChannelPositions2(const int128u& ChannelLayout, int32u ChannelsCount=(int32u)-1)
 {
     //Sound Channel Labeling
     if ((ChannelLayout.hi&0xFFFFFFFFFFFFFF00LL)!=0x060E2B3404010100LL && (ChannelLayout.lo&0xFFFFFFFF00000000LL)!=0x0402021000000000LL)
@@ -1366,7 +1366,7 @@ static const char* Mxf_ChannelAssignment_ChannelPositions2(const int128u Channel
 }
 
 //---------------------------------------------------------------------------
-static const char* Mxf_ChannelAssignment_ChannelLayout(const int128u ChannelLayout, int32u ChannelsCount=(int32u)-1)
+static const char* Mxf_ChannelAssignment_ChannelLayout(const int128u& ChannelLayout, int32u ChannelsCount=(int32u)-1)
 {
     //Sound Channel Labeling
     if ((ChannelLayout.hi&0xFFFFFFFFFFFFFF00LL)!=0x060E2B3404010100LL && (ChannelLayout.lo&0xFFFFFFFF00000000LL)!=0x0402021000000000LL)

--- a/Source/MediaInfo/Multiple/File_Wm_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Wm_Elements.cpp
@@ -134,7 +134,7 @@ namespace Elements
     UUID(Mutex_Bitrate,                                         D6E22A01, 35DA, 11D1, 9034, 00A0C90349BE);
 }
 
-static const char* Wm_StreamType(const int128u Kind)
+static const char* Wm_StreamType(const int128u& Kind)
 {
     switch (Kind.hi)
     {
@@ -149,7 +149,7 @@ static const char* Wm_StreamType(const int128u Kind)
     }
 }
 
-static const char* Wm_ExclusionType(const int128u ExclusionType)
+static const char* Wm_ExclusionType(const int128u& ExclusionType)
 {
     switch (ExclusionType.hi)
     {

--- a/Source/MediaInfo/Reader/Reader_libcurl.cpp
+++ b/Source/MediaInfo/Reader/Reader_libcurl.cpp
@@ -64,7 +64,7 @@ namespace MediaInfoLib
 namespace Http
 {
     //Helpers
-    void CutHead(std::string &Input, std::string &Output, std::string Delimiter)
+   static  void CutHead(std::string &Input, std::string &Output, const std::string& Delimiter)
     {
         // Remove the delimiter and everything that precedes
         size_t Delimiter_Pos = Input.find(Delimiter);
@@ -75,7 +75,7 @@ namespace Http
             Input           = Input.substr(Begin, Input.size() - Begin);
         }
     }
-    void CutTail(std::string &Input, std::string &Output, const std::string &Delimiter, bool KeepDelimiter=false)
+    static void CutTail(std::string &Input, std::string &Output, const std::string &Delimiter, bool KeepDelimiter=false)
     {
         // Remove the delimiter and everything that follows
         size_t Delimiter_Pos = Input.find(Delimiter);

--- a/Source/MediaInfo/Text/File_AribStdB24B37.cpp
+++ b/Source/MediaInfo/Text/File_AribStdB24B37.cpp
@@ -832,7 +832,7 @@ void File_AribStdB24B37::Add (Char Character)
 }
 
 //---------------------------------------------------------------------------
-void File_AribStdB24B37::Add (Ztring Character)
+void File_AribStdB24B37::Add (const Ztring& Character)
 {
     Streams[(size_t)(Element_Code-1)].Line+=Character;
 }

--- a/Source/MediaInfo/Text/File_AribStdB24B37.h
+++ b/Source/MediaInfo/Text/File_AribStdB24B37.h
@@ -85,7 +85,7 @@ private :
     void data_unit_data(int64u End);
     void Character(int16u CharacterSet, int8u G_Value, int8u FirstByte, int8u SecondByte);
     void Add(Char Character);
-    void Add(Ztring Character);
+    void Add(const Ztring& Character);
     void DefaultMacro();
     void control_code();
     void NUL();


### PR DESCRIPTION
V813 Decreased performance. The 'x' argument should probably be rendered as a constant reference.
http://www.viva64.com/en/w/V813/print/
