### PR TITLE
PVS Studio fix

### DIFF
--- a/Source/MediaInfo/Export/Export_Mpeg7.cpp
+++ b/Source/MediaInfo/Export/Export_Mpeg7.cpp
@@ -115,7 +115,7 @@ int32u Mpeg7_ContentCS_termID(MediaInfo_Internal &MI)
         return 40200;
     if (Format==__T("MPEG Audio") || Format==__T("Wave"))
         return 10000;
-    if (Format==__T("BMP") || Format==__T("GIF") || Format==__T("JPEG") || Format==__T("JPEG 2000") || Format==__T("JPEG 2000") || Format==__T("PNG") || Format==__T("TIFF"))
+    if (Format==__T("BMP") || Format==__T("GIF") || Format==__T("JPEG") || Format==__T("JPEG 2000") || Format==__T("PNG") || Format==__T("TIFF"))
         return 40100;
     return 500000;
 }
@@ -173,7 +173,7 @@ int32u Mpeg7_FileFormatCS_termID(MediaInfo_Internal &MI)
         return 60000;
     if (Format==__T("JPEG"))
         return 10000;
-    if (Format==__T("JPEG 2000") || Format==__T("JPEG 2000"))
+    if (Format==__T("JPEG 2000"))
         return 20000;
     if (Format==__T("MPEG Audio"))
         return (MI.Get(Stream_Audio, 0, Audio_Format_Profile).find(__T("3"))!=string::npos)?40000:0;

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -1428,7 +1428,7 @@ size_t File__Analyze::Merge(File__Analyze &ToAdd, stream_t StreamKind, size_t St
         }
         if (!colour_description_present_Temp.empty())
         {
-            if (!colour_description_present_Temp.empty() && !Retrieve(Stream_Video, StreamPos_To, Video_colour_description_present).empty()
+            if (!Retrieve(Stream_Video, StreamPos_To, Video_colour_description_present).empty()
              && (colour_primaries_Temp!=Retrieve(Stream_Video, StreamPos_To, Video_colour_primaries)
               || transfer_characteristics_Temp!=Retrieve(Stream_Video, StreamPos_To, Video_transfer_characteristics)
               || matrix_coefficients_Temp!=Retrieve(Stream_Video, StreamPos_To, Video_matrix_coefficients)))

--- a/Source/MediaInfo/Multiple/File_DcpCpl.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpCpl.cpp
@@ -60,6 +60,8 @@ File_DcpCpl::File_DcpCpl()
 
     //Temp
     ReferenceFiles=NULL;
+    //PKL
+    PKL_Pos = (size_t)-1;
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -1080,7 +1080,7 @@ void File_Mk::Header_Parse()
     }
 
     //Parsing
-    int64u Name, Size;
+    int64u Name, Size = 0;
     bool NameIsValid=true;
     if (Element_Offset+1<Element_Size)
     {

--- a/Source/MediaInfo/Multiple/File_Mxf.h
+++ b/Source/MediaInfo/Multiple/File_Mxf.h
@@ -1058,6 +1058,7 @@ protected :
             CompletionDate=(int64u)-1;
             TextlessElementsExist=(int8u)-1;
             ProgrammeHasText=(int8u)-1;
+            FpaPass=(int8u)-1;
         }
 
         ~as11()

--- a/Source/MediaInfo/Reader/Reader_libcurl.cpp
+++ b/Source/MediaInfo/Reader/Reader_libcurl.cpp
@@ -64,7 +64,7 @@ namespace MediaInfoLib
 namespace Http
 {
     //Helpers
-    static  void CutHead(std::string &Input, std::string &Output, const std::string& Delimiter)
+   static  void CutHead(std::string &Input, std::string &Output, const std::string& Delimiter)
     {
         // Remove the delimiter and everything that precedes
         size_t Delimiter_Pos = Input.find(Delimiter);

--- a/Source/MediaInfo/Reader/Reader_libcurl.cpp
+++ b/Source/MediaInfo/Reader/Reader_libcurl.cpp
@@ -64,7 +64,7 @@ namespace MediaInfoLib
 namespace Http
 {
     //Helpers
-    void CutHead(std::string &Input, std::string &Output, std::string Delimiter)
+    void CutHead(std::string &Input, std::string &Output, const std::string& Delimiter)
     {
         // Remove the delimiter and everything that precedes
         size_t Delimiter_Pos = Input.find(Delimiter);

--- a/Source/MediaInfo/Reader/Reader_libcurl.cpp
+++ b/Source/MediaInfo/Reader/Reader_libcurl.cpp
@@ -64,7 +64,7 @@ namespace MediaInfoLib
 namespace Http
 {
     //Helpers
-    void CutHead(std::string &Input, std::string &Output, const std::string& Delimiter)
+    static  void CutHead(std::string &Input, std::string &Output, const std::string& Delimiter)
     {
         // Remove the delimiter and everything that precedes
         size_t Delimiter_Pos = Input.find(Delimiter);
@@ -75,7 +75,7 @@ namespace Http
             Input           = Input.substr(Begin, Input.size() - Begin);
         }
     }
-    void CutTail(std::string &Input, std::string &Output, const std::string &Delimiter, bool KeepDelimiter=false)
+    static void CutTail(std::string &Input, std::string &Output, const std::string &Delimiter, bool KeepDelimiter=false)
     {
         // Remove the delimiter and everything that follows
         size_t Delimiter_Pos = Input.find(Delimiter);

--- a/Source/MediaInfo/Text/File_AribStdB24B37.cpp
+++ b/Source/MediaInfo/Text/File_AribStdB24B37.cpp
@@ -832,7 +832,7 @@ void File_AribStdB24B37::Add (Char Character)
 }
 
 //---------------------------------------------------------------------------
-void File_AribStdB24B37::Add (Ztring Character)
+void File_AribStdB24B37::Add (const Ztring& Character)
 {
     Streams[(size_t)(Element_Code-1)].Line+=Character;
 }

--- a/Source/MediaInfo/Text/File_AribStdB24B37.h
+++ b/Source/MediaInfo/Text/File_AribStdB24B37.h
@@ -85,7 +85,7 @@ private :
     void data_unit_data(int64u End);
     void Character(int16u CharacterSet, int8u G_Value, int8u FirstByte, int8u SecondByte);
     void Add(Char Character);
-    void Add(Ztring Character);
+    void Add(const Ztring& Character);
     void DefaultMacro();
     void control_code();
     void NUL();

--- a/Source/MediaInfo/Text/File_DvbSubtitle.cpp
+++ b/Source/MediaInfo/Text/File_DvbSubtitle.cpp
@@ -392,10 +392,11 @@ void File_DvbSubtitle::region_composition_segment()
     }
 
     FILLING_BEGIN();
-        subtitle_streams[subtitle_stream_id].pages[page_id].regions[region_id].region_composition_segment=true;
-        subtitle_streams[subtitle_stream_id].pages[page_id].regions[region_id].region_width=region_width;
-        subtitle_streams[subtitle_stream_id].pages[page_id].regions[region_id].region_height=region_height;
-        subtitle_streams[subtitle_stream_id].pages[page_id].regions[region_id].region_depth=region_depth;
+        region_data& region = subtitle_streams[subtitle_stream_id].pages[page_id].regions[region_id];
+        region.region_composition_segment=true;
+        region.region_width=region_width;
+        region.region_height=region_height;
+        region.region_depth=region_depth;
     FILLING_END();
 }
 

--- a/Source/MediaInfo/Video/File_Avc_Duplicate.cpp
+++ b/Source/MediaInfo/Video/File_Avc_Duplicate.cpp
@@ -204,7 +204,7 @@ void File_Avc::File__Duplicate_Write (int64u Element_Code, int32u frame_num)
     }
     else if (frame_num!=(int32u)-1)
     {
-        if (frame_num!=frame_num_Old && frame_num_Old!=(int32u)-1 && frame_num!=(int32u)-1)
+        if (frame_num!=frame_num_Old && frame_num_Old!=(int32u)-1)
         {
             // Form:
             //  8 bytes : PTS

--- a/Source/MediaInfo/Video/File_Ffv1.cpp
+++ b/Source/MediaInfo/Video/File_Ffv1.cpp
@@ -1597,7 +1597,7 @@ void File_Ffv1::read_quant_table(int i, int j, size_t scale)
             return;
         }
 
-        for (size_t a=0; a<=len_minus1; a++)
+        for (int32u a=0; a<=len_minus1; a++)
         {
             quant_tables[i][j][k] = scale * v;
             k++;

--- a/Source/MediaInfo/Video/File_Mpeg4v.cpp
+++ b/Source/MediaInfo/Video/File_Mpeg4v.cpp
@@ -1215,7 +1215,7 @@ void File_Mpeg4v::video_object_layer_start()
     }
 
     //Coherancy
-    if (shape!=2 && shape==0 && (object_layer_width==0 || object_layer_height==0 || ((float32)object_layer_width)/object_layer_height<((float32)0.1) || object_layer_width/object_layer_height>10))
+    if (shape==0 && (object_layer_width==0 || object_layer_height==0 || ((float32)object_layer_width)/object_layer_height<((float32)0.1) || object_layer_width/object_layer_height>10))
         Trusted_IsNot("Problem with width and height!");
 
     FILLING_BEGIN();


### PR DESCRIPTION
V614 Potentially uninitialized variable 'Size' used. file_mk.cpp 1150
 V571 Recurring check. The '!colour_description_present_Temp.empty()' condition was already verified in line 1429. file__analyze_streams.cpp 1431
 V571 Recurring check. The 'frame_num != (int32u) - 1' condition was already verified in line 205. file_avc_duplicate.cpp 207
 V127 An overflow of the 32-bit 'k' variable is possible inside a long cycle which utilizes a memsize-type loop counter. file_ffv1.cpp 1603
 V730 Not all members of a class are initialized inside the constructor. Consider inspecting: FpaPass. file_mxf.h 1031
 V730 Not all members of a class are initialized inside the constructor. Consider inspecting: PKL_Pos. file_dcpcpl.cpp 50
 V590 Consider inspecting the 'shape != 2 && shape == 0' expression. The expression is excessive or contains a misprint. file_mpeg4v.cpp 1218 (Fixed #263)
 V501 There are identical sub-expressions 'Format == L"JPEG 2000"' to the left and to the right of the '||' operator. export_mpeg7.cpp 176
 V501 There are identical sub-expressions 'Format == L"JPEG 2000"' to the left and to the right of the '||' operator. export_mpeg7.cpp 118
 V813 Decreased performance. The 'Delimiter' argument should probably be rendered as a constant reference. reader_libcurl.cpp 67
 V813 Decreased performance. The 'Character' argument should probably be rendered as a constant reference. file_aribstdb24b37.cpp 835
 V807 Decreased performance. Consider creating a reference to avoid using the same expression repeatedly. file_dvbsubtitle.cpp 395