### PR TITLE
Fix operator= and copy constructor

### DIFF
--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -497,7 +497,7 @@ void File__Analyze::Open_Buffer_OutOfBand (File__Analyze* Sub, const int8u* ToAd
         if (Trace_Activated)
         {
             //Details handling
-            if ((!Sub->Element[0].TraceNode.Is_Empty() || Sub->Element[0].TraceNode.Children.size()) && !Trace_DoNotSave)
+            if ((!Sub->Element[0].TraceNode.Name_Is_Empty() || Sub->Element[0].TraceNode.Children.size()) && !Trace_DoNotSave)
             {
                 //From Sub
                 while(Sub->Element_Level)
@@ -1050,7 +1050,7 @@ void File__Analyze::Open_Buffer_Continue (File__Analyze* Sub, const int8u* ToAdd
         if (Trace_Activated)
         {
             //Details handling
-            if ((!Sub->Element[0].TraceNode.Is_Empty() || Sub->Element[0].TraceNode.Children.size()) && !Trace_DoNotSave)
+            if ((!Sub->Element[0].TraceNode.Name_Is_Empty() || Sub->Element[0].TraceNode.Children.size()) && !Trace_DoNotSave)
             {
                 //From Sub
                 while(Sub->Element_Level)
@@ -2249,7 +2249,7 @@ bool File__Analyze::Header_Manage()
     #if MEDIAINFO_TRACE
     if (Trace_Activated)
     {
-        if (Element[Element_Level-1].TraceNode.Is_Empty())
+        if (Element[Element_Level-1].TraceNode.Name_Is_Empty())
             Element[Element_Level-1].TraceNode.Set_Name("Unknown");
         Element[Element_Level].TraceNode.Size=Element_Offset;
         if (Element_Offset==0)

--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -497,7 +497,7 @@ void File__Analyze::Open_Buffer_OutOfBand (File__Analyze* Sub, const int8u* ToAd
         if (Trace_Activated)
         {
             //Details handling
-            if ((Sub->Element[0].TraceNode.Get_Name() || Sub->Element[0].TraceNode.Children.size()) && !Trace_DoNotSave)
+            if ((!Sub->Element[0].TraceNode.Is_Empty() || Sub->Element[0].TraceNode.Children.size()) && !Trace_DoNotSave)
             {
                 //From Sub
                 while(Sub->Element_Level)
@@ -1050,7 +1050,7 @@ void File__Analyze::Open_Buffer_Continue (File__Analyze* Sub, const int8u* ToAdd
         if (Trace_Activated)
         {
             //Details handling
-            if ((Sub->Element[0].TraceNode.Get_Name() || Sub->Element[0].TraceNode.Children.size()) && !Trace_DoNotSave)
+            if ((!Sub->Element[0].TraceNode.Is_Empty() || Sub->Element[0].TraceNode.Children.size()) && !Trace_DoNotSave)
             {
                 //From Sub
                 while(Sub->Element_Level)
@@ -2249,7 +2249,7 @@ bool File__Analyze::Header_Manage()
     #if MEDIAINFO_TRACE
     if (Trace_Activated)
     {
-        if (!Element[Element_Level-1].TraceNode.Get_Name())
+        if (Element[Element_Level-1].TraceNode.Is_Empty())
             Element[Element_Level-1].TraceNode.Set_Name("Unknown");
         Element[Element_Level].TraceNode.Size=Element_Offset;
         if (Element_Offset==0)

--- a/Source/MediaInfo/File__Analyze.h
+++ b/Source/MediaInfo/File__Analyze.h
@@ -414,7 +414,7 @@ public :
         int64u Pos=Element_Offset+BS->OffsetBeforeLastCall_Get();
 
         element_details::Element_Node *node = new element_details::Element_Node;
-        node->Set_Name(Parameter.c_str());
+        node->Set_Name(Parameter);
         node->Pos = Pos==(int64u)-1 ? Pos : (File_Offset+Buffer_Offset+Pos);
         node->Value.set_Option(GenericOption);
         node->Value = Value;

--- a/Source/MediaInfo/File__Analyze_Element.cpp
+++ b/Source/MediaInfo/File__Analyze_Element.cpp
@@ -598,32 +598,13 @@ std::ostream& operator<<(std::ostream& os, const element_details::Element_Node_D
 //***************************************************************************
 // Element_Node_Info
 //***************************************************************************
-
-//---------------------------------------------------------------------------
-element_details::Element_Node_Info& element_details::Element_Node_Info::operator=(const Element_Node_Info& v)
-{
-    if (this == &v)
-        return *this;
-
-    data = v.data;
-    if (v.Measure)
-    {
-        size_t len = strlen(v.Measure) + 1;
-        Measure = new char[len];
-        std::memcpy(Measure, v.Measure, len);
-    }
-
-    return *this;
-}
-
-//---------------------------------------------------------------------------
 std::ostream& operator<<(std::ostream& os, element_details::Element_Node_Info* v)
 {
     if (!v)
         return os;
 
     os << v->data;
-    if (v->Measure)
+    if (!v->Measure.empty())
         os << v->Measure;
 
     return os;
@@ -634,7 +615,7 @@ std::ostream& operator<<(std::ostream& os, element_details::Element_Node_Info* v
 //***************************************************************************
 //---------------------------------------------------------------------------
 element_details::Element_Node::Element_Node()
-: Pos(0), Size(0), Name(NULL),
+: Pos(0), Size(0), 
   Current_Child(-1), NoShow(false), OwnChildren(true), IsCat(false)
 {
 }
@@ -720,7 +701,7 @@ int element_details::Element_Node::Print_Micro_Xml(std::ostringstream& ss, size_
     {
         Element_Node_Info* Info = Infos[i];
 
-        if (Info->Measure && !std::strcmp(Info->Measure, "Parser"))
+        if (Info->Measure == "Parser")
         {
             if (!(Info->data == string()))
                 ss << " parser=\"" << Info->data << "\"";
@@ -794,7 +775,7 @@ int element_details::Element_Node::Print_Xml(std::ostringstream& ss, size_t leve
     {
         Element_Node_Info* Info = Infos[i];
 
-        if (Info->Measure && !std::strcmp(Info->Measure, "Parser"))
+        if (Info->Measure == "Parser")
         {
             if (!(Info->data == string()))
                 ss << " parser=\"" << Info->data << "\"";
@@ -893,7 +874,7 @@ int element_details::Element_Node::Print_Tree(std::ostringstream& ss, size_t lev
     {
         Element_Node_Info* Info = Infos[i];
 
-        if (Info->Measure && !std::strcmp(Info->Measure, "Parser"))
+        if (Info->Measure == "Parser")
         {
             if (!(Info->data == string()))
                 ss << " - Parser=" << Info->data;

--- a/Source/MediaInfo/File__Analyze_Element.cpp
+++ b/Source/MediaInfo/File__Analyze_Element.cpp
@@ -677,7 +677,7 @@ void element_details::Element_Node::Init()
 //---------------------------------------------------------------------------
 int element_details::Element_Node::Print_Micro_Xml(std::ostringstream& ss, size_t level)
 {
-    if (IsCat || Is_Empty())
+    if (IsCat || Name_Is_Empty())
         goto print_children;
 
     if (Value.empty())
@@ -729,7 +729,7 @@ print_children:
     for (size_t i = 0; i < Children.size(); ++i)
         Children[i]->Print_Micro_Xml(ss, level);
 
-    if (!IsCat && !Is_Empty())
+    if (!IsCat && !Name_Is_Empty())
     {
         //end tag
         if (Value.empty())
@@ -748,7 +748,7 @@ int element_details::Element_Node::Print_Xml(std::ostringstream& ss, size_t leve
     std::string spaces;
     bool Modified = false;
 
-    if (IsCat || Is_Empty())
+    if (IsCat || Name_Is_Empty())
         goto print_children;
 
     spaces.resize(level, ' ');
@@ -805,7 +805,7 @@ print_children:
     for (size_t i = 0; i < Children.size(); ++i)
         Children[i]->Print_Xml(ss, level);
 
-    if (!IsCat && !Is_Empty())
+    if (!IsCat && !Name_Is_Empty())
     {
         //end tag
         if (Value.empty())
@@ -848,7 +848,7 @@ int element_details::Element_Node::Print_Tree(std::ostringstream& ss, size_t lev
 
     if (IsCat)
         return Print_Tree_Cat(ss, level);
-    else if (Is_Empty())
+    else if (Name_Is_Empty())
         goto print_children;
 
     ss << std::setfill('0') << std::setw(8) << std::hex << std::uppercase << Pos << std::nouppercase << std::dec;
@@ -862,7 +862,7 @@ int element_details::Element_Node::Print_Tree(std::ostringstream& ss, size_t lev
     if (!Value.empty())
     {
         ss << ":";
-        int nb_free = NB_SPACES - level - (Is_Empty() ? 0 : Name.length()); // 40 - len(Name) - len(spaces)
+        int nb_free = NB_SPACES - level - (Name_Is_Empty() ? 0 : Name.length()); // 40 - len(Name) - len(spaces)
         spaces.resize(nb_free > 0 ? nb_free : 1, ' ');
         Value.Set_Output_Format(Element_Node_Data::Format_Tree);
         ss << spaces << Value;

--- a/Source/MediaInfo/File__Analyze_Element.cpp
+++ b/Source/MediaInfo/File__Analyze_Element.cpp
@@ -647,18 +647,7 @@ element_details::Element_Node::Element_Node(const Element_Node& node)
 
     Pos = node.Pos;
     Size = node.Size;
-    if (node.Name)
-    {
-        size_t len = strlen(node.Name);
-        if (len)
-        {
-            len++;
-            Name = new char[len];
-            std::memcpy(Name, node.Name, len);
-        }
-    }
-    else
-        Name = NULL;
+    Name = node.Name;
     Value = node.Value;
     Infos = node.Infos;
     Children = node.Children;
@@ -671,8 +660,6 @@ element_details::Element_Node::Element_Node(const Element_Node& node)
 //---------------------------------------------------------------------------
 element_details::Element_Node::~Element_Node()
 {
-    delete[] Name;
-
     if (!OwnChildren)
         return;
 
@@ -690,11 +677,7 @@ void element_details::Element_Node::Init()
 {
     Pos = 0;
     Size = 0;
-    if (Name)
-    {
-        delete[] Name;
-        Name = NULL;
-    }
+    Name.clear();
     Value.clear();
     if (Children.size() && OwnChildren)
         for (size_t i = 0; i < Children.size(); ++i)
@@ -713,7 +696,7 @@ void element_details::Element_Node::Init()
 //---------------------------------------------------------------------------
 int element_details::Element_Node::Print_Micro_Xml(std::ostringstream& ss, size_t level)
 {
-    if (IsCat || !Name)
+    if (IsCat || Is_Empty())
         goto print_children;
 
     if (Value.empty())
@@ -765,7 +748,7 @@ print_children:
     for (size_t i = 0; i < Children.size(); ++i)
         Children[i]->Print_Micro_Xml(ss, level);
 
-    if (!IsCat && Name)
+    if (!IsCat && !Is_Empty())
     {
         //end tag
         if (Value.empty())
@@ -784,7 +767,7 @@ int element_details::Element_Node::Print_Xml(std::ostringstream& ss, size_t leve
     std::string spaces;
     bool Modified = false;
 
-    if (IsCat || !Name)
+    if (IsCat || Is_Empty())
         goto print_children;
 
     spaces.resize(level, ' ');
@@ -841,7 +824,7 @@ print_children:
     for (size_t i = 0; i < Children.size(); ++i)
         Children[i]->Print_Xml(ss, level);
 
-    if (!IsCat && Name)
+    if (!IsCat && !Is_Empty())
     {
         //end tag
         if (Value.empty())
@@ -884,7 +867,7 @@ int element_details::Element_Node::Print_Tree(std::ostringstream& ss, size_t lev
 
     if (IsCat)
         return Print_Tree_Cat(ss, level);
-    else if (!Name)
+    else if (Is_Empty())
         goto print_children;
 
     ss << std::setfill('0') << std::setw(8) << std::hex << std::uppercase << Pos << std::nouppercase << std::dec;
@@ -898,7 +881,7 @@ int element_details::Element_Node::Print_Tree(std::ostringstream& ss, size_t lev
     if (!Value.empty())
     {
         ss << ":";
-        int nb_free = NB_SPACES - level - (Name ? 0 : strlen(Name)); // 40 - len(Name) - len(spaces)
+        int nb_free = NB_SPACES - level - (Is_Empty() ? 0 : Name.length()); // 40 - len(Name) - len(spaces)
         spaces.resize(nb_free > 0 ? nb_free : 1, ' ');
         Value.Set_Output_Format(Element_Node_Data::Format_Tree);
         ss << spaces << Value;
@@ -966,46 +949,6 @@ void element_details::Element_Node::Add_Child(Element_Node* node)
     Children.push_back(new_node);
 }
 
-//---------------------------------------------------------------------------
-void element_details::Element_Node::Set_Name(const char* Name_)
-{
-    delete[] Name;
-
-    if (!Name_)
-    {
-        Name = NULL;
-        return;
-    }
-
-    size_t len = strlen(Name_);
-    if (!len)
-    {
-        Name = NULL;
-        return;
-    }
-
-    len++;
-    Name = new char[len];
-    std::memcpy(Name, Name_, len);
-}
-
-//---------------------------------------------------------------------------
-void element_details::Element_Node::Set_Name(const string &Name_)
-{
-    delete[] Name;
-
-
-    size_t len = Name_.length();;
-    if (!len)
-    {
-        Name = NULL;
-        return;
-    }
-
-    Name = new char[len + 1];
-    std::memcpy(Name, Name_.c_str(), len);
-    Name[len] = '\0';
-}
 #endif
 
 }

--- a/Source/MediaInfo/File__Analyze_Element.h
+++ b/Source/MediaInfo/File__Analyze_Element.h
@@ -118,29 +118,16 @@ struct element_details
             data.set_Option(Option);
             data = parameter;
             if (_Measure)
-            {
-                size_t len = strlen(_Measure);
-                Measure = new char[len + 1];
-                std::memcpy(Measure, _Measure, len);
-                Measure[len] = '\0';
-            }
-            else
-                Measure = NULL;
-        }
-
-        ~Element_Node_Info()
-        {
-            delete[] Measure;
+                Measure = _Measure;
         }
 
         friend std::ostream& operator<<(std::ostream& os, element_details::Element_Node_Info* v);
 
         Element_Node_Data data;
-        char*             Measure;
-
-        Element_Node_Info& operator=(const Element_Node_Info&);
+        std::string       Measure;
 
     private:
+        Element_Node_Info& operator=(const Element_Node_Info&);
         Element_Node_Info(const Element_Node_Info&);
     };
 
@@ -180,7 +167,6 @@ struct element_details
         int  Print_Micro_Xml(std::ostringstream& ss, size_t level);                 //Print the node in micro XML into ss
         int  Print_Tree(std::ostringstream& ss, size_t level=1);                    //Print the node into ss
         int  Print_Tree_Cat(std::ostringstream& ss, size_t level=1);
-        Element_Node &operator =(const Element_Node &);
     };
 #endif //MEDIAINFO_TRACE
 

--- a/Source/MediaInfo/File__Analyze_Element.h
+++ b/Source/MediaInfo/File__Analyze_Element.h
@@ -157,7 +157,7 @@ struct element_details
         {
             Name = Name_;
         }
-        bool Is_Empty() const {return Name.empty();}
+        bool Name_Is_Empty() const {return Name.empty();}
 
         // Print
         int  Print(MediaInfo_Config::trace_Format Format, std::string& str);  //Print the node into str

--- a/Source/MediaInfo/File__Analyze_Element.h
+++ b/Source/MediaInfo/File__Analyze_Element.h
@@ -154,7 +154,7 @@ struct element_details
         int64u                           Pos;             // Position of the element in the file
         int64u                           Size;            // Size of the element (including header and sub-elements)
     private:
-        char*                            Name;            // Name planned for this element
+        std::string                      Name;            // Name planned for this element
     public:
         Element_Node_Data                Value;           // The value (currently used only with Trace XML)
         std::vector<Element_Node_Info*>  Infos;           // More info about the element
@@ -165,10 +165,12 @@ struct element_details
         bool                             IsCat;           // Node is a category
 
         void                             Init();          //Initialize with common values
-        void Add_Child(Element_Node* node);              //Add a subchild to the current node
-        void Set_Name(const char* Name_);
-        void Set_Name(const string &Name_);
-        const char* Get_Name() {return Name;}
+        void Add_Child(Element_Node* node);               //Add a subchild to the current node
+        void Set_Name(const string &Name_)
+        {
+            Name = Name_;
+        }
+        bool Is_Empty() const {return Name.empty();}
 
         // Print
         int  Print(MediaInfo_Config::trace_Format Format, std::string& str);  //Print the node into str

--- a/Source/MediaInfo/File__Analyze_Element.h
+++ b/Source/MediaInfo/File__Analyze_Element.h
@@ -178,6 +178,7 @@ struct element_details
         int  Print_Micro_Xml(std::ostringstream& ss, size_t level);                 //Print the node in micro XML into ss
         int  Print_Tree(std::ostringstream& ss, size_t level=1);                    //Print the node into ss
         int  Print_Tree_Cat(std::ostringstream& ss, size_t level=1);
+        Element_Node &operator =(const Element_Node &);
     };
 #endif //MEDIAINFO_TRACE
 

--- a/Source/MediaInfo/MediaInfo_Internal.h
+++ b/Source/MediaInfo/MediaInfo_Internal.h
@@ -130,6 +130,7 @@ private :
     //Helpers
     void CreateDummy (const String& Value); //Create dummy Information
     MediaInfo_Internal(const MediaInfo_Internal&); // Copy Constructor
+    MediaInfo_Internal &operator =(const MediaInfo_Internal &);
 
     //Open Buffer
     bool Info_IsMultipleParsing;

--- a/Source/MediaInfo/Multiple/File_DashMpd.cpp
+++ b/Source/MediaInfo/Multiple/File_DashMpd.cpp
@@ -155,6 +155,8 @@ struct template_generic
 
     template_generic(const template_generic &ToCopy)
     {
+        if (this == &ToCopy)
+            return;
         Sequence=new sequence;
         *Sequence=*ToCopy.Sequence;
         template_generic::BaseURL=ToCopy.BaseURL;
@@ -173,6 +175,8 @@ struct template_generic
     void Representation_Attributes_Parse    (XMLElement* Item);
 
     void Decode ();
+private:
+    template_generic &operator =(const template_generic &);
 };
 
 void template_generic::AdaptationSet_Attributes_Parse (XMLElement* Item)

--- a/Source/MediaInfo/Video/File_Avc.h
+++ b/Source/MediaInfo/Video/File_Avc.h
@@ -56,6 +56,7 @@ public :
 
 private :
     File_Avc(const File_Avc &File_Avc); //No copy
+    File_Avc &operator =(const File_Avc &);
 
     //Structures - seq_parameter_set
     struct seq_parameter_set_struct
@@ -84,17 +85,6 @@ private :
                         //initial_cpb_removal_delay_offset(initial_cpb_removal_delay_offset_)
                     {
                     }
-
-                    xxl_data &operator=(const xxl_data &x)
-                    {
-                        bit_rate_value=x.bit_rate_value;
-                        cpb_size_value=x.cpb_size_value;
-                        cbr_flag=x.cbr_flag;
-                        //initial_cpb_removal_delay=x.initial_cpb_removal_delay;
-                        //initial_cpb_removal_delay_offset=x.initial_cpb_removal_delay_offset;
-                        return *this;
-                    }
-
                 private:
                     xxl_data();
                 };
@@ -113,20 +103,9 @@ private :
                     time_offset_length(time_offset_length_)
                 {
                 }
-
-                xxl &operator=(const xxl &x)
-                {
-                    SchedSel=x.SchedSel;
-                    initial_cpb_removal_delay_length_minus1=x.initial_cpb_removal_delay_length_minus1;
-                    cpb_removal_delay_length_minus1=x.cpb_removal_delay_length_minus1;
-                    dpb_output_delay_length_minus1=x.dpb_output_delay_length_minus1;
-                    time_offset_length=x.time_offset_length;
-
-                    return *this;
-                }
-
             private:
                 xxl();
+                xxl &operator =(const xxl &);
             };
             struct bitstream_restriction_struct
             {
@@ -137,14 +116,6 @@ private :
                     max_num_reorder_frames(max_num_reorder_frames_)
                 {
                 }
-
-                bitstream_restriction_struct &operator=(const bitstream_restriction_struct &b)
-                {
-                    max_num_reorder_frames=b.max_num_reorder_frames;
-
-                    return *this;
-                }
-
             private:
                 bitstream_restriction_struct();
             };
@@ -201,6 +172,7 @@ private :
 
         private:
             vui_parameters_struct &operator=(const vui_parameters_struct &v);
+            vui_parameters_struct(const vui_parameters_struct &);
             vui_parameters_struct();
         };
         vui_parameters_struct* vui_parameters;
@@ -350,6 +322,7 @@ private :
 
     private:
         pic_parameter_set_struct &operator=(const pic_parameter_set_struct &v);
+        pic_parameter_set_struct(const pic_parameter_set_struct &);
         pic_parameter_set_struct();
     };
     typedef vector<pic_parameter_set_struct*> pic_parameter_set_structs;

--- a/Source/MediaInfo/Video/File_Avc.h
+++ b/Source/MediaInfo/Video/File_Avc.h
@@ -106,6 +106,7 @@ private :
             private:
                 xxl();
                 xxl &operator =(const xxl &);
+                xxl(const xxl &);
             };
             struct bitstream_restriction_struct
             {
@@ -269,6 +270,7 @@ private :
 
     private:
         seq_parameter_set_struct &operator=(const seq_parameter_set_struct &v);
+        seq_parameter_set_struct(const seq_parameter_set_struct &);
         seq_parameter_set_struct();
     };
     typedef vector<seq_parameter_set_struct*> seq_parameter_set_structs;

--- a/Source/MediaInfo/Video/File_Hevc.h
+++ b/Source/MediaInfo/Video/File_Hevc.h
@@ -112,15 +112,8 @@ private :
                     SchedSel(SchedSel_)
                 {
                 }
-
-                xxl &operator=(const xxl &x)
-                {
-                    SchedSel = x.SchedSel;
-
-                    return *this;
-                }
-
             private:
+                xxl &operator=(const xxl &x);
                 xxl();
             };
             struct xxl_common

--- a/Source/MediaInfo/Video/File_Hevc.h
+++ b/Source/MediaInfo/Video/File_Hevc.h
@@ -114,6 +114,7 @@ private :
                 }
             private:
                 xxl &operator=(const xxl &x);
+                xxl(const xxl &);
                 xxl();
             };
             struct xxl_common

--- a/Source/MediaInfo/Video/File_Hevc.h
+++ b/Source/MediaInfo/Video/File_Hevc.h
@@ -37,6 +37,8 @@ public :
 
 private :
     File_Hevc(const File_Hevc &File_Hevc); //No copy
+    File_Hevc &operator =(const File_Hevc &); //No copy
+
 
     //Structures - video_parameter_set
     struct video_parameter_set_struct
@@ -67,6 +69,7 @@ private :
 
     private:
         video_parameter_set_struct &operator=(const video_parameter_set_struct &v);
+        video_parameter_set_struct(const video_parameter_set_struct &a);
         video_parameter_set_struct();
     };
     typedef vector<video_parameter_set_struct*> video_parameter_set_structs;
@@ -97,16 +100,6 @@ private :
                         //initial_cpb_removal_delay(initial_cpb_removal_delay_),
                         //initial_cpb_removal_delay_offset(initial_cpb_removal_delay_offset_)
                     {
-                    }
-
-                    xxl_data &operator=(const xxl_data &x)
-                    {
-                        bit_rate_value = x.bit_rate_value;
-                        cpb_size_value = x.cpb_size_value;
-                        cbr_flag = x.cbr_flag;
-                        //initial_cpb_removal_delay=x.initial_cpb_removal_delay;
-                        //initial_cpb_removal_delay_offset=x.initial_cpb_removal_delay_offset;
-                        return *this;
                     }
 
                 private:
@@ -149,18 +142,6 @@ private :
                     au_cpb_removal_delay_length_minus1(au_cpb_removal_delay_length_minus1_),
                     dpb_output_delay_length_minus1(dpb_output_delay_length_minus1_)
                 {
-                }
-
-                xxl_common &operator=(const xxl_common &x)
-                {
-                    sub_pic_hrd_params_present_flag = x.sub_pic_hrd_params_present_flag;
-                    du_cpb_removal_delay_increment_length_minus1 = x.du_cpb_removal_delay_increment_length_minus1;
-                    dpb_output_delay_du_length_minus1 = x.dpb_output_delay_du_length_minus1;
-                    initial_cpb_removal_delay_length_minus1 = x.initial_cpb_removal_delay_length_minus1;
-                    au_cpb_removal_delay_length_minus1 = x.au_cpb_removal_delay_length_minus1;
-                    dpb_output_delay_length_minus1 = x.dpb_output_delay_length_minus1;
-
-                    return *this;
                 }
 
             private:
@@ -217,6 +198,7 @@ private :
 
         private:
             vui_parameters_struct &operator=(const vui_parameters_struct &v);
+            vui_parameters_struct(const vui_parameters_struct &);
             vui_parameters_struct();
         };
         vui_parameters_struct* vui_parameters;
@@ -290,6 +272,7 @@ private :
 
     private:
         seq_parameter_set_struct &operator=(const seq_parameter_set_struct &v);
+        seq_parameter_set_struct(const seq_parameter_set_struct &);
         seq_parameter_set_struct();
     };
     typedef vector<seq_parameter_set_struct*> seq_parameter_set_structs;
@@ -331,6 +314,7 @@ private :
 
     private:
         pic_parameter_set_struct &operator=(const pic_parameter_set_struct &v);
+        pic_parameter_set_struct(const pic_parameter_set_struct &a);
         pic_parameter_set_struct();
     };
     typedef vector<pic_parameter_set_struct*> pic_parameter_set_structs;


### PR DESCRIPTION
V690 The 'template_generic' class implements a copy constructor, but lacks the '=' operator. It is dangerous to use such a class. file_dashmpd.cpp 118
V690 The 'xxl_data' class implements the '=' operator, but lacks a copy constructor. It is dangerous to use such a class. file_avc.h 67
V690 The 'xxl' class implements the '=' operator, but lacks a copy constructor. It is dangerous to use such a class. file_avc.h 65
V690 The 'bitstream_restriction_struct' class implements the '=' operator, but lacks a copy constructor. It is dangerous to use such a class. file_avc.h 131
V690 The '=' operator is declared as private in the 'vui_parameters_struct' class, but the default copy constructor will still be generated by compiler. It is dangerous to use such a class. file_avc.h 63
V690 The '=' operator is declared as private in the 'seq_parameter_set_struct' class, but the default copy constructor will still be generated by compiler. It is dangerous to use such a class. file_avc.h 61
V690 The '=' operator is declared as private in the 'pic_parameter_set_struct' class, but the default copy constructor will still be generated by compiler. It is dangerous to use such a class. file_avc.h 305
V690 Copy constructor is declared as private in the 'File_Avc' class, but the default '=' operator will still be generated by compiler. It is dangerous to use such a class. file_avc.h 25
V690 The '=' operator is declared as private in the 'video_parameter_set_struct' class, but the default copy constructor will still be generated by compiler. It is dangerous to use such a class. file_hevc.h 42
V690 The 'xxl_data' class implements the '=' operator, but lacks a copy constructor. It is dangerous to use such a class. file_hevc.h 81
V690 The 'xxl' class implements the '=' operator, but lacks a copy constructor. It is dangerous to use such a class. file_hevc.h 79
V690 The 'xxl_common' class implements the '=' operator, but lacks a copy constructor. It is dangerous to use such a class. file_hevc.h 133
V690 The '=' operator is declared as private in the 'vui_parameters_struct' class, but the default copy constructor will still be generated by compiler. It is dangerous to use such a class. file_hevc.h 77
V690 The '=' operator is declared as private in the 'seq_parameter_set_struct' class, but the default copy constructor will still be generated by compiler. It is dangerous to use such a class. file_hevc.h 75
V690 The '=' operator is declared as private in the 'pic_parameter_set_struct' class, but the default copy constructor will still be generated by compiler. It is dangerous to use such a class. file_hevc.h 298
V690 Copy constructor is declared as private in the 'File_Hevc' class, but the default '=' operator will still be generated by compiler. It is dangerous to use such a class. file_hevc.h 23

TODO - fix copy-paste struct xxl_data