### PR TITLE
Fix Base64::encode

### DIFF
--- a/Source/ThirdParty/base64/base64.h
+++ b/Source/ThirdParty/base64/base64.h
@@ -29,10 +29,17 @@ namespace Base64 {
     @return Base64 encoded string
 */
 inline std::string Base64::encode(const std::string &sString) {
-  static const char* sBase64Table =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-  static const char cFillChar = '=';
-  std::string::size_type   nLength = sString.length();
+   static const char sBase64Table[64] =
+    { 'A','B','C','D','E','F','G','H',
+        'I','J','K','L','M','N','O','P',
+        'Q','R','S','T','U','V','W','X',
+        'Y','Z','a','b','c','d','e','f',
+        'g','h','i','j','k','l','m','n',
+        'o','p','q','r','s','t','u','v',
+        'w','x','y','z','0','1','2','3',
+        '4','5','6','7','8','9','+','/' };
+  const char cFillChar = '=';
+  const std::string::size_type   nLength = sString.length();
   std::string              sResult;
 
   // Allocate memory for the converted string

--- a/Source/ThirdParty/base64/base64.h
+++ b/Source/ThirdParty/base64/base64.h
@@ -29,11 +29,8 @@ namespace Base64 {
     @return Base64 encoded string
 */
 inline std::string Base64::encode(const std::string &sString) {
-  static const std::string sBase64Table(
-  // 0000000000111111111122222222223333333333444444444455555555556666
-  // 0123456789012345678901234567890123456789012345678901234567890123
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-  );
+  static const char* sBase64Table =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
   static const char cFillChar = '=';
   std::string::size_type   nLength = sString.length();
   std::string              sResult;


### PR DESCRIPTION
    * Remove dynamic allocation for sBase64Table (optimisation)
    * TODO - remove inline for Base64::encode / Base64::decode ?
    * Magic fix crash Win XP SP3 + Visual Basic + MediaInfoNET.dll + MediaInfo.DLL https://sourceforge.net/p/mediainfo/bugs/990/

Crash - stack :
     ntdll.dll!ExecuteHandler@20()    Unknown
     ntdll.dll!_KiUserExceptionDispatcher@8()    Unknown
>    MediaInfo.DLL!Base64::encode(const std::basic_string<char,std::char_traits<char>,std::allocator<char> > & sString) Line 32    C++
     MediaInfo.DLL!MediaInfoLib::File_Mk::Segment_Attachments_AttachedFile_FileData() Line 1761    C++
     MediaInfo.DLL!MediaInfoLib::File_Mk::Data_Parse() Line 1257    C++
     MediaInfo.DLL!MediaInfoLib::File__Analyze::Data_Manage() Line 2356    C++
     MediaInfo.DLL!MediaInfoLib::File__Analyze::Buffer_Parse() Line 1516    C++
     MediaInfo.DLL!MediaInfoLib::File__Analyze::Open_Buffer_Continue_Loop() Line 1091    C++
     MediaInfo.DLL!MediaInfoLib::File__Analyze::Open_Buffer_Continue(const unsigned char * ToAdd, unsigned int ToAdd_Size) Line 675    C++
     MediaInfo.DLL!MediaInfoLib::MediaInfo_Internal::Open_Buffer_Continue(const unsigned char * ToAdd, unsigned int ToAdd_Size) Line 827    C++
     MediaInfo.DLL!MediaInfoLib::Reader_File::Format_Test_PerParser_Continue(MediaInfoLib::MediaInfo_Internal * MI) Line 694    C++
     MediaInfo.DLL!MediaInfoLib::Reader_File::Format_Test_PerParser(MediaInfoLib::MediaInfo_Internal * MI, const std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> > & File_Name) Line 293    C++
     MediaInfo.DLL!MediaInfoLib::Reader_File::Format_Test(MediaInfoLib::MediaInfo_Internal * MI, std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> > File_Name) Line 207    C++
     MediaInfo.DLL!MediaInfoLib::MediaInfo_Internal::Entry() Line 626    C++
     MediaInfo.DLL!MediaInfoLib::MediaInfo_Internal::Open(const std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> > & File_Name_) Line 381    C++
     MediaInfo.DLL!MediaInfoLib::MediaInfo::Open(const std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> > & File_Name_) Line 89    C++
     MediaInfo.DLL!MediaInfo_Open(void * Handle, const wchar_t * File) Line 637    C++
     [Managed to Native Transition]
     MediaInfoNET.dll!MediaInfoNET.MediaInfo.Open(String FileName) Line 83    Basic
     MediaInfoNET.dll!MediaInfoNET.MediaFile.GetMediaInfo(Boolean AppendInfo) Line 83    Basic
     MediaInfoNET.dll!MediaInfoNET.MediaFile.New(String SourceFile) Line 62    Basic