### PR TITLE
IMF and PTX: more languages detected from file names

### DIFF
--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -11,6 +11,7 @@ https://sourceforge.net/p/mediainfo/_list/tickets
 Version 0.7.91
 --------------
 + IMF and PTX: more languages detected from file names (but the full list of common languages tags still need to be added)
++ IMF and PTX: support of non-standard but common "LAS" = "Spanish (Latin America)" language code
 + MXF: Support of color primaries, transfer characteristic, coding equations defined in SMPTE ST 2067-21:2016 e.g. xvYCC or BT.2020
 x PTX: fix crash due to bad parsing of some file names while looking for track language
 

--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -10,7 +10,9 @@ https://sourceforge.net/p/mediainfo/_list/tickets
 
 Version 0.7.91
 --------------
++ IMF and PTX: more languages detected from file names (but the full list of common languages tags still need to be added)
 + MXF: Support of color primaries, transfer characteristic, coding equations defined in SMPTE ST 2067-21:2016 e.g. xvYCC or BT.2020
+x PTX: fix crash due to bad parsing of some file names while looking for track language
 
 Version 0.7.90, 2016-10-31
 --------------

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -750,7 +750,14 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Paramete
                 {
                     if (Languages[Pos].size()>=1)
                     {
-                        Ztring Language_Translated=MediaInfoLib::Config.Language_Get(__T("Language_")+Languages[Pos][0]);
+                        Ztring Language_Translated;
+                        if (Languages[Pos].size()==2)
+                            Language_Translated=MediaInfoLib::Config.Language_Get(__T("Language_")+Languages[Pos].Read()); //Testing in case the langauge file has the complex form
+                        if (Language_Translated.find(__T("Language_"))==0)
+                            Language_Translated.clear(); //No translation found
+                        if (Language_Translated.empty())
+                        {
+                        Language_Translated=MediaInfoLib::Config.Language_Get(__T("Language_")+Languages[Pos][0]);
                         if (Language_Translated.find(__T("Language_"))==0)
                             Language_Translated=Languages[Pos][0]; //No translation found
                         if (Languages[Pos].size()>=2)
@@ -767,6 +774,7 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Paramete
                                     Language_Translated+=__T('-'); //As the original string
                                     Language_Translated+=Languages[Pos][Pos2];
                                 }
+                        }
                         }
                         Language1.push_back(Language_Translated);
                         if (Languages[Pos][0].size()==2)

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -701,6 +701,7 @@ void MediaInfo_Config_DefaultLanguage (Translation &Info)
     "Language_en-us;English (United States)\n"
     "Language_eo;Esperanto\n"
     "Language_es;Spanish\n"
+    "Language_es-419;Spanish (Latin America)\n"
     "Language_et;Estonian\n"
     "Language_eu;Basque\n"
     "Language_fa;Persian\n"

--- a/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
+++ b/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
@@ -115,6 +115,7 @@ void File__ReferenceFilesHelper_InfoFromFileName (sequences &Sequences)
     ZtringListList List;
     vector<size_t> Iterators;
 
+    size_t ItemsValid=0;
     for (size_t Sequences_Pos=0; Sequences_Pos<Sequences.size(); Sequences_Pos++)
     {
         ZtringList List2;
@@ -139,10 +140,13 @@ void File__ReferenceFilesHelper_InfoFromFileName (sequences &Sequences)
                 List2[Pos].MakeLowerCase();
             List.push_back(List2);
             Iterators.push_back(Sequences_Pos);
+            ItemsValid++;
         }
+        else
+            List.push_back(Ztring());
     }
 
-    if (List.size()<2)
+    if (ItemsValid<2)
         return;
 
     for (size_t Pos2=0; Pos2<List.size(); Pos2++)
@@ -184,8 +188,10 @@ void File__ReferenceFilesHelper_InfoFromFileName (sequences &Sequences)
              || Test==__T("eng")
              || Test==__T("fra")
              || Test==__T("fre")
+             || Test==__T("ger")
              || Test==__T("ita")
              || Test==__T("jpn")
+             || Test==__T("las") //Latin America Spanish
              || Test==__T("rus")
              || Test==__T("spa")))
             {
@@ -279,7 +285,7 @@ void File__ReferenceFilesHelper_InfoFromFileName (sequences &Sequences)
                 Ztring Language;
                 if (List[Pos2][List[Pos2].size()-1-Language_Pos]==__T("ara"))
                     Language=__T("ar");
-                else if (List[Pos2][List[Pos2].size()-1-Language_Pos]==__T("deu"))
+                else if (List[Pos2][List[Pos2].size()-1-Language_Pos]==__T("deu") || List[Pos2][List[Pos2].size()-1-Language_Pos]==__T("ger"))
                     Language=__T("de");
                 else if (List[Pos2][List[Pos2].size()-1-Language_Pos]==__T("eng"))
                     Language=__T("en");
@@ -289,13 +295,14 @@ void File__ReferenceFilesHelper_InfoFromFileName (sequences &Sequences)
                     Language=__T("it");
                 else if (List[Pos2][List[Pos2].size()-1-Language_Pos]==__T("jpn"))
                     Language=__T("ja");
+                else if (List[Pos2][List[Pos2].size()-1-Language_Pos]==__T("las")) //Latin America Spanish
+                    Language=__T("es-419");
                 else if (List[Pos2][List[Pos2].size()-1-Language_Pos]==__T("rus"))
                     Language=__T("ru");
                 else if (List[Pos2][List[Pos2].size()-1-Language_Pos]==__T("spa"))
                     Language=__T("es");
 
-                if (!Language.empty())
-                    Sequences[Pos2]->Infos["Language"]=Language;
+                Sequences[Pos2]->Infos["Language"]=Language.empty()?List[Pos2][List[Pos2].size()-1-Language_Pos]:Language;
             }
     }
 }

--- a/Source/Resource/Text/Language/DefaultLanguage.csv
+++ b/Source/Resource/Text/Language/DefaultLanguage.csv
@@ -672,6 +672,7 @@ Language_en-gb;English (Great Britain)
 Language_en-us;English (United States)
 Language_eo;Esperanto
 Language_es;Spanish
+Language_es-419;Spanish (Latin America)
 Language_et;Estonian
 Language_eu;Basque
 Language_fa;Persian


### PR DESCRIPTION
IMF and PTX: more languages detected from file names (but the full list of common languages tags still need to be added)