### PR TITLE
VBI

### DIFF
--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -13,6 +13,7 @@ Version 0.7.92
 + MP4: more AppleStoreCountry values mapped to countries, show the country number if unknown
 + File extension: test if the file extension correspond to the container format
 x MIXML output: some *_Original values were missing
+x MXF/Teletext: was not correctly detecting non subtitle streams
 
 Version 0.7.91, 2016-11-30
 --------------

--- a/Project/BCB/Library/MediaInfoLib.cbproj
+++ b/Project/BCB/Library/MediaInfoLib.cbproj
@@ -544,6 +544,9 @@
 			<CppCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Umf.cpp">
 				<BuildOrder>180</BuildOrder>
 			</CppCompile>
+			<CppCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Vbi.cpp">
+				<BuildOrder>222</BuildOrder>
+			</CppCompile>
 			<CppCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Wm.cpp">
 				<BuildOrder>0</BuildOrder>
 			</CppCompile>

--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -266,6 +266,7 @@ set(MediaInfoLib_SRCS
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Skm.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Swf.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Umf.cpp
+  ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Vbi.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Wm.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Wm_Elements.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Xdcam_Clip.cpp

--- a/Project/GNU/Library/Makefile.am
+++ b/Project/GNU/Library/Makefile.am
@@ -154,6 +154,7 @@ lib@MediaInfoLib_LibName@_la_SOURCES = \
                        ../../../Source/MediaInfo/Multiple/File_Skm.cpp \
                        ../../../Source/MediaInfo/Multiple/File_Swf.cpp \
                        ../../../Source/MediaInfo/Multiple/File_Umf.cpp \
+                       ../../../Source/MediaInfo/Multiple/File_Vbi.cpp \
                        ../../../Source/MediaInfo/Multiple/File_Wm.cpp \
                        ../../../Source/MediaInfo/Multiple/File_Wm_Elements.cpp \
                        ../../../Source/MediaInfo/Multiple/File_Xdcam_Clip.cpp \

--- a/Project/MSVC2013/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2013/Library/MediaInfoLib.vcxproj
@@ -223,6 +223,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Pmp.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Ptx.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_SequenceInfo.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Vbi.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Xdcam_Clip.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File__ReferenceFilesHelper.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File__ReferenceFilesHelper_Resource.cpp" />
@@ -468,6 +469,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Pmp.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Ptx.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_SequenceInfo.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Vbi.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Xdcam_Clip.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File__ReferenceFilesHelper.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File__ReferenceFilesHelper_Common.h" />

--- a/Project/MSVC2013/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2013/Library/MediaInfoLib.vcxproj.filters
@@ -761,6 +761,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\File__Analyze_Element.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Vbi.cpp">
+      <Filter>Source Files\Multiple</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyse_Automatic.h">
@@ -1428,6 +1431,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyze_Element.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Vbi.h">
+      <Filter>Header Files\Multiple</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Project/MSVC2015/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2015/Library/MediaInfoLib.vcxproj
@@ -227,6 +227,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Pmp.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Ptx.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_SequenceInfo.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Vbi.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Xdcam_Clip.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File__ReferenceFilesHelper.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File__ReferenceFilesHelper_Resource.cpp" />
@@ -472,6 +473,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Pmp.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Ptx.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_SequenceInfo.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Vbi.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Xdcam_Clip.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File__ReferenceFilesHelper.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File__ReferenceFilesHelper_Common.h" />

--- a/Project/MSVC2015/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2015/Library/MediaInfoLib.vcxproj.filters
@@ -761,6 +761,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\File__Analyze_Element.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Vbi.cpp">
+      <Filter>Source Files\Multiple</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyse_Automatic.h">
@@ -1428,6 +1431,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyze_Element.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Vbi.h">
+      <Filter>Header Files\Multiple</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Project/Qt/MediaInfoLib.pro
+++ b/Project/Qt/MediaInfoLib.pro
@@ -184,6 +184,7 @@ HEADERS += \
         ../../Source/MediaInfo/Multiple/File_Skm.h \
         ../../Source/MediaInfo/Multiple/File_Swf.h \
         ../../Source/MediaInfo/Multiple/File_Umf.h \
+        ../../Source/MediaInfo/Multiple/File_Vbi.h \
         ../../Source/MediaInfo/Multiple/File_Wm.h \
         ../../Source/MediaInfo/Multiple/File_Xdcam_Clip.h \
         ../../Source/MediaInfo/PreComp.h \
@@ -398,6 +399,7 @@ SOURCES += \
         ../../Source/MediaInfo/Multiple/File_Skm.cpp \
         ../../Source/MediaInfo/Multiple/File_Swf.cpp \
         ../../Source/MediaInfo/Multiple/File_Umf.cpp \
+        ../../Source/MediaInfo/Multiple/File_Vbi.cpp \
         ../../Source/MediaInfo/Multiple/File_Wm.cpp \
         ../../Source/MediaInfo/Multiple/File_Wm_Elements.cpp \
         ../../Source/MediaInfo/Multiple/File_Xdcam_Clip.cpp \

--- a/Source/MediaInfo/Multiple/File_Ancillary.cpp
+++ b/Source/MediaInfo/Multiple/File_Ancillary.cpp
@@ -317,14 +317,14 @@ void File_Ancillary::Streams_Finish()
     #if defined(MEDIAINFO_SDP_YES)
         if (Sdp_Parser && !Sdp_Parser->Status[IsFinished] && Sdp_Parser->Status[IsAccepted])
         {
-            size_t StreamPos_Base=Count_Get(Stream_Text);
             Finish(Sdp_Parser);
-            for (size_t StreamPos=0; StreamPos<Sdp_Parser->Count_Get(Stream_Text); StreamPos++)
-            {
-                Merge(*Sdp_Parser, Stream_Text, StreamPos, StreamPos_Base+StreamPos);
-                Ztring MuxingMode=Sdp_Parser->Retrieve(Stream_General, 0, General_Format);
-                Fill(Stream_Text, StreamPos_Last, "MuxingMode", __T("Ancillary data / OP-47 / ")+MuxingMode, true);
-            }
+            Ztring MuxingMode=Sdp_Parser->Retrieve(Stream_General, 0, General_Format);
+            for (size_t StreamKind=Stream_General+1; StreamKind<Stream_Max; StreamKind++)
+                for (size_t StreamPos=0; StreamPos<Sdp_Parser->Count_Get((stream_t)StreamKind); StreamPos++)
+                {
+                    Merge(*Sdp_Parser, (stream_t)StreamKind, StreamPos, StreamPos);
+                    Fill((stream_t)StreamKind, StreamPos_Last, "MuxingMode", __T("Ancillary data / OP-47 / ")+MuxingMode, true);
+                }
         }
     #endif //defined(MEDIAINFO_SDP_YES)
 

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -28,6 +28,9 @@
 #if defined(MEDIAINFO_DVDIF_YES)
     #include "MediaInfo/Multiple/File_DvDif.h"
 #endif
+#if defined(MEDIAINFO_VBI_YES)
+    #include "MediaInfo/Multiple/File_Vbi.h"
+#endif
 #if defined(MEDIAINFO_AVC_YES)
     #include "MediaInfo/Video/File_Avc.h"
 #endif
@@ -16214,7 +16217,12 @@ void File_Mxf::ChooseParser__Aaf_GC_Data(const essences::iterator &Essence, cons
     switch (Code_Compare4_3)
     {
         case 0x01 : //VBI, SMPTE ST 436
-                    Essence->second.Parsers.push_back(new File__Analyze());
+                    #if defined(MEDIAINFO_VBI_YES)
+                        MayHaveCaptionsInStream=true;
+                        Essence->second.Parsers.push_back(new File_Vbi());
+                    #else
+                        Essence->second.Parsers.push_back(new File__Analyze());
+                    #endif //defined(MEDIAINFO_VBI_YES)
                     break;
         case 0x02 : //Ancillary
                     #if defined(MEDIAINFO_ANCILLARY_YES)

--- a/Source/MediaInfo/Multiple/File_Vbi.cpp
+++ b/Source/MediaInfo/Multiple/File_Vbi.cpp
@@ -1,0 +1,116 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//---------------------------------------------------------------------------
+// Pre-compilation
+#include "MediaInfo/PreComp.h"
+#ifdef __BORLANDC__
+    #pragma hdrstop
+#endif
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/Setup.h"
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#if defined(MEDIAINFO_VBI_YES)
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/Multiple/File_Vbi.h"
+#if defined(MEDIAINFO_TELETEXT_YES)
+    #include "MediaInfo/Text/File_Teletext.h"
+#endif
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+namespace MediaInfoLib
+{
+//---------------------------------------------------------------------------
+
+//***************************************************************************
+// Constructor/Destructor
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+File_Vbi::File_Vbi()
+:File__Analyze()
+{
+    //Configuration
+    ParserName="Vbi";
+    PTS_DTS_Needed=true;
+
+    #if defined(MEDIAINFO_TELETEXT_YES)
+        Teletext_Parser=NULL;
+    #endif //defined(MEDIAINFO_TELETEXT_YES)
+}
+
+//---------------------------------------------------------------------------
+File_Vbi::~File_Vbi()
+{
+    #if defined(MEDIAINFO_TELETEXT_YES)
+        if (Teletext_Parser)
+            delete Teletext_Parser;
+    #endif //defined(MEDIAINFO_TELETEXT_YES)
+}
+
+//---------------------------------------------------------------------------
+void File_Vbi::Streams_Finish()
+{
+    #if defined(MEDIAINFO_TELETEXT_YES)
+        if (Teletext_Parser && !Teletext_Parser->Status[IsFinished] && Teletext_Parser->Status[IsAccepted])
+        {
+            Finish(Teletext_Parser);
+            for (size_t StreamKind=Stream_General+1; StreamKind<Stream_Max; StreamKind++)
+                for (size_t StreamPos=0; StreamPos<Teletext_Parser->Count_Get((stream_t)StreamKind); StreamPos++)
+                {
+                    Merge(*Teletext_Parser, (stream_t)StreamKind, StreamPos, StreamPos);
+                    Fill((stream_t)StreamKind, StreamPos, "MuxingMode", "VBI", Unlimited, true);
+                }
+        }
+    #endif //defined(MEDIAINFO_TELETEXT_YES)
+}
+
+//***************************************************************************
+// Buffer - Global
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+void File_Vbi::Read_Buffer_Continue()
+{
+    if (!Status[IsAccepted])
+        Accept(); //No way to detect non-VBI content
+
+    Buffer_Offset=Buffer_Size; //This is per frame
+
+    Frame_Count++;
+    Frame_Count_InThisBlock++;
+    if (Frame_Count_NotParsedIncluded!=(int64u)-1)
+        Frame_Count_NotParsedIncluded++;
+}
+
+//---------------------------------------------------------------------------
+void File_Vbi::Read_Buffer_Unsynched()
+{
+    #if defined(MEDIAINFO_TELETEXT_YES)
+       if (Teletext_Parser)
+            Teletext_Parser->Open_Buffer_Unsynch();
+    #endif //defined(MEDIAINFO_TELETEXT_YES)
+}
+
+//***************************************************************************
+// Helpers
+//***************************************************************************
+
+//***************************************************************************
+// C++
+//***************************************************************************
+
+} //NameSpace
+
+#endif //MEDIAINFO_VBI_YES
+

--- a/Source/MediaInfo/Multiple/File_Vbi.h
+++ b/Source/MediaInfo/Multiple/File_Vbi.h
@@ -1,0 +1,54 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+//
+// Information about VBI data (SMPTE ST436M),Teletext (ETSI EN300 706)
+//
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+//---------------------------------------------------------------------------
+#ifndef MediaInfo_VbiH
+#define MediaInfo_VbiH
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/File__Analyze.h"
+#include <vector>
+//---------------------------------------------------------------------------
+
+namespace MediaInfoLib
+{
+
+//***************************************************************************
+// Class File_Vbi
+//***************************************************************************
+
+class File_Vbi : public File__Analyze
+{
+public :
+
+    #if defined(MEDIAINFO_TELETEXT_YES)
+		File__Analyze*  Teletext_Parser;
+    #endif //defined(MEDIAINFO_TELETEXT_YES)
+	
+    //Constructor/Destructor
+	File_Vbi();
+	~File_Vbi();
+
+private :
+    //Streams management
+    void Streams_Finish();
+
+    //Buffer - Global
+    void Read_Buffer_Continue();
+    void Read_Buffer_Unsynched();
+};
+
+} //NameSpace
+
+#endif
+

--- a/Source/MediaInfo/Setup.h
+++ b/Source/MediaInfo/Setup.h
@@ -537,6 +537,9 @@
 #if !defined(MEDIAINFO_MULTI_NO) && !defined(MEDIAINFO_UMF_NO) && !defined(MEDIAINFO_UMF_YES)
     #define MEDIAINFO_UMF_YES
 #endif
+#if !defined(MEDIAINFO_MULTI_NO) && !defined(MEDIAINFO_VBI_NO) && !defined(MEDIAINFO_VBI_YES)
+    #define MEDIAINFO_VBI_YES
+#endif
 #if !defined(MEDIAINFO_MULTI_NO) && !defined(MEDIAINFO_WM_NO) && !defined(MEDIAINFO_WM_YES)
     #define MEDIAINFO_WM_YES
 #endif

--- a/Source/MediaInfo/Text/File_Sdp.cpp
+++ b/Source/MediaInfo/Text/File_Sdp.cpp
@@ -72,13 +72,13 @@ void File_Sdp::Streams_Finish()
     {
         if (Stream->second.Parser)
         {
-            size_t Current=Count_Get(Stream_Text);
             Finish(Stream->second.Parser);
-            Merge(*Stream->second.Parser);
-            //Fill(Stream_Text, StreamPos_Last, Text_ID, Ztring::ToZtring((Stream->first&0x80)?2:1)+__T('-')+Ztring::ToZtring(Stream->first&0x1F)+__T("-")+Stream->second.Parser->Get(Stream_Text, 0, Text_ID), true);
-            size_t Count=Count_Get(Stream_Text)-Current;
-            for (size_t Pos=0; Pos<Count; Pos++)
-                Fill(Stream_Text, Current+Pos, Text_ID, Stream->second.Parser->Get(Stream_Text, Pos, Text_ID), true);
+            for (size_t StreamKind=Stream_General+1; StreamKind<Stream_Max; StreamKind++)
+                for (size_t StreamPos=0; StreamPos<Stream->second.Parser->Count_Get((stream_t)StreamKind); StreamPos++)
+                {
+                    Merge(*Stream->second.Parser, (stream_t)StreamKind, StreamPos, StreamPos);
+                    Fill((stream_t)StreamKind, StreamPos, General_ID, Stream->second.Parser->Get((stream_t)StreamKind, StreamPos, General_ID), true);
+                }
         }
     }
 }
@@ -232,7 +232,6 @@ void File_Sdp::Data_Parse()
             if (Stream.Parser==NULL)
             {
                 Stream.Parser=new File_Teletext();
-                Stream.Parser->IsSubtitle=true;
                 Open_Buffer_Init(Stream.Parser);
             }
             if (Stream.Parser->PTS_DTS_Needed)

--- a/Source/MediaInfo/Text/File_Teletext.h
+++ b/Source/MediaInfo/Text/File_Teletext.h
@@ -38,7 +38,6 @@ public :
     #if defined(MEDIAINFO_MPEGPS_YES)
         bool FromMpegPs;
     #endif
-    bool IsSubtitle;
 
 private :
     //Streams management
@@ -66,12 +65,14 @@ private :
     struct stream
     {
         vector<std::wstring> CC_Displayed_Values;
+        bool IsSubtitle;
 
         stream()
         {
             CC_Displayed_Values.resize(26);
             for (size_t PosY=0; PosY<26; ++PosY)
                 CC_Displayed_Values[PosY].resize(40, L' ');
+            IsSubtitle=false;
         }
 
         void Clear()


### PR DESCRIPTION
Template for support of VBI in MXF

Note: there is some basic template for Teletext support but the analog to digital algorithm is not present.
Was tested with a (non open source) Teletext analog to digital algorithm.