### PR TITLE
PVS Studio fix

### DIFF
--- a/Source/MediaInfo/File__Analyze_Element.cpp
+++ b/Source/MediaInfo/File__Analyze_Element.cpp
@@ -433,7 +433,10 @@ static void Xml_Content_Escape(const char* Content, size_t Size, std::string& To
     if (Size)
         ToReturn = std::string(Content, Size);
     else
-        ToReturn = std::string();
+    {
+        ToReturn.clear();
+        return;
+    }
 
     for (; Pos<Size; Pos++)
     {

--- a/Source/MediaInfo/MediaInfoList_Internal.cpp
+++ b/Source/MediaInfo/MediaInfoList_Internal.cpp
@@ -553,8 +553,8 @@ String MediaInfoList_Internal::Option (const String &Option, const String &Value
 {
     CriticalSectionLocker CSL(CS);
     Ztring OptionLower=Option; OptionLower.MakeLowerCase();
-         if (Option==__T(""))
-        return __T("");
+         if (Option.empty())
+        return Option;
     else if (OptionLower==__T("manguage_update"))
     {
         //Special case : Language_Update must update all MediaInfo classes

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -1876,12 +1876,12 @@ struct Mpeg4_muxing
 };
 struct stream_temp
 {
+    int64u stsc_SampleSizeOffset;
+    int64u stts_Current;
     size_t stco_Pos; //Chunk Offset
     size_t stsc_Pos; //Sample to Chunk
     size_t stsc_SampleNumber;
-    int64u stsc_SampleSizeOffset;
     size_t stts_Durations_Pos; //Time to Sample
-    int64u stts_Current;
     size_t stsz_Pos;
 
     stream_temp()

--- a/Source/MediaInfo/Multiple/File_Mxf.h
+++ b/Source/MediaInfo/Multiple/File_Mxf.h
@@ -548,8 +548,8 @@ protected :
     //TimeCode
     struct mxftimecode
     {
-        int16u  RoundedTimecodeBase;
         int64u  StartTimecode;
+        int16u  RoundedTimecodeBase;
         bool    DropFrame;
 
         mxftimecode(int16u RoundedTimecodeBase_ = 0, int64u StartTimecode_ = (int64u)-1, bool DropFrame_ = false)


### PR DESCRIPTION
V815 Decreased performance. Consider replacing the expression 'ToReturn = std::string()' with 'ToReturn.clear()'. file__analyze_element.cpp 436
V815 Decreased performance. Consider replacing the expression 'Option == L""' with 'Option.empty()'. mediainfolist_internal.cpp 556
V802 On 32-bit platform, structure size can be reduced from 24 to 16 bytes by rearranging the fields according to their sizes in decreasing order. file_mxf.h 550
V802 On 32-bit platform, structure size can be reduced from 48 to 40 bytes by rearranging the fields according to their sizes in decreasing order. file_mpeg4.cpp 1878