### PR TITLE
 AVI/WAV: test of truncated file

### DIFF
--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -13,6 +13,7 @@ Version 0.7.92
 + MXF and MPEG video streams: detection of HLG Transfer Characteristic
 + MP4: more AppleStoreCountry values mapped to countries, show the country number if unknown
 + File extension: test if the file extension correspond to the container format
++ AVI/WAV: test of truncated file
 x MIXML output: some *_Original values were missing
 x MXF/Teletext: was not correctly detecting non subtitle streams
 

--- a/Source/MediaInfo/Multiple/File_Riff.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff.cpp
@@ -914,7 +914,11 @@ void File_Riff::Header_Parse()
         Size_Complete=0; //Hack in some indexes with Size==0 (why?), ignoring content of header
     }
     if (File_Offset+Buffer_Offset+8+Size_Complete>File_Size)
+    {
         Size_Complete=File_Size-(File_Offset+Buffer_Offset+8);
+        if (Element_Level<=2) //Incoherencies info only at the top level chunk
+            Fill(Stream_General, 0, "IsTruncated", "Yes");
+    }
 
     //Alignment
     if (Size_Complete%2 && !IsNotWordAligned)


### PR DESCRIPTION
Responding to https://twitter.com/bitsgalore/status/816718028683546624
http://openpreservation.org/blog/2017/01/04/breaking-waves-and-some-flacs/
About the WAV truncate detection.

Check the new "IsTruncated: Yes" line:

General
Complete name                            : C:\Users\jerome\Downloads\frogs-01.wav
Format                                   : Wave
File size                                : 1.96 MiB
Duration                                 : 11 s 626 ms
Overall bit rate mode                    : Constant
Overall bit rate                         : 1 411 kb/s
Track name                               : untitled
Writing application                      : Lavf57.56.100

Audio
Format                                   : PCM
Format settings, Endianness              : Little
Format settings, Sign                    : Signed
Codec ID                                 : 1
Duration                                 : 11 s 626 ms
Bit rate mode                            : Constant
Bit rate                                 : 1 411.2 kb/s
Channel(s)                               : 2 channels
Sampling rate                            : 44.1 kHz
Bit depth                                : 16 bits
Stream size                              : 1.96 MiB (100%)

General
Complete name                            : C:\Users\jerome\Downloads\frogs-01-byte-missing-at-offset-811537.wav
Format                                   : Wave
File size                                : 1.96 MiB
Duration                                 : 11 s 626 ms
Overall bit rate mode                    : Constant
Overall bit rate                         : 1 411 kb/s
Track name                               : untitled
Writing application                      : Lavf57.56.100
IsTruncated                              : Yes

Audio
Format                                   : PCM
Format settings, Endianness              : Little
Format settings, Sign                    : Signed
Codec ID                                 : 1
Duration                                 : 11 s 626 ms
Bit rate mode                            : Constant
Bit rate                                 : 1 411.2 kb/s
Channel(s)                               : 2 channels
Sampling rate                            : 44.1 kHz
Bit depth                                : 16 bits
Stream size                              : 1.96 MiB (100%)

General
Complete name                            : C:\Users\jerome\Downloads\frogs-01-last-2032-bytes-missing.wav
Format                                   : Wave
File size                                : 1.95 MiB
Duration                                 : 11 s 615 ms
Overall bit rate mode                    : Constant
Overall bit rate                         : 1 411 kb/s
Track name                               : untitled
Writing application                      : Lavf57.56.100
IsTruncated                              : Yes

Audio
Format                                   : PCM
Format settings, Endianness              : Little
Format settings, Sign                    : Signed
Codec ID                                 : 1
Duration                                 : 11 s 615 ms
Bit rate mode                            : Constant
Bit rate                                 : 1 411.2 kb/s
Channel(s)                               : 2 channels
Sampling rate                            : 44.1 kHz
Bit depth                                : 16 bits
Stream size                              : 1.95 MiB (100%)

General
Complete name                            : C:\Users\jerome\Downloads\frogs-01-last-byte-missing.wav
Format                                   : Wave
File size                                : 1.96 MiB
Duration                                 : 11 s 626 ms
Overall bit rate mode                    : Constant
Overall bit rate                         : 1 411 kb/s
Track name                               : untitled
Writing application                      : Lavf57.56.100
IsTruncated                              : Yes

Audio
Format                                   : PCM
Format settings, Endianness              : Little
Format settings, Sign                    : Signed
Codec ID                                 : 1
Duration                                 : 11 s 626 ms
Bit rate mode                            : Constant
Bit rate                                 : 1 411.2 kb/s
Channel(s)                               : 2 channels
Sampling rate                            : 44.1 kHz
Bit depth                                : 16 bits
Stream size                              : 1.96 MiB (100%)

