### PR TITLE
HEVC: support preferred_transfer_characteristics SEI 

### DIFF
--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -10,7 +10,8 @@ https://sourceforge.net/p/mediainfo/_list/tickets
 
 Version 0.7.92
 --------------
-+ MXF and MPEG video streams: detection of HLG Transfer Characteristic
++ #F507, MXF: detection of HLG Transfer Characteristic
++ #F508, HEVC: support of preferred_transfer_characteristics SEI (from HEVC/H.265 draft, preferred method for HLG in DVB)
 + MP4: more AppleStoreCountry values mapped to countries, show the country number if unknown
 + File extension: test if the file extension correspond to the container format
 + AVI/WAV: test of truncated file

--- a/Source/MediaInfo/Video/File_Hevc.cpp
+++ b/Source/MediaInfo/Video/File_Hevc.cpp
@@ -255,6 +255,8 @@ void File_Hevc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator se
     if ((*seq_parameter_set_Item)->bit_depth_luma_minus8==(*seq_parameter_set_Item)->bit_depth_chroma_minus8)
         Fill(Stream_Video, 0, Video_BitDepth, (*seq_parameter_set_Item)->bit_depth_luma_minus8+8);
 
+    if (preferred_transfer_characteristics!=2)
+        Fill(Stream_Video, 0, Video_transfer_characteristics, Mpegv_transfer_characteristics(preferred_transfer_characteristics));
     if ((*seq_parameter_set_Item)->vui_parameters)
     {
         if ((*seq_parameter_set_Item)->vui_parameters->timing_info_present_flag)
@@ -739,6 +741,7 @@ void File_Hevc::Synched_Init()
     chroma_sample_loc_type_bottom_field=(int32u)-1;
     maximum_content_light_level=0;
     maximum_frame_average_light_level=0;
+    preferred_transfer_characteristics=2;
 
     //Default values
     Streams.resize(0x100);
@@ -1816,6 +1819,7 @@ void File_Hevc::sei_message(int32u &seq_parameter_set_id)
         case 132 :   sei_message_decoded_picture_hash(payloadSize); break;
         case 137 :   sei_message_mastering_display_colour_volume(); break;
         case 144 :   sei_message_light_level(); break;
+        case 147 :   sei_alternative_transfer_characteristics(); break;
         default :
                     Element_Info1("unknown");
                     Skip_XX(payloadSize,                        "data");
@@ -2159,6 +2163,15 @@ void File_Hevc::sei_message_light_level()
     //Parsing
     Get_B2(maximum_content_light_level,                         "maximum_content_light_level");
     Get_B2(maximum_frame_average_light_level,                   "maximum_frame_average_light_level");
+}
+
+//---------------------------------------------------------------------------
+void File_Hevc::sei_alternative_transfer_characteristics()
+{
+    Element_Info1("alternative_transfer_characteristics");
+
+    //Parsing
+    Get_B1(preferred_transfer_characteristics,                  "preferred_transfer_characteristics"); Param_Info1(Mpegv_transfer_characteristics(preferred_transfer_characteristics));
 }
 
 //***************************************************************************

--- a/Source/MediaInfo/Video/File_Hevc.h
+++ b/Source/MediaInfo/Video/File_Hevc.h
@@ -363,6 +363,7 @@ private :
     void sei_message_decoded_picture_hash(int32u payloadSize);
     void sei_message_mastering_display_colour_volume();
     void sei_message_light_level();
+    void sei_alternative_transfer_characteristics();
 
     //Packets - SubElements
     void slice_segment_header();
@@ -424,6 +425,7 @@ private :
     int8u   profile_space;
     int8u   profile_idc;
     int8u   level_idc;
+    int8u   preferred_transfer_characteristics;
     bool    tier_flag;
     bool    general_progressive_source_flag;
     bool    general_interlaced_source_flag;


### PR DESCRIPTION
From HEVC/H.265 draft, preferred method for HLG in DVB
https://sourceforge.net/p/mediainfo/feature-requests/508/
