### PR TITLE
Trace/XML: newline in tag name need to be escaped

### DIFF
--- a/Source/MediaInfo/File__Analyze_Element.cpp
+++ b/Source/MediaInfo/File__Analyze_Element.cpp
@@ -423,9 +423,6 @@ static void Xml_Content_Escape(const char* Content, size_t Size, std::string& To
                 Pos += 3;
                 Size += 3;
                 break;
-            case '\r':
-            case '\n':
-                break;
             default:
                 if (C<0x20)
                 {


### PR DESCRIPTION
Signed-off-by: Florent Tribouilloy <florent@mediaarea.net>