### PR TITLE
MIXML output: Format_Profile divided in Format_Profile, Format_Level…

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -2,6 +2,10 @@ I changed some elements in the interface.
 No break in binary compatibily (no crash), but some details.
 
 
+0.7.91 --> 0.7.92
+-----------------
+- MIXML output: Format_Profile divided in Format_Profile, Format_Level, Format_Tier
+
 0.7.79 --> 0.7.80
 -----------------
 - Visual Basic binding: StreamKind.Visual changed to StreamKind.Video for more coherency with other bindings (StreamKind.Visual is still available but it is deprecated)

--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -14,6 +14,7 @@ Version 0.7.92
 + MP4: more AppleStoreCountry values mapped to countries, show the country number if unknown
 + File extension: test if the file extension correspond to the container format
 + AVI/WAV: test of truncated file
++ MIXML output: Format_Profile divided in Format_Profile, Format_Level, Format_Tier
 x MIXML output: some *_Original values were missing
 x MXF/Teletext: was not correctly detecting non subtitle streams
 

--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -526,6 +526,16 @@ Ztring MediaInfo_Internal::Inform (stream_t StreamKind, size_t StreamPos, bool I
                         if (SlashPos!=string::npos)
                             Valeur.erase(SlashPos);
                     }
+                    Ztring Format_Profile_More;
+                    if (XML_0_7_78 && Nom==__T("Format_Profile"))
+                    {
+                        size_t SeparatorPos=Valeur.find(__T('@'));
+                        if (SeparatorPos!=string::npos && Valeur.find(__T(" / "))==string::npos) //TODO: better support of compatibility modes (e.g. "Multiview") and sequences (e.g. different profiles in different files "BCS@L3 / BCS@L2 / BCS@L3")
+                        {
+                            Format_Profile_More=Valeur.substr(SeparatorPos+1);
+                            Valeur.erase(SeparatorPos);
+                        }
+                    }
 
                     Retour+=__T("<");
                     Retour+=Nom;
@@ -539,6 +549,27 @@ Ztring MediaInfo_Internal::Inform (stream_t StreamKind, size_t StreamPos, bool I
                     Retour+=__T("</");
                     Retour+=Nom;
                     Retour+=__T(">");
+
+                    if (!Format_Profile_More.empty())
+                    {
+                        if (Format_Profile_More[0] == __T('L'))
+                            Format_Profile_More.erase(0, 1);
+                        size_t SeparatorPos=Format_Profile_More.find(__T('@'));
+                        if (SeparatorPos!=string::npos)
+                        {
+                            Retour+=__T("\n<Format_Level>");
+                            Retour+=Format_Profile_More.substr(0, SeparatorPos);
+                            Retour+=__T("</Format_Level>\n<Format_Tier>");
+                            Retour+=Format_Profile_More.substr(SeparatorPos+1);
+                            Retour+=__T("</Format_Tier>");
+                        }
+                        else
+                        {
+                            Retour+=__T("\n<Format_Level>");
+                            Retour+=Format_Profile_More;
+                            Retour+=__T("</Format_Level>");
+                        }
+                    }
                 }
                 #endif //defined(MEDIAINFO_XML_YES)
                 #if defined(MEDIAINFO_CSV_YES)


### PR DESCRIPTION
MIXML output: Format_Profile divided in Format_Profile, Format_Level, Format_Tier

Examples:

```XML
<Format>AVC</Format>
<Format_Profile>High</Format_Profile>
<Format_Level>4.1</Format_Level>

<Format>HEVC</Format>
<Format_Profile>Main</Format_Profile>
<Format_Level>6.2</Format_Level>
<Format_Tier>Main</Format_Tier>
```

It is breaking compatibility but MIXML is not a lot used and still not considered as stable, so is OK.