### PR TITLE
x MP4/MOV: Dolby E was not detected if Demux_SplitAudioBlocks option

### DIFF
--- a/Source/MediaInfo/Audio/File_ChannelGrouping.cpp
+++ b/Source/MediaInfo/Audio/File_ChannelGrouping.cpp
@@ -207,9 +207,6 @@ void File_ChannelGrouping::Read_Buffer_Continue()
     Common->Channels[Channel_Pos]->Offsets_Buffer.insert(Common->Channels[Channel_Pos]->Offsets_Buffer.begin(), Offsets_Buffer.begin(), Offsets_Buffer.end());
     Offsets_Buffer.clear();
     Skip_XX(Buffer_Size,                                        "Channel grouping data");
-    Common->Channel_Current++;
-    if (Common->Channel_Current>=Channel_Total)
-        Common->Channel_Current=0;
 
     //Copying to merged channel
     size_t Minimum=(size_t)-1;

--- a/Source/MediaInfo/Audio/File_ChannelGrouping.h
+++ b/Source/MediaInfo/Audio/File_ChannelGrouping.h
@@ -85,18 +85,15 @@ public :
                 Buffer_Size-=Buffer_Offset;
                 Buffer_Offset=0;
             }
-
         };
         vector<channel*>    Channels;
         channel             MergedChannel;
-        size_t              Channel_Current;
         std::vector<File__Analyze*> Parsers;
         size_t              Instances;
         size_t              Instances_Max;
 
         common()
         {
-            Channel_Current=0;
             Instances=0;
             Instances_Max=0;
         }

--- a/Source/MediaInfo/Audio/File_Pcm.cpp
+++ b/Source/MediaInfo/Audio/File_Pcm.cpp
@@ -253,15 +253,6 @@ void File_Pcm::Streams_Finish()
 //---------------------------------------------------------------------------
 void File_Pcm::Read_Buffer_Continue()
 {
-    //Testing if we get enough data
-    if (SamplingRate && BitDepth && Channels)
-    {
-        int64u BitRate=SamplingRate*BitDepth*Channels;
-        int64u ByteRate=BitRate/8;
-        if (Buffer_Size>=ByteRate/4) // 1/4 of second is enough for detection
-            Frame_Count_Valid=2;
-    }
-
     #if MEDIAINFO_DEMUX
         if (Demux_UnpacketizeContainer && !Frame_Count && !Status[IsAccepted])
         {

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -4444,7 +4444,7 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxxSound()
                 }
             }
             Parser->Codec=Ztring().From_Local(Codec.c_str());
-            Streams[moov_trak_tkhd_TrackID].Parsers.push_back(Parser);
+            Streams[moov_trak_tkhd_TrackID].Parsers.push_back(Parser); //Warning: PCM parser must be the last one (for detection "by default" and this property is used when e.g. "Demux_SplitAudioBlocks" is used)
             Streams[moov_trak_tkhd_TrackID].IsPcm=true;
 
             #if MEDIAINFO_DEMUX


### PR DESCRIPTION
Moving PCM acceptance threshold config to Mpeg4 demuxer, so it can set the frame count limit depending of the Demux_SplitAudioBlocks: if audio blocks are split, there are several PCM frames of half-stream 1 before first PCM frame of half-stream 2.