### PR TITLE
cUrl

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config.cpp
+++ b/Source/MediaInfo/MediaInfo_Config.cpp
@@ -117,6 +117,9 @@
 #include "ZenLib/ZtringListListF.h"
 #include "ZenLib/File.h"
 #include <algorithm>
+#if defined(MEDIAINFO_LIBCURL_YES)
+    #include "MediaInfo/Reader/Reader_libcurl.h"
+#endif //defined(MEDIAINFO_LIBCURL_YES)
 using namespace ZenLib;
 using namespace std;
 //---------------------------------------------------------------------------
@@ -921,6 +924,14 @@ Ztring MediaInfo_Config::Option (const String &Option, const String &Value_Raw)
         #if defined(MEDIAINFO_LIBCURL_YES)
             Ssh_KnownHostsFileName_Set(Value);
             return Ztring();
+        #else // defined(MEDIAINFO_LIBCURL_YES)
+            return __T("Libcurl support is disabled due to compilation options");
+        #endif // defined(MEDIAINFO_LIBCURL_YES)
+    }
+    else if (Option_Lower==__T("info_canhandleurls"))
+    {
+        #if defined(MEDIAINFO_LIBCURL_YES)
+            return CanHandleUrls()?__T("1"):__T("0");;
         #else // defined(MEDIAINFO_LIBCURL_YES)
             return __T("Libcurl support is disabled due to compilation options");
         #endif // defined(MEDIAINFO_LIBCURL_YES)
@@ -2539,6 +2550,12 @@ void MediaInfo_Config::Log_Send (int8u Type, int8u Severity, int32u MessageCode,
 //***************************************************************************
 
 #if defined(MEDIAINFO_LIBCURL_YES)
+bool MediaInfo_Config::CanHandleUrls()
+{
+    CriticalSectionLocker CSL(CS);
+    return Reader_libcurl::Load();
+}
+
 void MediaInfo_Config::Ssh_PublicKeyFileName_Set (const Ztring &Value)
 {
     CriticalSectionLocker CSL(CS);

--- a/Source/MediaInfo/MediaInfo_Config.h
+++ b/Source/MediaInfo/MediaInfo_Config.h
@@ -250,6 +250,7 @@ public :
     #endif //MEDIAINFO_EVENTS
 
     #if defined(MEDIAINFO_LIBCURL_YES)
+          bool      CanHandleUrls();
           void      Ssh_PublicKeyFileName_Set (const Ztring &NewValue);
           Ztring    Ssh_PublicKeyFileName_Get ();
           void      Ssh_PrivateKeyFileName_Set (const Ztring &NewValue);

--- a/Source/MediaInfo/Reader/Reader_libcurl.cpp
+++ b/Source/MediaInfo/Reader/Reader_libcurl.cpp
@@ -565,64 +565,8 @@ Reader_libcurl::~Reader_libcurl ()
 //---------------------------------------------------------------------------
 size_t Reader_libcurl::Format_Test(MediaInfo_Internal* MI, String File_Name)
 {
-    #if defined MEDIAINFO_LIBCURL_DLL_RUNTIME
-        if (libcurl_Module_Count==0)
-        {
-            size_t Errors=0;
-
-            /* Load library */
-            #ifdef MEDIAINFO_GLIBC
-                libcurl_Module=g_module_open(MEDIAINFODLL_NAME, G_MODULE_BIND_LAZY);
-            #elif defined (_WIN32) || defined (WIN32)
-                libcurl_Module=LoadLibrary(MEDIAINFODLL_NAME);
-            #else
-                libcurl_Module=dlopen(MEDIAINFODLL_NAME, RTLD_LAZY);
-                if (!libcurl_Module)
-                    libcurl_Module=dlopen("./" MEDIAINFODLL_NAME, RTLD_LAZY);
-                if (!libcurl_Module)
-                    libcurl_Module=dlopen("/usr/local/lib/" MEDIAINFODLL_NAME, RTLD_LAZY);
-                if (!libcurl_Module)
-                    libcurl_Module=dlopen("/usr/local/lib64/" MEDIAINFODLL_NAME, RTLD_LAZY);
-                if (!libcurl_Module)
-                    libcurl_Module=dlopen("/usr/lib/" MEDIAINFODLL_NAME, RTLD_LAZY);
-                if (!libcurl_Module)
-                    libcurl_Module=dlopen("/usr/lib64/" MEDIAINFODLL_NAME, RTLD_LAZY);
-            #endif
-            if (!libcurl_Module)
-            {
-                #if MEDIAINFO_EVENTS
-                    MediaInfoLib::Config.Log_Send(0xC0, 0xFF, 0, Reader_libcurl_FileNameWithoutPassword(File_Name)+__T(", Libcurl library is not found"));
-                #endif //MEDIAINFO_EVENTS
-                return 0;
-            }
-
-            /* Load methods */
-            MEDIAINFO_ASSIGN    (curl_easy_init,            "curl_easy_init")
-            MEDIAINFO_ASSIGN    (curl_easy_setopt,          "curl_easy_setopt")
-            MEDIAINFO_ASSIGN    (curl_easy_perform,         "curl_easy_perform")
-            MEDIAINFO_ASSIGN    (curl_easy_cleanup,         "curl_easy_cleanup")
-            MEDIAINFO_ASSIGN    (curl_easy_getinfo,         "curl_easy_getinfo")
-            MEDIAINFO_ASSIGN    (curl_slist_append,         "curl_slist_append")
-            MEDIAINFO_ASSIGN    (curl_slist_free_all,       "curl_slist_free_all")
-            MEDIAINFO_ASSIGN    (curl_easy_duphandle,       "curl_easy_duphandle")
-            MEDIAINFO_ASSIGN    (curl_easy_strerror,        "curl_easy_strerror")
-            MEDIAINFO_ASSIGN    (curl_version_info,         "curl_version_info")
-            MEDIAINFO_ASSIGN    (curl_multi_init,           "curl_multi_init")
-            MEDIAINFO_ASSIGN    (curl_multi_add_handle,     "curl_multi_add_handle")
-            MEDIAINFO_ASSIGN    (curl_multi_remove_handle,  "curl_multi_remove_handle")
-            MEDIAINFO_ASSIGN    (curl_multi_perform,        "curl_multi_perform")
-            MEDIAINFO_ASSIGN    (curl_multi_cleanup,        "curl_multi_cleanup")
-            if (Errors>0)
-            {
-                #if MEDIAINFO_EVENTS
-                    MediaInfoLib::Config.Log_Send(0xC0, 0xFF, 0, Reader_libcurl_FileNameWithoutPassword(File_Name)+__T(", Libcurl library is not correctly loaded"));
-                #endif //MEDIAINFO_EVENTS
-                return 0;
-            }
-
-            libcurl_Module_Count++;
-        }
-    #endif //defined MEDIAINFO_LIBCURL_DLL_RUNTIME
+    if (!Load())
+        return 0;
 
     #if MEDIAINFO_EVENTS
         {
@@ -1182,6 +1126,77 @@ size_t Reader_libcurl::Format_Test_PerParser_Seek (MediaInfo_Internal* MI, size_
     return ToReturn;
 }
 #endif //MEDIAINFO_SEEK
+
+//***************************************************************************
+// Open/Close library
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+bool Reader_libcurl::Load(const Ztring File_Name)
+{
+    #if defined MEDIAINFO_LIBCURL_DLL_RUNTIME
+        if (libcurl_Module_Count==0)
+        {
+            size_t Errors=0;
+
+            /* Load library */
+            #ifdef MEDIAINFO_GLIBC
+                libcurl_Module=g_module_open(MEDIAINFODLL_NAME, G_MODULE_BIND_LAZY);
+            #elif defined (_WIN32) || defined (WIN32)
+                libcurl_Module=LoadLibrary(MEDIAINFODLL_NAME);
+            #else
+                libcurl_Module=dlopen(MEDIAINFODLL_NAME, RTLD_LAZY);
+                if (!libcurl_Module)
+                    libcurl_Module=dlopen("./" MEDIAINFODLL_NAME, RTLD_LAZY);
+                if (!libcurl_Module)
+                    libcurl_Module=dlopen("/usr/local/lib/" MEDIAINFODLL_NAME, RTLD_LAZY);
+                if (!libcurl_Module)
+                    libcurl_Module=dlopen("/usr/local/lib64/" MEDIAINFODLL_NAME, RTLD_LAZY);
+                if (!libcurl_Module)
+                    libcurl_Module=dlopen("/usr/lib/" MEDIAINFODLL_NAME, RTLD_LAZY);
+                if (!libcurl_Module)
+                    libcurl_Module=dlopen("/usr/lib64/" MEDIAINFODLL_NAME, RTLD_LAZY);
+            #endif
+            if (!libcurl_Module)
+            {
+                #if MEDIAINFO_EVENTS
+                    if (!File_Name.empty())
+                        MediaInfoLib::Config.Log_Send(0xC0, 0xFF, 0, Reader_libcurl_FileNameWithoutPassword(File_Name)+__T(", Libcurl library is not found"));
+                #endif //MEDIAINFO_EVENTS
+                return 0;
+            }
+
+            /* Load methods */
+            MEDIAINFO_ASSIGN    (curl_easy_init,            "curl_easy_init")
+            MEDIAINFO_ASSIGN    (curl_easy_setopt,          "curl_easy_setopt")
+            MEDIAINFO_ASSIGN    (curl_easy_perform,         "curl_easy_perform")
+            MEDIAINFO_ASSIGN    (curl_easy_cleanup,         "curl_easy_cleanup")
+            MEDIAINFO_ASSIGN    (curl_easy_getinfo,         "curl_easy_getinfo")
+            MEDIAINFO_ASSIGN    (curl_slist_append,         "curl_slist_append")
+            MEDIAINFO_ASSIGN    (curl_slist_free_all,       "curl_slist_free_all")
+            MEDIAINFO_ASSIGN    (curl_easy_duphandle,       "curl_easy_duphandle")
+            MEDIAINFO_ASSIGN    (curl_easy_strerror,        "curl_easy_strerror")
+            MEDIAINFO_ASSIGN    (curl_version_info,         "curl_version_info")
+            MEDIAINFO_ASSIGN    (curl_multi_init,           "curl_multi_init")
+            MEDIAINFO_ASSIGN    (curl_multi_add_handle,     "curl_multi_add_handle")
+            MEDIAINFO_ASSIGN    (curl_multi_remove_handle,  "curl_multi_remove_handle")
+            MEDIAINFO_ASSIGN    (curl_multi_perform,        "curl_multi_perform")
+            MEDIAINFO_ASSIGN    (curl_multi_cleanup,        "curl_multi_cleanup")
+            if (Errors>0)
+            {
+                #if MEDIAINFO_EVENTS
+                    if (!File_Name.empty())
+                        MediaInfoLib::Config.Log_Send(0xC0, 0xFF, 0, Reader_libcurl_FileNameWithoutPassword(File_Name)+__T(", Libcurl library is not correctly loaded"));
+                #endif //MEDIAINFO_EVENTS
+                return 0;
+            }
+
+            libcurl_Module_Count++;
+        }
+    #endif //defined MEDIAINFO_LIBCURL_DLL_RUNTIME
+
+    return true;
+}
 
 } //NameSpace
 

--- a/Source/MediaInfo/Reader/Reader_libcurl.h
+++ b/Source/MediaInfo/Reader/Reader_libcurl.h
@@ -40,6 +40,9 @@ public :
     size_t Format_Test_PerParser_Continue (MediaInfo_Internal* MI);
     size_t Format_Test_PerParser_Seek (MediaInfo_Internal* MI, size_t Method, int64u Value, int64u ID);
 
+    // Open/Close library
+    static bool Load(const Ztring File_Name=Ztring());
+
 public:
     struct curl_data;
 

--- a/Source/MediaInfo/Reader/Reader_libcurl_Include.h
+++ b/Source/MediaInfo/Reader/Reader_libcurl_Include.h
@@ -917,7 +917,7 @@ extern "C"
     #define MEDIAINFODLL_NAME  "libcurl.4.dylib"
     #define __stdcall
 #else
-    #define MEDIAINFODLL_NAME  "libcurl.so.0"
+    #define MEDIAINFODLL_NAME  "libcurl.so.4"
     #define __stdcall
 #endif //!defined(_WIN32) || defined (WIN32)
 


### PR DESCRIPTION
"Info_CanHandleUrls" option in the library.
Will be used by " --Info_CanHandleUrls" option in the CLI.
returns "1" if URLs can be handled (currently: through libcurl), else "0".