### PR TITLE
S_DVBSUB

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -2747,6 +2747,7 @@ void MediaInfo_Config_CodecID_Text_Matroska (InfoMap &Info)
     "S_VOBSUB;VobSub;;Picture based subtitle format used on DVDs\n"
     "S_HDMV/PGS;PGS;;Picture based subtitle format used on BDs/HD-DVDs\n"
     "S_HDMV/TEXTST;TEXTST;;Text based subtitle format used on BDs\n"
+    "S_DVBSUB;DVB Subtitle;;Picture based subtitle format used on DVBs\n"
     ));
     Info.Separator_Set(0, ZenLib::EOL);
 }
@@ -3877,6 +3878,7 @@ void MediaInfo_Config_Codec (InfoMap &Info)
     "S_VOBSUB;VobSub;Mk;T;;;Picture based subtitle format used on DVDs\n"
     "S_HDMV/PGS;PGS;Mk;T;;;Picture based subtitle format used on BDs/HD-DVDs\n"
     "S_HDMV/TEXTST;TEXTST;Mk;T;;;Text based subtitle format used on BDs\n"
+    "S_DVBSUB;DVB Subtitle;Mk;T;;;Picture based subtitle format used on DVBs\n"
     ));
     Info.Separator_Set(0, ZenLib::EOL);
 }

--- a/Source/Resource/Text/DataBase/Codec.csv
+++ b/Source/Resource/Text/DataBase/Codec.csv
@@ -1081,3 +1081,4 @@ S_IMAGE/BMP;Bitmap;Mk;T;;;Basic image based subtitle format;
 S_VOBSUB;VobSub;Mk;T;;;Picture based subtitle format used on DVDs
 S_HDMV/PGS;PGS;Mk;T;;;Picture based subtitle format used on BDs/HD-DVDs
 S_HDMV/TEXTST;TEXTST;Mk;T;;;Text based subtitle format used on BDs
+S_DVBSUB;DVB Subtitle;Mk;T;;;Picture based subtitle format used on DVBs;

--- a/Source/Resource/Text/DataBase/CodecID_Text_Matroska.csv
+++ b/Source/Resource/Text/DataBase/CodecID_Text_Matroska.csv
@@ -1,4 +1,5 @@
 S_ASS;ASS;;Advanced Sub Station Alpha
+S_DVBSUB;DVB Subtitle;;Picture based subtitle format used on DVBs
 S_IMAGE/BMP;Bitmap;;Basic image based subtitle format
 S_SSA;SSA;;Sub Station Alpha
 S_TEXT/ASS;ASS;;Advanced Sub Station Alpha


### PR DESCRIPTION
https://github.com/Matroska-Org/matroska-specification/blob/dfaf1eb14cd2cdb628967a09c8bbdd630f5b6118/subtitles.md#digital-video-broadcasting-dvb-subtitles

This time, i've a sample :wink: 
[dvbtextualsubtitles.zip](https://github.com/MediaArea/MediaInfoLib/files/762067/dvbtextualsubtitles.zip)

As a side note, _**TVheadend**_ is able to produce it.
I've extracted it with [FFmpeg](https://git.ffmpeg.org/gitweb/ffmpeg.git/blobdiff/e87a4a85c11e348be8682acf39573fd2c5e22193..dface53497c3531da101b2872df301acca313142:/libavformat/matroska.c).

**EDIT**: I should have mentioned that _**mkvmerge**_ is able to produce it since 9.8.0.
As do _**TSDoctor**_ and _**VideoRedoSuite**_, commercial softwares having a free trial.