### PR TITLE
+ IMF: Add awareness of 2016 SMPTE 2067 namespaces

### DIFF
--- a/Source/MediaInfo/Multiple/File_DcpCpl.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpCpl.cpp
@@ -114,6 +114,7 @@ static bool IsSmpteSt2067_3(const char* Ns)
 {
     return Ns &&
            (!strcmp(Ns, "http://www.smpte-ra.org/schemas/2067-3/2013") ||
+            !strcmp(Ns, "http://www.smpte-ra.org/schemas/2067-3/2016") ||
             !strcmp(Ns, "http://www.smpte-ra.org/schemas/2067-3/XXXX")); //Some muxers use XXXX instead of year
 
 }

--- a/Source/MediaInfo/Multiple/File_DcpPkl.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpPkl.cpp
@@ -123,7 +123,8 @@ bool File_DcpPkl::FileHeader_Begin()
         return false;
     }
     if (strcmp(NameSpace, "http://www.digicine.com/PROTO-ASDCP-PKL-20040311#") &&
-        strcmp(NameSpace, "http://www.smpte-ra.org/schemas/429-8/2007/PKL"))
+        strcmp(NameSpace, "http://www.smpte-ra.org/schemas/429-8/2007/PKL") &&
+        strcmp(NameSpace, "http://www.smpte-ra.org/schemas/2067-2/2016/PKL"))
     {
         Reject("DcpPkl");
         return false;


### PR DESCRIPTION
IMF files coming out of Clipster 6.1.0.0 use the 2016 SMPTE 2067 namespace, and aren't detected as IMF by MediaInfoLib. This patch fixes the issue. Thanks!

Signed-off-by: Peter Chapman <peterc@telestream.net>