### PR TITLE
x Matroska: crash in case of big attachment and CRC32 present

### DIFF
--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -21,6 +21,7 @@ x HLS: duration was sometimes wrong, reading only the first TS file duration. No
 x MPEG-TS: if stream is encrypted or invalid, level was sometimes not the expected one for AVC (e.g. "BaseLine@3.0" instead of "Baseline@3")
 x Matroska: FFV1 stream width/height was not initialized when Matroska track header width/height is after CodecID
 x FFV1: fix potential crash with some buggy slice headers
+x Matroska: crash in case of big attachment and CRC32 present
 
 Version 0.7.92.1, 2017-02-02
 --------------

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -619,6 +619,7 @@ File_Mk::File_Mk()
     Segment_Cluster_Count=0;
     CurrentAttachmentIsCover=false;
     CoverIsSetFromAttachment=false;
+    CRC32Compute_SkipUpTo=0;
 
     //Hints
     File_Buffer_Size_Hint_Pointer=NULL;
@@ -1083,6 +1084,24 @@ void File_Mk::Streams_Finish()
 }
 
 //***************************************************************************
+// Buffer - Global
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+void File_Mk::Read_Buffer_Continue()
+{
+    //Handling CRC32 computing when there is no need of the data (data not parsed, only needed for CRC32)
+    if (CRC32Compute_SkipUpTo>File_Offset)
+    {
+        int64u Size=CRC32Compute_SkipUpTo-File_Offset;
+        if (Element_Size>Size)
+            Element_Size=Size;
+        Element_Offset=Element_Size;
+        CRC32_Check();
+    }
+}
+
+//***************************************************************************
 // Buffer
 //***************************************************************************
 
@@ -1507,7 +1526,7 @@ void File_Mk::Data_Parse()
         ATOM_END_MK
     DATA_END
 
-    if (!CRC32Compute.empty())
+    if (!Element_IsWaitingForMoreData() && !CRC32Compute.empty())
         CRC32_Check();
 }
 
@@ -4633,8 +4652,16 @@ void File_Mk::CRC32_Check ()
     for (size_t i = 0; i<CRC32Compute.size(); i++)
         if (CRC32Compute[i].UpTo && File_Offset + Buffer_Offset - (size_t)Header_Size >= CRC32Compute[i].From)
         {
-            Matroska_CRC32_Compute(CRC32Compute[i].Computed, Buffer + Buffer_Offset - (size_t)Header_Size, Buffer + Buffer_Offset + (size_t)(Element_WantNextLevel?Element_Offset:Element_Size));
-            if (File_Offset + Buffer_Offset + (Element_WantNextLevel?Element_Offset:Element_Size) >= CRC32Compute[i].UpTo)
+            //Handling of case when data is not completetely loaded because it is not needed by the parser
+            const size_t Offset = Buffer_Offset + (size_t)((Element_WantNextLevel && Element_Offset <= Element_Size) ? Element_Offset : Element_Size);
+            if (Element_Offset > Element_Size)
+            {
+                CRC32Compute_SkipUpTo = File_Offset + Element_Offset;
+                Element_Offset = Element_Size;
+            }
+            
+            Matroska_CRC32_Compute(CRC32Compute[i].Computed, Buffer + Buffer_Offset - (size_t)Header_Size, Buffer + Offset);
+            if (File_Offset + Offset >= CRC32Compute[i].UpTo)
             {
                 CRC32Compute[i].Computed ^= 0xFFFFFFFF;
 

--- a/Source/MediaInfo/Multiple/File_Mk.h
+++ b/Source/MediaInfo/Multiple/File_Mk.h
@@ -37,6 +37,9 @@ public :
     ~File_Mk();
 
 private :
+    //Buffer - Global
+    void Read_Buffer_Continue();
+
     //Buffer
     void Header_Parse();
     void Data_Parse();
@@ -351,6 +354,7 @@ private :
         int32u  Expected;
     };
     std::vector<crc32> CRC32Compute;
+    int64u CRC32Compute_SkipUpTo;
 
     //Chapters
     struct chapterdisplay


### PR DESCRIPTION
Fix for https://github.com/MediaArea/MediaInfoLib/issues/316
Based on https://github.com/MediaArea/MediaInfoLib/pull/357