### PR TITLE
Fix build with C++Builder 10.1 (Part 1)

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -811,7 +811,7 @@ void File_Mk::Streams_Finish()
                     float64 Duration_1000 = Statistics_FrameCount / float64_int64s(FrameRate_FromTags) * 1.001001;
                     bool CanBe1001 = false;
                     bool CanBe1000 = false;
-                    if (fabs((Duration_1000 - Duration_1001) * 10000) >= 15)
+                    if (std::fabs((Duration_1000 - Duration_1001) * 10000) >= 15)
                     {
                         Ztring DurationS; DurationS.From_Number(Statistics_Duration, 3);
                         Ztring DurationS_1001; DurationS_1001.From_Number(Duration_1001, 3);

--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -533,9 +533,9 @@ private :
         int32u StreamID;
         int32u Reserved1;
         int64u Reserved2;
-        friend bool operator<(const mdat_Pos_Type& l, const mdat_Pos_Type& r)
+        bool operator<(const mdat_Pos_Type& r) const
         {
-            return l.Offset<r.Offset;
+            return Offset<r.Offset;
         }
     };
     typedef std::vector<mdat_Pos_Type> mdat_pos;


### PR DESCRIPTION
1. [bcc32 Error] File_Mk.cpp(814): E2268 Call to undefined function 'fabs'
2. [bcc32 Error] algorithm(1430): E2093 'operator<' not implemented in type 'MediaInfoLib::File_Mpeg4::mdat_Pos_Type' for arguments of the same type
