### PR TITLE
Fix C++ Builder 10.1 error

### DIFF
--- a/Source/MediaInfo/Audio/File_Dts.cpp
+++ b/Source/MediaInfo/Audio/File_Dts.cpp
@@ -490,7 +490,10 @@ void File_Dts::Streams_Fill_Core_ES()
     }
     else
     {
-        Ztring Debug=__T("Debug, Core_Core_AMODE=")+Ztring::ToZtring(Core_Core_AMODE)+(Presence[presence_Core_XCh]?(__T(", Core_XCh_AMODE=")+Ztring::ToZtring(Core_XCh_AMODE)):__T(""))+__T(", Core_Core_LFF=")+Ztring::ToZtring(Core_Core_LFF);
+		Ztring Debug=__T("Debug, Core_Core_AMODE=")+Ztring::ToZtring(Core_Core_AMODE);
+		if(Presence[presence_Core_XCh])
+			Debug +=__T(", Core_XCh_AMODE=")+Ztring::ToZtring(Core_XCh_AMODE);
+		Debug +=__T(", Core_Core_LFF=")+Ztring::ToZtring(Core_Core_LFF);
         Data[ChannelPositions].push_back(Debug);
         Data[ChannelPositions2].push_back(Debug);
         Data[ChannelLayout].push_back(Debug);

--- a/Source/MediaInfo/Audio/File_Dts.cpp
+++ b/Source/MediaInfo/Audio/File_Dts.cpp
@@ -490,10 +490,10 @@ void File_Dts::Streams_Fill_Core_ES()
     }
     else
     {
-		Ztring Debug=__T("Debug, Core_Core_AMODE=")+Ztring::ToZtring(Core_Core_AMODE);
-		if(Presence[presence_Core_XCh])
-			Debug +=__T(", Core_XCh_AMODE=")+Ztring::ToZtring(Core_XCh_AMODE);
-		Debug +=__T(", Core_Core_LFF=")+Ztring::ToZtring(Core_Core_LFF);
+        Ztring Debug=__T("Debug, Core_Core_AMODE=")+Ztring::ToZtring(Core_Core_AMODE);
+        if(Presence[presence_Core_XCh])
+           Debug +=__T(", Core_XCh_AMODE=")+Ztring::ToZtring(Core_XCh_AMODE);
+        Debug +=__T(", Core_Core_LFF=")+Ztring::ToZtring(Core_Core_LFF);
         Data[ChannelPositions].push_back(Debug);
         Data[ChannelPositions2].push_back(Debug);
         Data[ChannelLayout].push_back(Debug);


### PR DESCRIPTION
E2354 Two operands must evaluate to the same type