### PR TITLE
VS support: switch back to madler/zlib

### DIFF
--- a/Project/MSVC2013/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2013/Library/MediaInfoLib.vcxproj
@@ -633,8 +633,8 @@
     <ProjectReference Include="..\..\..\..\ZenLib\Project\MSVC2013\Library\ZenLib.vcxproj">
       <Project>{0da1da7d-f393-4e7c-a7ce-cb5c6a67bc94}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\zlib\build-VS2013\libz-static\libz-static.vcxproj">
-      <Project>{b56d17bc-072b-42f3-844a-870a07afbaaa}</Project>
+    <ProjectReference Include="..\..\..\..\zlib\contrib\vstudio\vc12\zlibstat.vcxproj">
+      <Project>{745dec58-ebb3-47a9-a9b8-4c6627c01bf8}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Project/MSVC2013/MediaInfoLib.sln
+++ b/Project/MSVC2013/MediaInfoLib.sln
@@ -21,7 +21,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RegressionTest", "Regressio
 		{BE6D3EF8-2F82-4F1E-956A-890C3614A2D5} = {BE6D3EF8-2F82-4F1E-956A-890C3614A2D5}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libz-static", "..\..\..\zlib\build-VS2013\libz-static\libz-static.vcxproj", "{B56D17BC-072B-42F3-844A-870A07AFBAAA}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zlibstat", "..\..\..\zlib\contrib\vstudio\vc12\zlibstat.vcxproj", "{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -79,20 +79,20 @@ Global
 		{91C094CA-1170-4CE4-9B79-17324C8DACA8}.Release|Win32.Build.0 = Release|Win32
 		{91C094CA-1170-4CE4-9B79-17324C8DACA8}.Release|x64.ActiveCfg = Release|x64
 		{91C094CA-1170-4CE4-9B79-17324C8DACA8}.Release|x64.Build.0 = Release|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|Win32.ActiveCfg = Debug|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|Win32.Build.0 = Debug|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|x64.ActiveCfg = Debug|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|x64.Build.0 = Debug|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|Win32.ActiveCfg = Release|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|Win32.Build.0 = Release|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|x64.ActiveCfg = Release|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|x64.Build.0 = Release|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|Win32.ActiveCfg = Debug|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|Win32.Build.0 = Debug|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|x64.ActiveCfg = Debug|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|x64.Build.0 = Debug|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|Win32.ActiveCfg = Release|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|Win32.Build.0 = Release|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|x64.ActiveCfg = Release|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0DA1DA7D-F393-4E7C-A7CE-CB5C6A67BC94} = {F696A30D-66C6-46A8-B1BC-04B13BF14290}
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA} = {F696A30D-66C6-46A8-B1BC-04B13BF14290}
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8} = {F696A30D-66C6-46A8-B1BC-04B13BF14290}
 	EndGlobalSection
 EndGlobal

--- a/Project/MSVC2015/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2015/Library/MediaInfoLib.vcxproj
@@ -633,8 +633,8 @@
     <ProjectReference Include="..\..\..\..\ZenLib\Project\MSVC2015\Library\ZenLib.vcxproj">
       <Project>{0da1da7d-f393-4e7c-a7ce-cb5c6a67bc94}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\zlib\build-VS2015\libz-static\libz-static.vcxproj">
-      <Project>{b56d17bc-072b-42f3-844a-870a07afbaaa}</Project>
+    <ProjectReference Include="..\..\..\..\zlib\contrib\vstudio\vc14\zlibstat.vcxproj">
+      <Project>{745dec58-ebb3-47a9-a9b8-4c6627c01bf8}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Project/MSVC2015/MediaInfoLib.sln
+++ b/Project/MSVC2015/MediaInfoLib.sln
@@ -21,7 +21,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RegressionTest", "Regressio
 		{BE6D3EF8-2F82-4F1E-956A-890C3614A2D5} = {BE6D3EF8-2F82-4F1E-956A-890C3614A2D5}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libz-static", "..\..\..\zlib\build-VS2015\libz-static\libz-static.vcxproj", "{B56D17BC-072B-42F3-844A-870A07AFBAAA}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zlibstat", "..\..\..\zlib\contrib\vstudio\vc14\zlibstat.vcxproj", "{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -79,20 +79,20 @@ Global
 		{91C094CA-1170-4CE4-9B79-17324C8DACA8}.Release|Win32.Build.0 = Release|Win32
 		{91C094CA-1170-4CE4-9B79-17324C8DACA8}.Release|x64.ActiveCfg = Release|x64
 		{91C094CA-1170-4CE4-9B79-17324C8DACA8}.Release|x64.Build.0 = Release|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|Win32.ActiveCfg = Debug|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|Win32.Build.0 = Debug|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|x64.ActiveCfg = Debug|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|x64.Build.0 = Debug|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|Win32.ActiveCfg = Release|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|Win32.Build.0 = Release|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|x64.ActiveCfg = Release|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|x64.Build.0 = Release|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|Win32.ActiveCfg = Debug|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|Win32.Build.0 = Debug|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|x64.ActiveCfg = Debug|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|x64.Build.0 = Debug|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|Win32.ActiveCfg = Release|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|Win32.Build.0 = Release|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|x64.ActiveCfg = Release|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0DA1DA7D-F393-4E7C-A7CE-CB5C6A67BC94} = {F696A30D-66C6-46A8-B1BC-04B13BF14290}
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA} = {F696A30D-66C6-46A8-B1BC-04B13BF14290}
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8} = {F696A30D-66C6-46A8-B1BC-04B13BF14290}
 	EndGlobalSection
 EndGlobal

--- a/Project/MSVC2017/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2017/Library/MediaInfoLib.vcxproj
@@ -633,8 +633,8 @@
     <ProjectReference Include="..\..\..\..\ZenLib\Project\MSVC2017\Library\ZenLib.vcxproj">
       <Project>{0da1da7d-f393-4e7c-a7ce-cb5c6a67bc94}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\zlib\build-VS2017\libz-static\libz-static.vcxproj">
-      <Project>{b56d17bc-072b-42f3-844a-870a07afbaaa}</Project>
+    <ProjectReference Include="..\..\..\..\zlib\contrib\vstudio\vc15\zlibstat.vcxproj">
+      <Project>{745dec58-ebb3-47a9-a9b8-4c6627c01bf8}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Project/MSVC2017/MediaInfoLib.sln
+++ b/Project/MSVC2017/MediaInfoLib.sln
@@ -21,7 +21,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RegressionTest", "Regressio
 		{BE6D3EF8-2F82-4F1E-956A-890C3614A2D5} = {BE6D3EF8-2F82-4F1E-956A-890C3614A2D5}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libz-static", "..\..\..\zlib\build-VS2017\libz-static\libz-static.vcxproj", "{B56D17BC-072B-42F3-844A-870A07AFBAAA}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zlibstat", "..\..\..\zlib\contrib\vstudio\vc15\zlibstat.vcxproj", "{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -79,20 +79,20 @@ Global
 		{91C094CA-1170-4CE4-9B79-17324C8DACA8}.Release|Win32.Build.0 = Release|Win32
 		{91C094CA-1170-4CE4-9B79-17324C8DACA8}.Release|x64.ActiveCfg = Release|x64
 		{91C094CA-1170-4CE4-9B79-17324C8DACA8}.Release|x64.Build.0 = Release|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|Win32.ActiveCfg = Debug|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|Win32.Build.0 = Debug|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|x64.ActiveCfg = Debug|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Debug|x64.Build.0 = Debug|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|Win32.ActiveCfg = Release|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|Win32.Build.0 = Release|Win32
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|x64.ActiveCfg = Release|x64
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA}.Release|x64.Build.0 = Release|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|Win32.ActiveCfg = Debug|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|Win32.Build.0 = Debug|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|x64.ActiveCfg = Debug|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Debug|x64.Build.0 = Debug|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|Win32.ActiveCfg = Release|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|Win32.Build.0 = Release|Win32
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|x64.ActiveCfg = Release|x64
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0DA1DA7D-F393-4E7C-A7CE-CB5C6A67BC94} = {F696A30D-66C6-46A8-B1BC-04B13BF14290}
-		{B56D17BC-072B-42F3-844A-870A07AFBAAA} = {F696A30D-66C6-46A8-B1BC-04B13BF14290}
+		{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8} = {F696A30D-66C6-46A8-B1BC-04B13BF14290}
 	EndGlobalSection
 EndGlobal

--- a/Project/MSVC2017/MediaInfoLib.sln
+++ b/Project/MSVC2017/MediaInfoLib.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26206.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ThirdParty", "ThirdParty", "{F696A30D-66C6-46A8-B1BC-04B13BF14290}"
 EndProject


### PR DESCRIPTION
From https://github.com/MediaArea/MediaInfoLib/pull/422, I prefer to keep original project locations and IDs.

Project has been patched in order to accept 32-bit compilation.