### PR TITLE
MPEG-TS: MpegTs_ForceTextStreamDisplay option

### DIFF
--- a/History_DLL.txt
+++ b/History_DLL.txt
@@ -15,6 +15,7 @@ Version 0.7.92
 + MP4: more AppleStoreCountry values mapped to countries, show the country number if unknown
 + File extension: test if the file extension correspond to the container format
 + AVI/WAV: test of truncated file
++ MPEG-TS: MpegTs_ForceTextStreamDisplay option for showing e.g. DVB streams detected in PMT even if there is no PES at the beginning of the file
 + MIXML output: Format_Profile divided in Format_Profile, Format_Level, Format_Tier
 x MIXML output: some *_Original values were missing
 x MXF/Teletext: was not correctly detecting non subtitle streams

--- a/Source/MediaInfo/MediaInfo_Config.cpp
+++ b/Source/MediaInfo/MediaInfo_Config.cpp
@@ -867,6 +867,15 @@ Ztring MediaInfo_Config::Option (const String &Option, const String &Value_Raw)
     {
         return MpegTs_ForceStreamDisplay_Get()?__T("1"):__T("0");
     }
+    else if (Option_Lower == __T("mpegts_forcetextstreamdisplay"))
+    {
+        MpegTs_ForceTextStreamDisplay_Set(Value.To_int8u() ? true : false);
+        return Ztring();
+    }
+    else if (Option_Lower == __T("mpegts_forcetextstreamdisplay_get"))
+    {
+        return MpegTs_ForceTextStreamDisplay_Get() ? __T("1") : __T("0");
+    }
     else if (Option_Lower==__T("maxml_streamkinds"))
     {
         #if MEDIAINFO_ADVANCED
@@ -2266,6 +2275,18 @@ bool MediaInfo_Config::MpegTs_ForceStreamDisplay_Get ()
 {
     CriticalSectionLocker CSL(CS);
     return MpegTs_ForceStreamDisplay;
+}
+
+void MediaInfo_Config::MpegTs_ForceTextStreamDisplay_Set(bool Value)
+{
+    CriticalSectionLocker CSL(CS);
+    MpegTs_ForceTextStreamDisplay = Value;
+}
+
+bool MediaInfo_Config::MpegTs_ForceTextStreamDisplay_Get()
+{
+    CriticalSectionLocker CSL(CS);
+    return MpegTs_ForceTextStreamDisplay;
 }
 
 #if MEDIAINFO_ADVANCED

--- a/Source/MediaInfo/MediaInfo_Config.h
+++ b/Source/MediaInfo/MediaInfo_Config.h
@@ -208,6 +208,8 @@ public :
           int64u    MpegTs_MaximumScanDuration_Get ();
           void      MpegTs_ForceStreamDisplay_Set (bool Value);
           bool      MpegTs_ForceStreamDisplay_Get ();
+          void      MpegTs_ForceTextStreamDisplay_Set(bool Value);
+          bool      MpegTs_ForceTextStreamDisplay_Get();
     #if MEDIAINFO_ADVANCED
           void      MpegTs_VbrDetection_Delta_Set (float64 Value);
           float64   MpegTs_VbrDetection_Delta_Get ();
@@ -286,6 +288,7 @@ private :
     int64u          MpegTs_MaximumOffset;
     int64u          MpegTs_MaximumScanDuration;
     bool            MpegTs_ForceStreamDisplay;
+    bool            MpegTs_ForceTextStreamDisplay;
     #if MEDIAINFO_ADVANCED
         float64     MpegTs_VbrDetection_Delta;
         int64u      MpegTs_VbrDetection_Occurences;

--- a/Source/MediaInfo/Multiple/File_MpegTs.cpp
+++ b/Source/MediaInfo/Multiple/File_MpegTs.cpp
@@ -288,6 +288,7 @@ File_MpegTs::File_MpegTs()
     Complete_Stream=NULL;
     Begin_MaxDuration=MediaInfoLib::Config.ParseSpeed_Get()>=0.8?(int64u)-1:MediaInfoLib::Config.MpegTs_MaximumScanDuration_Get()*27/1000;
     ForceStreamDisplay=MediaInfoLib::Config.MpegTs_ForceStreamDisplay_Get();
+    ForceTextStreamDisplay=MediaInfoLib::Config.MpegTs_ForceTextStreamDisplay_Get();
 
     #if MEDIAINFO_SEEK
         Seek_Value=(int64u)-1;
@@ -456,6 +457,26 @@ void File_MpegTs::Streams_Update_Programs()
         {
             if (Program->second.IsParsed)
             {
+                // Special case: force text stream display if requested and if video stream is present
+                if (ForceTextStreamDisplay)
+                {
+                    for (size_t Pos = 0; Pos < Program->second.elementary_PIDs.size(); Pos++)
+                    {
+                        int16u elementary_PID = Program->second.elementary_PIDs[Pos];
+                        if (Complete_Stream->Streams[elementary_PID]->StreamKind == Stream_Video && Complete_Stream->Streams[elementary_PID]->IsRegistered)
+                        {
+                            // Video stream is present, finding and filling text streams
+                            for (size_t Pos = 0; Pos < Program->second.elementary_PIDs.size(); Pos++)
+                            {
+                                int16u elementary_PID = Program->second.elementary_PIDs[Pos];
+                                if (Complete_Stream->Streams[elementary_PID]->StreamKind_FromDescriptor == Stream_Text && !Complete_Stream->Streams[elementary_PID]->IsRegistered)
+                                    Streams_Update_Programs_PerStream(elementary_PID);
+                            }
+                            break;
+                        }
+                    }
+                }
+
                 //Per pid
                 Ztring Languages, Codecs, Formats, StreamKinds, StreamPoss, elementary_PIDs, elementary_PIDs_String, Delay, LawRating, Title;
                 for (size_t Pos=0; Pos<Program->second.elementary_PIDs.size(); Pos++)
@@ -763,7 +784,7 @@ void File_MpegTs::Streams_Update_Programs_PerStream(size_t StreamID)
         }
 
         //By the StreamKind
-        if (StreamKind_Last==Stream_Max && Temp->StreamKind_FromDescriptor!=Stream_Max && (Temp->IsRegistered || ForceStreamDisplay || (!Temp->program_numbers.empty() && Complete_Stream->Transport_Streams[Complete_Stream->transport_stream_id].Programs[Temp->program_numbers[0]].registration_format_identifier==Elements::HDMV)))
+        if (StreamKind_Last==Stream_Max && Temp->StreamKind_FromDescriptor!=Stream_Max && (Temp->IsRegistered || ForceStreamDisplay || (ForceTextStreamDisplay && Temp->StreamKind_FromDescriptor==Stream_Text) || (!Temp->program_numbers.empty() && Complete_Stream->Transport_Streams[Complete_Stream->transport_stream_id].Programs[Temp->program_numbers[0]].registration_format_identifier==Elements::HDMV)))
         {
             Stream_Prepare(Temp->StreamKind_FromDescriptor);
         }

--- a/Source/MediaInfo/Multiple/File_MpegTs.h
+++ b/Source/MediaInfo/Multiple/File_MpegTs.h
@@ -109,6 +109,7 @@ private :
     int64u Begin_MaxDuration; //in 27 MHz
     int64u Buffer_TotalBytes_LastSynched;
     bool   ForceStreamDisplay;
+    bool   ForceTextStreamDisplay;
     bool   Searching_TimeStamp_Start;
 
     #if MEDIAINFO_EVENTS


### PR DESCRIPTION
For showing e.g. DVB streams detected in PMT even if there is no PES at the beginning of the file