### PR TITLE
Remove tablegen.c

### DIFF
--- a/Project/BCB/Library/MediaInfoLib.cbproj
+++ b/Project/BCB/Library/MediaInfoLib.cbproj
@@ -758,9 +758,6 @@
 			<CppCompile Include="..\..\..\Source\ThirdParty\aes-gladman\aes_modes.c">
 				<BuildOrder>214</BuildOrder>
 			</CppCompile>
-			<CppCompile Include="..\..\..\Source\ThirdParty\aes-gladman\tablegen.c">
-				<BuildOrder>219</BuildOrder>
-			</CppCompile>
 			<CppCompile Include="..\..\..\Source\ThirdParty\hmac-gladman\hmac.c">
 				<BuildOrder>219</BuildOrder>
 			</CppCompile>


### PR DESCRIPTION
Fix C++Builder warning
[TLIB Warning] Warning: public '_t_rc' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_t_fn' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_t_fl' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_t_in' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_t_il' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_t_im' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_main' in module 'shasum' clashes with prior module 'tablegen'
[TLIB Warning] Warning: public '_t_rc' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_t_fn' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_t_fl' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_t_in' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_t_il' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_t_im' in module 'tablegen' clashes with prior module 'aestab'
[TLIB Warning] Warning: public '_main' in module 'shasum' clashes with prior module 'tablegen'