### PR TITLE
Field names with first letter lower case were not handled

### DIFF
--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -703,7 +703,9 @@ Ztring MediaInfo_Internal::Inform (stream_t StreamKind, size_t StreamPos, bool I
     while (Retour.find(__T('%'), PosX)!=(size_t)-1)
     {
         PosX=Retour.find(__T('%'), PosX);
-        if (Retour.size() > PosX + 2 && Retour[PosX + 1] >= __T('A') && Retour[PosX + 1] <= __T('Z')) //To keep out "%" without any signification
+        if (Retour.size() > PosX + 2
+         && ((Retour[PosX + 1] >= __T('a') && Retour[PosX + 1] <= __T('z'))
+          || (Retour[PosX + 1] >= __T('A') && Retour[PosX + 1] <= __T('Z')))) //To keep out "%" without any signification
         {
             Ztring ARemplacer = Ztring(__T("%") + Retour.SubString(__T("%"), __T("%"), PosX)) + __T("%");
             Ztring RemplacerPar = Get(StreamKind, StreamPos, Retour.SubString(__T("%"), __T("%"), PosX));


### PR DESCRIPTION
in templates

Fixes https://github.com/MediaArea/MediaInfoLib/issues/466