### PR TITLE
Fix resource leak File_Avc::seq_parameter_set

### DIFF
--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -3276,7 +3276,7 @@ void File_Avc::seq_parameter_set()
         if (Null)
             Trusted_IsNot("Should be NULL byte");
     }
-
+    bool use_Data_Item_New = false;
     FILLING_BEGIN_PRECISE();
         //NextCode
         NextCode_Clear();
@@ -3284,6 +3284,7 @@ void File_Avc::seq_parameter_set()
 
         //Add
         seq_parameter_set_data_Add(seq_parameter_sets, seq_parameter_set_id, Data_Item_New);
+        use_Data_Item_New = true;
 
         //Autorisation of other streams
         Streams[0x08].Searching_Payload=true; //pic_parameter_set
@@ -3296,6 +3297,8 @@ void File_Avc::seq_parameter_set()
         if (Streams[0x07].ShouldDuplicate)
             Streams[0x0B].ShouldDuplicate=true; //end_of_stream
     FILLING_END();
+    if (use_Data_Item_New==false)
+        delete Data_Item_New;
 }
 
 void File_Avc::seq_parameter_set_data_Add(std::vector<seq_parameter_set_struct*> &Data, const int32u Data_id, seq_parameter_set_struct* Data_Item_New)


### PR DESCRIPTION
The object (0x2CA17D8) was never deleted
The object (0x02CA17D8) [size: 64 bytes] was created with new
Call Tree:
   0x00AF51F6(=PreRelease.exe:0x01:6F41F6) ..\..\..\Source\MediaInfo\Video\File_Avc.cpp#3765
   0x00AF2EFF(=PreRelease.exe:0x01:6F1EFF) ..\..\..\Source\MediaInfo\Video\File_Avc.cpp#3240
   0x00AE85C9(=PreRelease.exe:0x01:6E75C9) ..\..\..\Source\MediaInfo\Video\File_Avc.cpp#1694
   0x0053DF93(=PreRelease.exe:0x01:13CF93) ..\..\..\Source\MediaInfo\File__Analyze.cpp#2358
   0x00539654(=PreRelease.exe:0x01:138654) ..\..\..\Source\MediaInfo\File__Analyze.cpp#1512
   0x00537122(=PreRelease.exe:0x01:136122) ..\..\..\Source\MediaInfo\File__Analyze.cpp#1082
   0x005332D3(=PreRelease.exe:0x01:1322D3) ..\..\..\Source\MediaInfo\File__Analyze.cpp#695
   0x006BC547(=PreRelease.exe:0x01:2BB547) ..\..\..\Source\MediaInfo\MediaInfo_Internal.cpp#833
   0x00A5B242(=PreRelease.exe:0x01:65A242) ..\..\..\Source\MediaInfo\Reader\Reader_File.cpp#754
   0x00A58DEF(=PreRelease.exe:0x01:657DEF) ..\..\..\Source\MediaInfo\Reader\Reader_File.cpp#291
   0x00698AE8(=PreRelease.exe:0x01:297AE8) ..\..\..\Source\MediaInfo\MediaInfo_File.cpp#884
   0x00A5847C(=PreRelease.exe:0x01:65747C) ..\..\..\Source\MediaInfo\Reader\Reader_File.cpp#208
   0x006BAD19(=PreRelease.exe:0x01:2B9D19) ..\..\..\Source\MediaInfo\MediaInfo_Internal.cpp#625
   0x006B57BB(=PreRelease.exe:0x01:2B47BB) ..\..\..\Source\MediaInfo\MediaInfo_Internal.cpp#380
   0x00649BE1(=PreRelease.exe:0x01:248BE1) ..\..\..\Source\MediaInfo\MediaInfo.cpp#88