### PR TITLE
fix warning C4701

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -1245,7 +1245,7 @@ void File_Mk::Header_Parse()
     }
 
     //Parsing
-    int64u Name, Size = 0;
+    int64u Name = 0, Size = 0;
     bool NameIsValid=true;
     if (Element_Offset+1<Element_Size)
     {


### PR DESCRIPTION
mediainfolib\source\mediainfo\multiple\file_mk.cpp(1274): warning C4701: potentially uninitialized local variable 'Name' used