### PR TITLE
AC-3: crash with some potentially malformed frames

### DIFF
--- a/Source/MediaInfo/Audio/File_Ac3.cpp
+++ b/Source/MediaInfo/Audio/File_Ac3.cpp
@@ -1889,9 +1889,12 @@ void File_Ac3::Core_Frame()
     {
         int16u frmsiz=CC2(Buffer+Buffer_Offset+(size_t)Element_Offset+2)&0x07FF;
         Element_Size=Element_Offset+2+frmsiz*2;
+        if (Element_Size>Element_Size_Save)
+            Element_Size=Element_Size_Save; // Not expected, but trying to parse the begining
     }
 
     //Pre-parsing, finding some elements presence
+    int16u auxdatal;
     if (Buffer[Buffer_Offset+(Element_Size)-3]&0x02) //auxdatae
         auxdatal=(((int16u)Buffer[Buffer_Offset+(Element_Size)-4])<<6)
                 |(         Buffer[Buffer_Offset+(Element_Size)-3] >>2);
@@ -3350,9 +3353,6 @@ void File_Ac3::Core_Frame()
     else
         Skip_XX(Element_Size-Element_Offset,                        "Unknown");
 
-    //true Element_Size is back
-    Element_Size=Element_Size_Save;
-
     if (bsid<=0x10)
     {
         size_t BitsAtEnd=18; //auxdatae+errorcheck
@@ -3376,6 +3376,17 @@ void File_Ac3::Core_Frame()
                 BS_End();
                 Skip_B2(                                            "crc2");
             Element_End0();
+        }
+        else
+        {
+            BS_End();
+            Skip_XX(Element_Size-Element_Offset,                    "Unknown");
+        }
+
+        if (bsid>0x0A) //E-AC-3 only
+        {
+            //true Element_Size is back
+            Element_Size=Element_Size_Save;
         }
     }
 

--- a/Source/MediaInfo/Audio/File_Ac3.h
+++ b/Source/MediaInfo/Audio/File_Ac3.h
@@ -96,9 +96,6 @@ private :
     size_t Save_Buffer_Offset;
     size_t Save_Buffer_Size;
 
-    //Temp auxdata
-    int16u  auxdatal;
-
     //Temp EMDF
     size_t EMDF_RemainPos;
     size_t RemainAfterEMDF;


### PR DESCRIPTION
Fix https://github.com/MediaArea/MediaInfoLib/issues/505, superseding https://github.com/MediaArea/MediaInfoLib/pull/506.