### PR TITLE
WAV: metadata coherency, ignore "fact" chunk more often

### DIFF
--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -3706,7 +3706,7 @@ void File_Riff::WAVE_fact()
                 if (BitRate)
                 {
                     int64u Duration_FromBitRate = File_Size * 8 * 1000 / BitRate;
-                    if (Duration_FromBitRate > Duration*1.10 || Duration_FromBitRate < Duration*0.9)
+                    if (Duration_FromBitRate > Duration*1.02 || Duration_FromBitRate < Duration*0.98)
                         IsOK = false;
                 }
             }


### PR DESCRIPTION
Tolerance range is reduced from 10% to 2% (arbitrary decided)