### PR TITLE
MXF: less false-positive detection of some files as MXF

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mxf.h
+++ b/Source/MediaInfo/Multiple/File_Mxf.h
@@ -1201,6 +1201,7 @@ protected :
 
     //Hints
     size_t* File_Buffer_Size_Hint_Pointer;
+    size_t  Synched_Count;
 
     //Partitions
     struct partition


### PR DESCRIPTION
Probing the first bytes as magic value is not enough.