### PR TITLE
Make template pkg-config file consistent between autotools and cmake

### DIFF
--- a/Project/CMake/libmediainfo.pc.in
+++ b/Project/CMake/libmediainfo.pc.in
@@ -2,10 +2,11 @@ prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=@LIB_INSTALL_DIR@
 includedir=@INCLUDE_INSTALL_DIR@
+Libs_Static=${libdir}/libmediainfo.a ${libdir}/libzen.a -lpthread -lz
 
 Name: libmediainfo
 Version: @MediaInfoLib_VERSION@
 Description: MediaInfoLib
+Requires: libzen zlib @CURL_PC@
 Libs: -L${libdir} -lmediainfo
 Cflags: -I${includedir}
-Requires: libzen @CURL_PC@

--- a/Project/GNU/Library/configure.ac
+++ b/Project/GNU/Library/configure.ac
@@ -506,6 +506,7 @@ elif pkg-config --exists libcurl; then
 		MediaInfoLib_LIBS="$MediaInfoLib_LIBS $(pkg-config --libs libcurl)"
 		MediaInfoLib_LIBS_Static="$MediaInfoLib_LIBS_Static $(pkg-config --libs libcurl)"
 	fi
+	Curl_Require="libcurl"
 elif test -e /usr/bin/curl-config; then
 	CXXFLAGS="$CXXFLAGS $(/usr/bin/curl-config --cflags)"
 	if test "$enable_staticlibs" = "yes"; then
@@ -856,6 +857,7 @@ AC_SUBST(MediaInfoLib_LIBS)
 AC_SUBST(MediaInfoLib_LIBS_Static)
 AC_SUBST(MediaInfoLib_Unicode)
 AC_SUBST(MediaInfoLib_LibName)
+AC_SUBST(Curl_Require)
 AC_CONFIG_FILES(libmediainfo-config, [chmod u+x libmediainfo-config])
 AC_CONFIG_FILES(libmediainfo.pc)
 

--- a/Project/GNU/Library/libmediainfo.pc.in
+++ b/Project/GNU/Library/libmediainfo.pc.in
@@ -3,12 +3,12 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 Unicode=@MediaInfoLib_Unicode@
-Libs_Static=@libdir@/lib@MediaInfoLib_LibName@.a ${libdir}/libzen.a -lpthread -lz
+Libs_Static=${libdir}/lib@MediaInfoLib_LibName@.a ${libdir}/libzen.a -lpthread -lz
 la_name=lib@MediaInfoLib_LibName@.la
 
 Name: libmediainfo
 Version: @PACKAGE_VERSION@
 Description: MediaInfoLib
-Requires: libzen
-Libs: -L@libdir@ -l@MediaInfoLib_LibName@ -lz -lpthread
+Requires: libzen zlib
+Libs: -L@libdir@ -l@MediaInfoLib_LibName@
 Cflags: -I@includedir@ @MediaInfoLib_CXXFLAGS@

--- a/Project/GNU/Library/libmediainfo.pc.in
+++ b/Project/GNU/Library/libmediainfo.pc.in
@@ -9,6 +9,6 @@ la_name=lib@MediaInfoLib_LibName@.la
 Name: libmediainfo
 Version: @PACKAGE_VERSION@
 Description: MediaInfoLib
-Requires: libzen zlib
+Requires: libzen zlib @Curl_Require@
 Libs: -L@libdir@ -l@MediaInfoLib_LibName@
 Cflags: -I@includedir@ @MediaInfoLib_CXXFLAGS@


### PR DESCRIPTION
* Adding Libs_Static to CMake .pc, like in ZenLib
* zlib is a required dependency so it can be hardcoded into Requires
* -lpthread is pulled in from libzen, so it's not needed again

Should be the last modification required.