### PR TITLE
pkg-config: fix build on debian/old RPM

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -348,7 +348,8 @@ if(NOT CURL_FOUND)
 else()
   include_directories(${CURL_INCLUDE_DIRS})
   target_link_libraries(mediainfo "${CURL_LIBRARIES}")
-  set(CURL_PC "libcurl")
+  set(CURL_PC " libcurl")
+  set(CURL_LIB " -lcurl")
 endif()
 
 target_include_directories(mediainfo PRIVATE

--- a/Project/CMake/libmediainfo.pc.in
+++ b/Project/CMake/libmediainfo.pc.in
@@ -2,11 +2,12 @@ prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=@LIB_INSTALL_DIR@
 includedir=@INCLUDE_INSTALL_DIR@
-Libs_Static=${libdir}/libmediainfo.a ${libdir}/libzen.a -lpthread -lz
+Libs_Static=${libdir}/libmediainfo.a ${libdir}/libzen.a -lpthread -lz@CURL_LIB@
 
 Name: libmediainfo
 Version: @MediaInfoLib_VERSION@
 Description: MediaInfoLib
-Requires: libzen zlib @CURL_PC@
-Libs: -L${libdir} -lmediainfo
+Requires: libzen
+Requires.private:@CURL_PC@
+Libs: -L${libdir} -lmediainfo -lz
 Cflags: -I${includedir}

--- a/Project/GNU/Library/configure.ac
+++ b/Project/GNU/Library/configure.ac
@@ -506,7 +506,8 @@ elif pkg-config --exists libcurl; then
 		MediaInfoLib_LIBS="$MediaInfoLib_LIBS $(pkg-config --libs libcurl)"
 		MediaInfoLib_LIBS_Static="$MediaInfoLib_LIBS_Static $(pkg-config --libs libcurl)"
 	fi
-	Curl_Require="libcurl"
+	Curl_Require=" libcurl"
+	Curl_Lib=" -lcurl"
 elif test -e /usr/bin/curl-config; then
 	CXXFLAGS="$CXXFLAGS $(/usr/bin/curl-config --cflags)"
 	if test "$enable_staticlibs" = "yes"; then
@@ -858,6 +859,7 @@ AC_SUBST(MediaInfoLib_LIBS_Static)
 AC_SUBST(MediaInfoLib_Unicode)
 AC_SUBST(MediaInfoLib_LibName)
 AC_SUBST(Curl_Require)
+AC_SUBST(Curl_Lib)
 AC_CONFIG_FILES(libmediainfo-config, [chmod u+x libmediainfo-config])
 AC_CONFIG_FILES(libmediainfo.pc)
 

--- a/Project/GNU/Library/libmediainfo.pc.in
+++ b/Project/GNU/Library/libmediainfo.pc.in
@@ -3,12 +3,13 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 Unicode=@MediaInfoLib_Unicode@
-Libs_Static=${libdir}/lib@MediaInfoLib_LibName@.a ${libdir}/libzen.a -lpthread -lz
+Libs_Static=${libdir}/lib@MediaInfoLib_LibName@.a ${libdir}/libzen.a -lpthread -lz@Curl_Lib@
 la_name=lib@MediaInfoLib_LibName@.la
 
 Name: libmediainfo
 Version: @PACKAGE_VERSION@
 Description: MediaInfoLib
-Requires: libzen zlib @Curl_Require@
-Libs: -L@libdir@ -l@MediaInfoLib_LibName@
+Requires: libzen
+Requires.private:@Curl_Require@
+Libs: -L@libdir@ -l@MediaInfoLib_LibName@ -lz
 Cflags: -I@includedir@ @MediaInfoLib_CXXFLAGS@

--- a/Project/GNU/libmediainfo.spec
+++ b/Project/GNU/libmediainfo.spec
@@ -109,6 +109,16 @@ Summary:        Most relevant technical and tag data for video and audio files -
 Group:          Development/Libraries
 Requires:       %{name}%{?_isa} = %{version}
 Requires:       libzen-devel%{?_isa} >= %{libzen_version}
+%if 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?rhel_version} > 599
+Requires:  libcurl-devel
+%endif
+%if 0%{?centos_version} > 599
+Requires:  libcurl-devel
+%endif
+%else
+Requires:  libcurl-devel
+%endif
 
 %description    -n %{name_without_0_ending}-devel
 MediaInfo is a convenient unified display of the most relevant technical

--- a/Project/OBS/deb6.debian/control
+++ b/Project/OBS/deb6.debian/control
@@ -41,7 +41,7 @@ Description: MediaInfo is a convenient unified display of the most relevant tech
 Package: libmediainfo-dev
 Section: libdevel
 Architecture: any
-Depends: libmediainfo0 (>= 0.7.97), libzen-dev (>= 0.4.35)
+Depends: libmediainfo0 (>= 0.7.97), libzen-dev (>= 0.4.35), libcurl4-gnutls-dev
 Replaces: libmediainfo0-dev
 Description: MediaInfo is a convenient unified display of the most relevant technical
  and tag data for video and audio files.

--- a/Project/OBS/deb9.debian/control
+++ b/Project/OBS/deb9.debian/control
@@ -24,8 +24,9 @@ Package: libmediainfo-dev
 Section: libdevel
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libzen-dev,
-         libmediainfo0v5 (= ${binary:Version}),
+Depends: libmediainfo0v5 (= ${binary:Version}),
+         libzen-dev,
+         libcurl4-gnutls-dev,
          ${misc:Depends}
 Description: library reading metadata from media files -- headers
  MediaInfo is a library used for retrieving technical information and other

--- a/debian/control
+++ b/debian/control
@@ -24,8 +24,9 @@ Package: libmediainfo-dev
 Section: libdevel
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libzen-dev,
-         libmediainfo0 (= ${binary:Version}),
+Depends: libmediainfo0 (= ${binary:Version}),
+         libzen-dev,
+         libcurl4-gnutls-dev,
          ${misc:Depends}
 Description: library reading metadata from media files -- headers
  MediaInfo is a library used for retrieving technical information and other


### PR DESCRIPTION
- zlib .pc isn't aviable on old systems
- pkg-config fail if libcurl .pc is missing

Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>