### PR TITLE
Fix V821

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac_GeneralAudio.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_GeneralAudio.cpp
@@ -291,10 +291,10 @@ void File_Aac::program_config_element()
         if (!Infos["Format_Settings_SBR"].empty())
         {
             Infos["Format_Profile"]=__T("HE-AAC");
-            Ztring SamplingRate=Infos["SamplingRate"];
             Infos["SamplingRate"].From_Number((extension_sampling_frequency_index==(int8u)-1)?(Frequency_b*2):extension_sampling_frequency, 10);
             if (MediaInfoLib::Config.LegacyStreamDisplay_Get())
             {
+                const Ztring SamplingRate = Infos["SamplingRate"];
                 Infos["Format_Profile"]+=__T(" / LC");
                 Infos["SamplingRate"]+=__T(" / ")+SamplingRate;
             }
@@ -306,13 +306,13 @@ void File_Aac::program_config_element()
         if (!Infos["Format_Settings_PS"].empty())
         {
             Infos["Format_Profile"]=__T("HE-AACv2");
-            Ztring Channels=Infos["Channel(s)"];
-            Ztring ChannelPositions=Infos["ChannelPositions"];
-            Ztring SamplingRate=Infos["SamplingRate"];
             Infos["Channel(s)"]=__T("2");
             Infos["ChannelPositions"]=__T("Front: L R");
             if (MediaInfoLib::Config.LegacyStreamDisplay_Get())
             {
+                const Ztring Channels = Infos["Channel(s)"];
+                const Ztring ChannelPositions = Infos["ChannelPositions"];
+                const Ztring SamplingRate = Infos["SamplingRate"];
                 Infos["Format_Profile"]+=__T(" / HE-AAC / LC");
                 Infos["Channel(s)"]+=__T(" / ")+Channels+__T(" / ")+Channels;
                 Infos["ChannelPositions"]+=__T(" / ")+ChannelPositions+__T(" / ")+ChannelPositions;

--- a/Source/MediaInfo/Audio/File_Aac_GeneralAudio_Sbr_Ps.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_GeneralAudio_Sbr_Ps.cpp
@@ -37,13 +37,13 @@ void File_Aac::ps_data(size_t End)
         if (Infos["Format_Settings_PS"].empty())
         {
             Infos["Format_Profile"]=__T("HE-AACv2");
-            Ztring Channels=Infos["Channel(s)"];
-            Ztring ChannelPositions=Infos["ChannelPositions"];
-            Ztring SamplingRate=Infos["SamplingRate"];
             Infos["Channel(s)"]=__T("2");
             Infos["ChannelPositions"]=__T("Front: L R");
             if (MediaInfoLib::Config.LegacyStreamDisplay_Get())
             {
+                const Ztring Channels = Infos["Channel(s)"];
+                const Ztring ChannelPositions = Infos["ChannelPositions"];
+                const Ztring SamplingRate = Infos["SamplingRate"];
                 Infos["Format_Profile"]+=__T(" / HE-AAC / LC");
                 Infos["Channel(s)"]+=__T(" / ")+Channels+__T(" / ")+Channels;
                 Infos["ChannelPositions"]+=__T(" / ")+ChannelPositions+__T(" / ")+ChannelPositions;

--- a/Source/MediaInfo/Audio/File_Aac_Main.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_Main.cpp
@@ -533,10 +533,10 @@ void File_Aac::AudioSpecificConfig_OutOfBand (int64s sampling_frequency_, int8u 
     if (sbrPresentFlag || !Infos["Format_Settings_SBR"].empty())
     {
         Infos["Format_Profile"]=__T("HE-AAC");
-        Ztring SamplingRate_Previous=Infos["SamplingRate"];
         int32u SamplingRate=(extension_sampling_frequency_index==(int8u)-1)?(((int32u)Frequency_b)*2):extension_sampling_frequency;
         if (SamplingRate)
         {
+            const Ztring SamplingRate_Previous = Infos["SamplingRate"];
             Infos["SamplingRate"].From_Number(SamplingRate, 10);
             if (MediaInfoLib::Config.LegacyStreamDisplay_Get())
             {
@@ -554,13 +554,13 @@ void File_Aac::AudioSpecificConfig_OutOfBand (int64s sampling_frequency_, int8u 
     if (psPresentFlag || !Infos["Format_Settings_PS"].empty())
     {
         Infos["Format_Profile"]=__T("HE-AACv2");
-        Ztring Channels=Infos["Channel(s)"];
-        Ztring ChannelPositions=Infos["ChannelPositions"];
-        Ztring SamplingRate_Previous=Infos["SamplingRate"];
         Infos["Channel(s)"]=__T("2");
         Infos["ChannelPositions"]=__T("Front: L R");
         if (MediaInfoLib::Config.LegacyStreamDisplay_Get())
         {
+            const Ztring Channels = Infos["Channel(s)"];
+            const Ztring ChannelPositions = Infos["ChannelPositions"];
+            const Ztring SamplingRate_Previous = Infos["SamplingRate"];
             Infos["Format_Profile"]+=__T(" / HE-AAC / LC");
             Infos["Channel(s)"]+=__T(" / ")+Channels+__T(" / ")+Channels;
             Infos["ChannelPositions"]+=__T(" / ")+ChannelPositions+__T(" / ")+ChannelPositions;

--- a/Source/MediaInfo/MediaInfo_Internal.cpp
+++ b/Source/MediaInfo/MediaInfo_Internal.cpp
@@ -1151,7 +1151,7 @@ Ztring MediaInfo_Internal::Get(stream_t StreamKind, size_t StreamPos, const Stri
     if (Parameter==__T("Inform"))
     {
         CS.Leave();
-        Ztring InformZtring=Inform(StreamKind, StreamPos, true);
+        const Ztring InformZtring=Inform(StreamKind, StreamPos, true);
         CS.Enter();
         size_t Pos=MediaInfoLib::Config.Info_Get(StreamKind).Find(__T("Inform"));
         if (Pos!=Error)

--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -1626,9 +1626,8 @@ void File_DvDif::video_recdate()
 
     Element_Name("video_recdate");
 
-    Ztring Date=recdate();
     if (Recorded_Date_Date.empty())
-        Recorded_Date_Date=Date;
+        Recorded_Date_Date= recdate();
 }
 
 //---------------------------------------------------------------------------
@@ -1642,9 +1641,8 @@ void File_DvDif::video_rectime()
 
     Element_Name("video_rectime");
 
-    Ztring Date=rectime();
     if (Recorded_Date_Time.empty())
-        Recorded_Date_Time=Date;
+        Recorded_Date_Time=rectime();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -4387,10 +4387,10 @@ void File_Mk::CRC32_Check ()
                                 if (Config->TryToFix_Get() && CRC32Compute[i].Computed!=CRC32Compute[i].Expected)
                                 {
                                     size_t NewBuffer_Size=(size_t)(CRC32Compute[i].UpTo-CRC32Compute[i].From);
-                                    int8u* NewBuffer=new int8u[NewBuffer_Size];
                                     File F;
                                     if (F.Open(File_Name))
                                     {
+                                        int8u* NewBuffer = new int8u[NewBuffer_Size];
                                         F.GoTo(CRC32Compute[i].From);
                                         F.Read(NewBuffer, NewBuffer_Size);
                                         int8u Modified=0;
@@ -4402,8 +4402,8 @@ void File_Mk::CRC32_Check ()
                                             Modified^=1<<BitInBytePosition;
                                             FixFile(CRC32Compute[i].From+BytePosition, &Modified, 1)?Param_Info1("Fixed"):Param_Info1("Not fixed");
                                         }
+                                        delete[] NewBuffer; //NewBuffer=NULL;
                                     }
-                                    delete[] NewBuffer; //NewBuffer=NULL;
                                 }
                             #endif //MEDIAINFO_FIXITY
 

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -1046,8 +1046,7 @@ void File_Mpeg4::Streams_Finish()
 
             //Hacks - Before
             Ztring CodecID=Retrieve(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_CodecID));
-            Ztring Source=Retrieve(StreamKind_Last, StreamPos_Last, "Source");
-            Ztring Source_Info=Retrieve(StreamKind_Last, StreamPos_Last, "Source_Info");
+            const Ztring Source=Retrieve(StreamKind_Last, StreamPos_Last, "Source");
 
             Merge(*Temp->second.MI->Info, Temp->second.StreamKind, 0, Temp->second.StreamPos);
             File_Size_Total+=Ztring(Temp->second.MI->Get(Stream_General, 0, General_FileSize)).To_int64u();
@@ -1062,8 +1061,9 @@ void File_Mpeg4::Streams_Finish()
             }
             if (Source!=Retrieve(StreamKind_Last, StreamPos_Last, "Source"))
             {
-                Ztring Source_Original=Retrieve(StreamKind_Last, StreamPos_Last, "Source");
-                Ztring Source_Original_Info=Retrieve(StreamKind_Last, StreamPos_Last, "Source_Info");
+                const Ztring Source_Original=Retrieve(StreamKind_Last, StreamPos_Last, "Source");
+                const Ztring Source_Original_Info=Retrieve(StreamKind_Last, StreamPos_Last, "Source_Info");
+                const Ztring Source_Info = Retrieve(StreamKind_Last, StreamPos_Last, "Source_Info");
                 Fill(StreamKind_Last, StreamPos_Last, "Source", Source, true);
                 Fill(StreamKind_Last, StreamPos_Last, "Source_Info", Source_Info, true);
                 Fill(StreamKind_Last, StreamPos_Last, "Source_Original", Source_Original, true);

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -6095,7 +6095,7 @@ void File_Mxf::Data_Parse()
         }
 
         //Frame info is specific to the container, and it is not updated
-        frame_info FrameInfo_Temp=FrameInfo;
+        const frame_info FrameInfo_Temp=FrameInfo;
         int64u Frame_Count_NotParsedIncluded_Temp=Frame_Count_NotParsedIncluded;
         if (!IsSub) //Updating for MXF only if MXF is not embedded in another container
         {


### PR DESCRIPTION
Decreased performance. The 'x' variable can be constructed in a lower level scope.
https://www.viva64.com/en/w/v821/print