### PR TITLE
Fix build with C++Builder 10.1

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -976,7 +976,7 @@ void File_Mk::Streams_Finish()
                                         + (s[ 6]-'0')      *10
                                         + (s[ 7]-'0')         ;
                                 for (size_t i=9; i<s_size; i++)
-                                    d+=(s[i]-'0')/pow(10.0, i-8);
+                                    d+=(s[i]-'0')/std::pow(10.0, double(i)-8);
                                 Fill(StreamKind_Last, StreamPos_Last, "Duration", d*1000, s.size()-12);
                                 continue;
                             }

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -3599,7 +3599,7 @@ void File_Riff::WAVE_bext()
             Fill(Stream_Audio, 0, Audio_Delay, float64_int64s(((float64)TimeReference)*1000/SamplesPerSec));
             Fill(Stream_Audio, 0, Audio_Delay_Source, "Container (bext)");
         }
-        if (Version>=1 && UMID1 && UMID2)
+        if (Version>=1 && UMID1 != 0 && UMID2 != 0)
         {
             Ztring UMID=__T("0x")+Ztring().From_Number(UMID1, 16)+Ztring().From_Number(UMID2, 16);
             if ((UMID1.lo&0xFF000000)==0x33000000)


### PR DESCRIPTION
[bcc32 Error] File_Mk.cpp(979): E2015 Ambiguity between 'std::pow(double,double) at c:\bcb10\include\windows\crtl\math.h:245' and 'std::pow(double,int) at c:\bcb10\include\windows\crtl\math.h:417'
[bcc32 Error] File_Mk.cpp(979): E2268 Call to undefined function 'pow'
[bcc32 Error] File_Riff_Elements.cpp(3602): E2096 Illegal structure operation