### PR TITLE
File_Mpegv: small fix ceil

### DIFF
--- a/Source/MediaInfo/Video/File_Mpegv.cpp
+++ b/Source/MediaInfo/Video/File_Mpegv.cpp
@@ -1584,14 +1584,15 @@ void File_Mpegv::Streams_Finish()
     else if (!TimeCodeIsNotTrustable && Time_End_Seconds!=Error && FrameRate)
     {
         TimeCode Time_Begin_TC;
-        Time_Begin_TC.FramesPerSecond=(int8u)ceil(FrameRate);
-        Time_Begin_TC.DropFrame=group_start_IsParsed?group_start_drop_frame_flag:((FrameRate-ceil(FrameRate))?true:false);
+        const int8u ceilFrameRate=(int8u)ceil(FrameRate);
+        Time_Begin_TC.FramesPerSecond=ceilFrameRate;
+        Time_Begin_TC.DropFrame=group_start_IsParsed?group_start_drop_frame_flag:((FrameRate-ceilFrameRate)?true:false);
         Time_Begin_TC.Hours=(int8u)(Time_Begin_Seconds/3600);
         Time_Begin_TC.Minutes=(int8u)((Time_Begin_Seconds%3600)/60);
         Time_Begin_TC.Seconds=(int8u)(Time_Begin_Seconds%60);
         Time_Begin_TC.Frames=(int8u)Time_Begin_Frames;
         TimeCode Time_End_TC;
-        Time_End_TC.FramesPerSecond=(int8u)ceil(FrameRate);
+        Time_End_TC.FramesPerSecond=ceilFrameRate;
         Time_End_TC.DropFrame=Time_Begin_TC.DropFrame;
         Time_End_TC.Hours=(int8u)(Time_End_Seconds/3600);
         Time_End_TC.Minutes=(int8u)((Time_End_Seconds%3600)/60);


### PR DESCRIPTION
 MI count-call(C++Builder CodeGuard)
 fflush (4 times)
 strcmp (81 times)
 strrchr (21 times)
 strncmp (2556 times)
 atan2 (286 times)
 log10 (5740 times)
 ceil (917488 times)
 pow (5777504 times)
 gmtime (4598 times)
 memcmp (130790 times)
 strncpy (39835 times)
 memchr (250680 times)
 sprintf (2007465 times)
 memmove (93454179 times)
 memset (212663 times)
 delete[] (869395 times)
 new[] (869395 times)
 delete (20649151 times)
 SysReallocMem (107 times)
 SysAllocMem (12 times)
 SysFreeMem (4593 times)
 SysGetMem (4582 times)
 strdup (10 times)
 free (37 times)
 _lsetlocale (15 times)
 new (20649160 times)
 calloc (19 times)
 strlen (2381543 times)
 realloc (1 times)
 malloc (7 times)
 memcpy (47544595 times)