### PR TITLE
Fixed undefined reference to File_Wtv

### DIFF
--- a/Source/MediaInfo/File__MultipleParsing.cpp
+++ b/Source/MediaInfo/File__MultipleParsing.cpp
@@ -131,7 +131,7 @@
 #if defined(MEDIAINFO_WM_YES)
     #include "MediaInfo/Multiple/File_Wm.h"
 #endif
-#if defined(MEDIAINFO_WM_YES)
+#if defined(MEDIAINFO_WTV_YES)
     #include "MediaInfo/Multiple/File_Wtv.h"
 #endif
 #if defined(MEDIAINFO_XDCAM_YES)

--- a/Source/MediaInfo/MediaInfo_File.cpp
+++ b/Source/MediaInfo/MediaInfo_File.cpp
@@ -512,7 +512,7 @@ bool MediaInfo_Internal::SelectFromExtension (const String &Parser)
     #if defined(MEDIAINFO_WM_YES)
         else if (Parser==__T("Wm"))          Info=new File_Wm();
     #endif
-    #if defined(MEDIAINFO_WM_YES)
+    #if defined(MEDIAINFO_WTV_YES)
         else if (Parser==__T("Wtv"))         Info=new File_Wtv();
     #endif
     #if defined(MEDIAINFO_XDCAM_YES)


### PR DESCRIPTION
...which is caused by using `MEDIAINFO_WM_YES` instead of `MEDIAINFO_WTV_YES`
