### PR TITLE
VC-3: skip the 4 last bytes of a VC-3 sample in MOV with 2+ frames

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -1488,6 +1488,12 @@ size_t File__Analyze::Merge(File__Analyze &ToAdd, stream_t StreamKind, size_t St
             Fill(Stream_Video, StreamPos_To, Video_DisplayAspectRatio_Original, DisplayAspectRatio_Original, true);
             Fill(Stream_Video, StreamPos_To, Video_DisplayAspectRatio, DisplayAspectRatio_Temp, true);
         }
+        if (!FrameRate_Temp.empty())
+        {
+            const Ztring& FramesPerContainerBlock=Retrieve(Stream_Video, StreamPos_To, "FramesPerContainerBlock");
+            if (!FramesPerContainerBlock.empty())
+                FrameRate_Temp.From_Number(FrameRate_Temp.To_float64()*FramesPerContainerBlock.To_float64());
+        }
         if ((!FrameRate_Temp.empty() && FrameRate_Temp!=Retrieve(Stream_Video, StreamPos_To, Video_FrameRate))
          || (!FrameRate_Num_Temp.empty() && FrameRate_Num_Temp!=Retrieve(Stream_Video, StreamPos_To, Video_FrameRate_Num))
          || (!FrameRate_Den_Temp.empty() && FrameRate_Den_Temp!=Retrieve(Stream_Video, StreamPos_To, Video_FrameRate_Den)))

--- a/Source/MediaInfo/Video/File_Vc3.cpp
+++ b/Source/MediaInfo/Video/File_Vc3.cpp
@@ -606,6 +606,19 @@ bool File_Vc3::Header_Begin()
         {
             Skip_B4(                                                "Frame size?");
             Buffer_Offset+=4;
+
+            if (Frame_Count_InThisBlock==Frame_Count)
+            {
+                Fill(Stream_Video, 0, "FramesPerContainerBlock", Frame_Count_InThisBlock);
+            }
+
+            if (!Status[IsFilled] && Frame_Count>=Frame_Count_Valid && Buffer_Offset+Element_Size>=Buffer_Size)
+            {
+                Fill("VC-3");
+
+                if (!IsSub && Config->ParseSpeed<1.0)
+                    Finish("VC-3");
+            }
         }
     }
 
@@ -701,7 +714,7 @@ void File_Vc3::Data_Parse()
         }
         if (!Status[IsAccepted])
             Accept("VC-3");
-        if (!Status[IsFilled] && Frame_Count>=Frame_Count_Valid)
+        if (!Status[IsFilled] && Frame_Count>=Frame_Count_Valid && Buffer_Offset+Element_Size>=Buffer_Size)
         {
             Fill("VC-3");
 

--- a/Source/MediaInfo/Video/File_Vc3.cpp
+++ b/Source/MediaInfo/Video/File_Vc3.cpp
@@ -539,7 +539,16 @@ void File_Vc3::Streams_Finish()
 #if MEDIAINFO_DEMUX
 bool File_Vc3::Demux_UnpacketizeContainer_Test()
 {
-    //TODO: handling of the extra 4 bytes in a MOV container having 2 frames in a sample (see "Frame size?" part)
+    //Handling of the extra 4 bytes in a MOV container having 2 frames in a sample (see "Frame size?" part)
+    if (IsSub && Buffer_Offset+4==Buffer_Size)
+    {
+        int32u FrameSize=BigEndian2int32u(Buffer+Buffer_Offset);
+        if (FrameSize && (Buffer_Offset%FrameSize)==0) //Checking coherency with last frame size
+        {
+            Skip_B4(                                            "Frame size?");
+            Buffer_Offset+=4;
+        }
+    }
 
     if (Buffer_Offset+0x2C>Buffer_Size)
         return false;
@@ -589,10 +598,15 @@ void File_Vc3::Read_Buffer_Unsynched()
 //---------------------------------------------------------------------------
 bool File_Vc3::Header_Begin()
 {
-    if (IsSub && Buffer_Offset+4==Buffer_Size && BigEndian2int32u(Buffer+Buffer_Offset)*Frame_Count_InThisBlock==Buffer_Offset)
+    //Handling of the extra 4 bytes in a MOV container having 2 frames in a sample
+    if (IsSub && Buffer_Offset+4==Buffer_Size)
     {
-        Skip_B4(                                                "Frame size?");
-        Buffer_Offset+=4;
+        int32u FrameSize=BigEndian2int32u(Buffer+Buffer_Offset);
+        if (FrameSize && (Buffer_Offset%FrameSize)==0)
+        {
+            Skip_B4(                                                "Frame size?");
+            Buffer_Offset+=4;
+        }
     }
 
     if (Buffer_Offset+0x00000280>Buffer_Size)


### PR DESCRIPTION
Looks like the 4 last bytes are the size of a frame