### PR TITLE
AIFF: was not skipping the SSND chunk header during demux, update

### DIFF
--- a/Source/MediaInfo/Multiple/File_Riff.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff.cpp
@@ -979,7 +979,7 @@ void File_Riff::Header_Parse()
             Buffer_DataToParse_End=File_Offset+Buffer_Offset+8+Size_Complete;
         else
             Buffer_DataToParse_End=File_Size; //Found one file with 0 as size of data part
-        Size_Complete=0;
+        Size_Complete=(Name==Elements::AIFF_SSND?8:0);
     }
 
     //Filling


### PR DESCRIPTION
Fix regression after https://github.com/MediaArea/MediaInfoLib/pull/685