### PR TITLE
Fix MXF_MCALabelDictionaryID_ChannelPositions

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -1495,24 +1495,24 @@ static string MXF_MCALabelDictionaryID_ChannelPositions(const std::vector<int128
                 LfeS+="LFE";
         }
         if (!FrontS.empty())
-            ToReturn+=FrontS.c_str();
+            ToReturn+=FrontS;
         if (!SideS.empty())
         {
             if (!ToReturn.empty())
                 ToReturn+=", ";
-            ToReturn+=SideS.c_str();
+            ToReturn+=SideS;
         }
         if (!BackS.empty())
         {
             if (!ToReturn.empty())
                 ToReturn+=", ";
-            ToReturn+=BackS.c_str();
+            ToReturn+=BackS;
         }
         if (!LfeS.empty())
         {
             if (!ToReturn.empty())
                 ToReturn+=", ";
-            ToReturn+=LfeS.c_str();
+            ToReturn+=LfeS;
         }
     }
 


### PR DESCRIPTION
https://www.viva64.com/en/w/v811/print/
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting the 'FrontS.c_str()' expression. file_mxf.cpp 1498
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting the 'SideS.c_str()' expression. file_mxf.cpp 1503
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting the 'BackS.c_str()' expression. file_mxf.cpp 1509
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting the 'LfeS.c_str()' expression. file_mxf.cpp 1515