### PR TITLE
Fix V560 A part of conditional expression is always true

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac_Main.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_Main.cpp
@@ -434,7 +434,7 @@ void File_Aac::AudioSpecificConfig (size_t End)
                     }
                     else
                         extension_sampling_frequency=Aac_sampling_frequency[extension_sampling_frequency_index];
-                    if (End!=(size_t)-1 && Data_BS_Remain()>=End+12)
+                    if (Data_BS_Remain()>=End+12)
                     {
                         int16u syncExtensionType;
                         Get_S2(11,syncExtensionType,            "syncExtensionType");

--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -595,7 +595,7 @@ void File__Analyze::Open_Buffer_Continue (const int8u* ToAdd, size_t ToAdd_Size)
                     AES_Decrypted_Size=ToAdd_Size*2;
                 }
                 AES->cbc_decrypt(ToAdd, AES_Decrypted, (int)ToAdd_Size, AES_IV);    //TODO: handle the case where ToAdd_Size is more than 2GB
-                if (File_Offset+Buffer_Size+ToAdd_Size>=Config->File_Current_Size && ToAdd_Size)
+                if (File_Offset+Buffer_Size+ToAdd_Size>=Config->File_Current_Size)
                 {
                     int8u LastByte=AES_Decrypted[ToAdd_Size-1];
                     ToAdd_Size-=LastByte;

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -2466,7 +2466,7 @@ void MediaInfo_Config_MediaInfo::Event_Send (File__Analyze* Source, const int8u*
             }
             if (Temp->DTS!=(int64u)-1)
             {
-                if (File_IgnoreEditsBefore && File_EditRate)
+                if (File_EditRate)
                 {
                     int64u TimeOffset=float64_int64s(((float64)File_IgnoreEditsBefore)/File_EditRate*1000000000);
                     if (Temp->DTS>TimeOffset)

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -1251,7 +1251,7 @@ void File_Mpeg4::Streams_Finish()
         {
             ReferenceFiles->ParseReferences();
             #if MEDIAINFO_NEXTPACKET
-                if (Config->NextPacket_Get() && ReferenceFiles && ReferenceFiles->Sequences_Size())
+                if (Config->NextPacket_Get() && ReferenceFiles->Sequences_Size())
                 {
                     ReferenceFiles_IsParsing=true;
                     return;

--- a/Source/MediaInfo/Multiple/File_MpegPs.cpp
+++ b/Source/MediaInfo/Multiple/File_MpegPs.cpp
@@ -3823,7 +3823,7 @@ void File_MpegPs::extension_stream()
                                                                 Streams_Extension[stream_id_extension].Parsers.push_back(ChooseParser_DTS());
                                                                 Streams_Extension[stream_id_extension].Parsers.push_back(ChooseParser_AC3());
                                                             }
-                                                            else if (stream_id_extension==0x75 && stream_id_extension<=0x7F)
+                                                            else if (stream_id_extension==0x75)
                                                                  Streams_Extension[stream_id_extension].Parsers.push_back(ChooseParser_VC1());
                                                       }
             }
@@ -3969,7 +3969,7 @@ const ZenLib::Char* File_MpegPs::extension_stream_ChooseExtension()
 {
     //AC3
         if ((stream_id_extension>=0x55 && stream_id_extension<=0x5F)
-         || (stream_id_extension==0x75 && stream_id_extension<=0x7F))
+         || (stream_id_extension==0x75))
         return __T(".vc1");
     //AC3+
     else if (stream_id_extension>=0x60 && stream_id_extension<=0x6F)

--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -1953,7 +1953,7 @@ void File_Avc::slice_header()
             switch(Element_Code)
             {
                 case 5 :    // This is an IDR frame
-                            if (Config->Config_PerPackage && Element_Code==0x05) // First slice of an IDR frame
+                            if (Config->Config_PerPackage) // First slice of an IDR frame
                             {
                                 // IDR
                                 Config->Config_PerPackage->FrameForAlignment(this, true);


### PR DESCRIPTION
V560 A part of conditional expression is always true: Element_Code == 0x05. file_avc.cpp 1956
V560 A part of conditional expression is always true: ReferenceFiles. file_mpeg4.cpp 1254
V560 A part of conditional expression is always true: File_IgnoreEditsBefore. mediainfo_config_mediainfo.cpp 2469
V560 A part of conditional expression is always true: ToAdd_Size. file__analyze.cpp 598
V560 A part of conditional expression is always true: End != (size_t) - 1. file_aac_main.cpp 437
V560 A part of conditional expression is always true: stream_id_extension <= 0x7F. file_mpegps.cpp 3826
V560 A part of conditional expression is always true: stream_id_extension <= 0x7F. file_mpegps.cpp 3972