### PR TITLE
Fix V796 It is possible that 'break'

### DIFF
--- a/Source/MediaInfo/Multiple/File_Lxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Lxf.cpp
@@ -525,6 +525,7 @@ size_t File_Lxf::Read_Buffer_Seek (size_t Method, int64u Value, int64u)
                         float64 TimeStamp=((float64)Value)/FrameRate;
                         Value=float64_int64s(TimeStamp*1000000000); // In nanoseconds
                     }
+                    return 1;
         case 2  :   //Timestamp
                     {
                     if (Value!=(int64u)-1)

--- a/Source/MediaInfo/Tag/File_Id3v2.cpp
+++ b/Source/MediaInfo/Tag/File_Id3v2.cpp
@@ -1203,8 +1203,9 @@ void File_Id3v2::Fill_Name()
         case Elements::TDAT : if (Element_Value.size()==4)
                          {
                             Month.assign(Element_Value.c_str(), 0, 2);
-                            Day.assign  (Element_Value.c_str(), 2, 2); break;
+                            Day.assign  (Element_Value.c_str(), 2, 2);
                          }
+                         break;
         case Elements::TDEN : Normalize_Date(Element_Value); Fill(Stream_General, 0, "Encoded_Date", Element_Value); break;
         case Elements::TDLY : break;
         case Elements::TDOR : Normalize_Date(Element_Value); Fill(Stream_General, 0, "Original/Released_Date", Element_Value); break;
@@ -1218,8 +1219,9 @@ void File_Id3v2::Fill_Name()
         case Elements::TIME : if (Element_Value.size()==4)
                          {
                             Hour.assign  (Element_Value.c_str(), 0, 2);
-                            Minute.assign(Element_Value.c_str(), 2, 2); break;
+                            Minute.assign(Element_Value.c_str(), 2, 2);
                          }
+                         break;
         case Elements::TIPL : Fill(Stream_General, 0, General_ThanksTo, Element_Value); break;
         case Elements::TIT1 : Fill(Stream_General, 0, General_Grouping, Element_Value); break;
         case Elements::TIT2 : Fill(Stream_General, 0, General_Track, Element_Value); break;

--- a/Source/MediaInfo/Video/File_Mpegv.cpp
+++ b/Source/MediaInfo/Video/File_Mpegv.cpp
@@ -3107,6 +3107,7 @@ void File_Mpegv::slice_start_macroblock_block(int8u i)
                         }
                         Skip_SB(                                "dct_coefficient sign");
                     }
+                    break;
             default:
                     Element_Info1(Mpegv_dct_coefficients[dct_coefficient].mapped_to2);
                     Element_Info1(Mpegv_dct_coefficients[dct_coefficient].mapped_to3);


### PR DESCRIPTION
V796 It is possible that 'break' statement is missing in switch statement. file_lxf.cpp 527
V796 It is possible that 'break' statement is missing in switch statement. file_mpegv.cpp 3109
V796 It is possible that 'break' statement is missing in switch statement. file_id3v2.cpp 1207
V796 It is possible that 'break' statement is missing in switch statement. file_id3v2.cpp 1222