### PR TITLE
Fix V601 The bool value is implicitly cast to the integer type

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config.h
+++ b/Source/MediaInfo/MediaInfo_Config.h
@@ -343,7 +343,7 @@ private :
     float32         Verbosity;
     float32         Trace_Level;
     int64u          Compat;
-    int64u          Https;
+    bool            Https;
     bool            Trace_TimeSection_OnlyFirstOccurrence;
     std::bitset<32> Trace_Layers; //0-7: Container, 8: Stream
     std::map<Ztring, bool> Trace_Modificators; //If we want to add/remove some details

--- a/Source/MediaInfo/MediaInfo_Internal.cpp
+++ b/Source/MediaInfo/MediaInfo_Internal.cpp
@@ -905,7 +905,7 @@ size_t MediaInfo_Internal::Open_Buffer_Seek (size_t Method, int64u Value, int64u
 {
     CriticalSectionLocker CSL(CS);
     if (Info==NULL)
-        return false;
+        return 0;
 
     return Info->Open_Buffer_Seek(Method, Value, ID);
 }

--- a/Source/MediaInfo/Multiple/File_DvDif.h
+++ b/Source/MediaInfo/Multiple/File_DvDif.h
@@ -244,7 +244,7 @@ protected :
     std::vector<size_t> Video_STA_Errors; //Per STA type
     std::vector<size_t> Video_STA_Errors_Total; //Per STA type
     std::vector<size_t> Audio_Errors; //Per Dseq
-    std::vector<size_t> audio_source_IsPresent;
+    std::vector<bool> audio_source_IsPresent;
     std::vector<bool>   CH_IsPresent;
     std::vector<std::vector<size_t> > Audio_Errors_Total; //Per Channel and Dseq
     std::vector<std::vector<size_t> > Audio_Invalids; //Per Channel and Dseq


### PR DESCRIPTION
V601 The 'true' value is implicitly cast to the integer type. mediainfo_config.cpp 262
V601 The 'false' value is implicitly cast to the integer type. mediainfo_internal.cpp 908
V601 The 'true' value is implicitly cast to the integer type. file_dvdif_analysis.cpp 289
V601 The 'false' value is implicitly cast to the integer type. file_dvdif_analysis.cpp 869