### PR TITLE
MOV: Support of external time code tracks (.qtc)

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -1196,6 +1196,7 @@ void MediaInfo_Config_Format (InfoMap &Info)
     "MPEG-PS;;;M;MpegPs;;mpeg mpg m2p vob pss evo;video/MP2P;\n"
     "MPEG-TS;;;M;MpegTs;;ts m2t m2s m4t m4s tmf ts tp trp ty;video/MP2T;\n"
     "MPEG-4;;;M;Mpeg4;;mov mp4 m4v m4a m4b m4p 3ga 3gpa 3gpp 3gp 3gpp2 3g2 k3g jpm jpx mqv ismv isma ismt f4a f4b f4v;video/mp4;\n"
+    "QuickTime TC;;;M;QuickTimeTC;;qtc;;\n"
     "MTV;;;M;Other;Chinese hack of MPEG-1 layer 3;mtv;;http://en.wikipedia.org/wiki/Chinese_MP4/MTV_Player\n"
     "MXF;;;M;Mxf;;mxf;application/mxf;\n"
     "NSV;;;M;Nsv;Nullsoft Streaming Video;nsv;;http://winamp.com\n"

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -640,6 +640,11 @@ Ztring MediaInfo_Config_MediaInfo::Option (const String &Option, const String &V
     {
         return File_ForceParser_Get();
     }
+    else if (Option_Lower==__T("file_forceparser_config"))
+    {
+        File_ForceParser_Config_Set(Value);
+        return __T("");
+    }
     else if (Option_Lower==__T("file_buffer_size_hint_pointer"))
     {
         File_Buffer_Size_Hint_Pointer_Set((size_t*)Ztring(Value).To_int64u());
@@ -1690,6 +1695,19 @@ Ztring MediaInfo_Config_MediaInfo::File_ForceParser_Get ()
 {
     CriticalSectionLocker CSL(CS);
     return File_ForceParser;
+}
+
+//---------------------------------------------------------------------------
+void MediaInfo_Config_MediaInfo::File_ForceParser_Config_Set (const Ztring &NewValue)
+{
+    CriticalSectionLocker CSL(CS);
+    File_ForceParser_Config=NewValue;
+}
+
+Ztring MediaInfo_Config_MediaInfo::File_ForceParser_Config_Get ()
+{
+    CriticalSectionLocker CSL(CS);
+    return File_ForceParser_Config;
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
@@ -187,6 +187,8 @@ public :
 
     void          File_ForceParser_Set (const Ztring &NewValue);
     Ztring        File_ForceParser_Get ();
+    void          File_ForceParser_Config_Set (const Ztring &NewValue);
+    Ztring        File_ForceParser_Config_Get ();
 
     void          File_Buffer_Size_Hint_Pointer_Set (size_t* NewValue);
     size_t*       File_Buffer_Size_Hint_Pointer_Get ();
@@ -454,6 +456,7 @@ private :
     Ztring                  File_Partial_Begin;
     Ztring                  File_Partial_End;
     Ztring                  File_ForceParser;
+    Ztring                  File_ForceParser_Config;
     size_t*                 File_Buffer_Size_Hint_Pointer;
     size_t                  File_Buffer_Read_Size;
 

--- a/Source/MediaInfo/MediaInfo_File.cpp
+++ b/Source/MediaInfo/MediaInfo_File.cpp
@@ -95,6 +95,9 @@
 #if defined(MEDIAINFO_MPEG4_YES)
     #include "MediaInfo/Multiple/File_Mpeg4.h"
 #endif
+#if defined(MEDIAINFO_MPEG4_YES)
+    #include "MediaInfo/Multiple/File_Mpeg4_TimeCode.h"
+#endif
 #if defined(MEDIAINFO_MPEGPS_YES)
     #include "MediaInfo/Multiple/File_MpegPs.h"
 #endif
@@ -469,6 +472,9 @@ bool MediaInfo_Internal::SelectFromExtension (const String &Parser)
     #endif
     #if defined(MEDIAINFO_MPEG4_YES)
         else if (Parser==__T("Mpeg4"))       Info=new File_Mpeg4();
+    #endif
+    #if defined(MEDIAINFO_MPEG4_YES)
+        else if (Parser==__T("QuickTimeTC")) Info=new File_Mpeg4_TimeCode();
     #endif
     #if defined(MEDIAINFO_MPEGPS_YES)
         else if (Parser==__T("MpegPs"))      Info=new File_MpegPs();

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -1203,6 +1203,20 @@ void File_Mpeg4::Streams_Finish()
                     ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
 
                 sequence* Sequence=new sequence;
+                const Ztring& Format=Retrieve(Stream->second.StreamKind, Stream->second.StreamPos, Fill_Parameter(Stream->second.StreamKind, Generic_Format));
+                if (Format==__T("QuickTime TC"))
+                {
+                    Sequence->Config["File_ForceParser"]=Format;
+                    if (Stream->second.Parsers.size()==1)
+                    {
+                        File_Mpeg4_TimeCode* Parser=(File_Mpeg4_TimeCode*)Stream->second.Parsers[0];
+                        ZtringListList Parser_Config;
+                        Parser_Config(__T("NumberOfFrames")).From_Number(Parser->NumberOfFrames);
+                        Parser_Config(__T("DropFrame")).From_Number(Parser->DropFrame?1:0);
+                        Parser_Config(__T("NegativeTimes")).From_Number(Parser->NegativeTimes?1:0);
+                        Sequence->Config["File_ForceParser_Config"]=Parser_Config.Read();
+                    }
+                }
                 Sequence->AddFileName(Stream->second.File_Name);
                 Sequence->StreamKind=Stream->second.StreamKind;
                 Sequence->StreamPos=Stream->second.StreamPos;

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -3355,6 +3355,26 @@ void File_Mpeg4::moov_trak_mdia_minf_dinf_dref()
 }
 
 //---------------------------------------------------------------------------
+static const size_t MacAlias_Size=16;
+static const char* MacAlias[MacAlias_Size]=
+{
+    "Directory Name",
+    "Directory IDs",
+    "Absolute Path",
+    "AppleShare Zone Name",
+    "AppleShare Server Name",
+    "AppleShare User Name",
+    "Driver Name",
+    NULL,
+    NULL,
+    "Revised AppleShare info",
+    "AppleRemoteAccess dialup info",
+    NULL,
+    NULL,
+    NULL,
+    "file name (Unicode)?",
+    "volume name (Unicode)?",
+};
 void File_Mpeg4::moov_trak_mdia_minf_dinf_dref_alis()
 {
     NAME_VERSION_FLAG("Alias"); //bit 0 = external/internal data

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -3456,26 +3456,69 @@ void File_Mpeg4::moov_trak_mdia_minf_dinf_dref_alis()
         Skip_XX(99-file_name_string_length,                     "file name string padding (hack)");
     while(Element_Offset<End)
     {
+        Element_Begin0();
         Trusted++;
         int16u type, size;
         Get_B2 (type,                                           "type");
+        if (type==0xFFFF)
+        {
+            Skip_XX(End-Element_Offset,                         "Padding");
+            break;
+        }
+        if (type<MacAlias_Size && MacAlias[type])
+        {
+            Param_Info1(MacAlias[type]);
+            Element_Info1(MacAlias[type]);
+        }
+        else
+            Element_Info1(Ztring::ToZtring(type));
         Get_B2 (size,                                           "size");
         switch (type)
         {
             case 0x0000 :
-                        Get_Local(size, Directory_Name,         "Directory Name");
+                        Get_Local(size, Directory_Name,         "Data");
                         break;
-            case 0x0002 :
-                        Skip_Local(size,                        "Absolute Path");
+            case 0x000E :
+                        {
+                        int16u size2;
+                        Peek_B2(size2);
+                        if (2+size2*2==size)
+                        {
+                            Skip_B2(                            "size2");
+                            Get_UTF16B (size2*2, file_name_string, "Data");
+                        }
+                        else
+                        {
+                            Info_Local(size, Data,              "Data"); //We try, for info...
+                            Element_Info1(Data);
+                        }
+                        }
                         break;
-            case 0xFFFF :
-                        Skip_XX(End-Element_Offset,             "Padding");
+            case 0x000F :
+                        {
+                        int16u size2;
+                        Peek_B2(size2);
+                        if (2+size2*2==size)
+                        {
+                            Skip_B2(                            "size2");
+                            Skip_UTF16B(size2*2,                "Data");
+                        }
+                        else
+                        {
+                            Info_Local(size, Data,              "Data"); //We try, for info...
+                            Element_Info1(Data);
+                        }
+                        }
                         break;
             default     :
-                        Skip_Local(size,                        "Unknown");
+                        {
+                        Info_Local(size, Data,                  "Data"); //We try, for info...
+                        Element_Info1(Data);
+                        }
         }
         if (size%2)
             Skip_B1(                                            "Padding");
+        Element_End0();
     }
     Element_End0();
 

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
@@ -23,6 +23,7 @@
 //---------------------------------------------------------------------------
 #include "MediaInfo/Multiple/File_Mpeg4_TimeCode.h"
 #include "MediaInfo/TimeCode.h"
+#include "MediaInfo/MediaInfo_Config_MediaInfo.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
@@ -77,6 +78,18 @@ void File_Mpeg4_TimeCode::Streams_Fill()
 //***************************************************************************
 
 //---------------------------------------------------------------------------
+void File_Mpeg4_TimeCode::Read_Buffer_Init()
+{
+    ZtringListList Map=Config->File_ForceParser_Config_Get();
+    if (!Map.empty())
+    {
+        NumberOfFrames=Map(__T("NumberOfFrames")).To_int8u();
+        DropFrame=Map(__T("DropFrame")).To_int8u()?true:false;
+        NegativeTimes=Map(__T("NegativeTimes")).To_int8u()?true:false;
+    }
+}
+
+//---------------------------------------------------------------------------
 void File_Mpeg4_TimeCode::Read_Buffer_Continue()
 {
     //Parsing
@@ -89,6 +102,8 @@ void File_Mpeg4_TimeCode::Read_Buffer_Continue()
             Pos=Position;
             if (NegativeTimes)
                 Pos=(int32s)Position;
+            if (Config->ParseSpeed<=1.0 && Element_Offset!=Element_Size)
+                Skip_XX(Element_Size-Element_Offset,            "Other positions");
         }
     }
 

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
@@ -39,6 +39,7 @@ protected :
     void Streams_Fill();
 
     //Buffer - Global
+    void Read_Buffer_Init();
     void Read_Buffer_Continue();
 };
 


### PR DESCRIPTION
https://sourceforge.net/p/mediainfo/feature-requests/522/

+ support of file names >64 chars long or non ASCII for referenced files