### PR TITLE
Permit to compile without referenced files support 

### DIFF
--- a/Project/BCB/Library/MediaInfoLib.cbproj
+++ b/Project/BCB/Library/MediaInfoLib.cbproj
@@ -314,6 +314,10 @@
 				<DependentOn>..\..\..\Source\MediaInfo\File__Duplicate.h</DependentOn>
 				<BuildOrder>47</BuildOrder>
 			</CppCompile>
+			<CppCompile Include="..\..\..\Source\MediaInfo\File__HasReferences.cpp">
+				<DependentOn>..\..\..\Source\MediaInfo\File__HasReferences.h</DependentOn>
+				<BuildOrder>225</BuildOrder>
+			</CppCompile>
 			<CppCompile Include="..\..\..\Source\MediaInfo\File__MultipleParsing.cpp">
 				<BuildOrder>31</BuildOrder>
 			</CppCompile>

--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -125,6 +125,7 @@ set(MediaInfoLib_SRCS
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/File__Base.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/File__MultipleParsing.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/File__Duplicate.cpp
+  ${MediaInfoLib_SOURCES_PATH}/MediaInfo/File__HasReferences.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/File_Dummy.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/File_Other.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/File_Unknown.cpp

--- a/Project/GNU/Library/Makefile.am
+++ b/Project/GNU/Library/Makefile.am
@@ -11,6 +11,7 @@ lib@MediaInfoLib_LibName@_la_SOURCES = \
                        ../../../Source/MediaInfo/File__Base.cpp \
                        ../../../Source/MediaInfo/File__MultipleParsing.cpp \
                        ../../../Source/MediaInfo/File__Duplicate.cpp \
+                       ../../../Source/MediaInfo/File__HasReferences.cpp \
                        ../../../Source/MediaInfo/File_Dummy.cpp \
                        ../../../Source/MediaInfo/File_Other.cpp \
                        ../../../Source/MediaInfo/File_Unknown.cpp \

--- a/Project/MSVC2013/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2013/Library/MediaInfoLib.vcxproj
@@ -149,6 +149,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\File__Analyze_Streams_Finish.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File__Base.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File__Duplicate.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\File__HasReferences.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File__MultipleParsing.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Dummy.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Other.cpp" />
@@ -427,6 +428,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyze_MinimizeSize.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Base.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Duplicate.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\File__HasReferences.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File__MultipleParsing.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Dummy.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Other.h" />

--- a/Project/MSVC2013/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2013/Library/MediaInfoLib.vcxproj.filters
@@ -770,6 +770,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_MiXml.cpp">
       <Filter>Source Files\Multiple</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\File__HasReferences.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyse_Automatic.h">
@@ -1437,6 +1440,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Wtv.h">
       <Filter>Header Files\Multiple</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\File__HasReferences.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Project/MSVC2015/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2015/Library/MediaInfoLib.vcxproj
@@ -149,6 +149,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\File__Analyze_Streams_Finish.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File__Base.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File__Duplicate.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\File__HasReferences.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File__MultipleParsing.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Dummy.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Other.cpp" />
@@ -427,6 +428,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyze_MinimizeSize.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Base.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Duplicate.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\File__HasReferences.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File__MultipleParsing.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Dummy.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Other.h" />

--- a/Project/MSVC2015/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2015/Library/MediaInfoLib.vcxproj.filters
@@ -770,6 +770,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_MiXml.cpp">
       <Filter>Source Files\Multiple</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\File__HasReferences.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyse_Automatic.h">
@@ -1437,6 +1440,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Wtv.h">
       <Filter>Header Files\Multiple</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\File__HasReferences.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Project/MSVC2017/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2017/Library/MediaInfoLib.vcxproj
@@ -149,6 +149,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\File__Analyze_Streams_Finish.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File__Base.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File__Duplicate.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\File__HasReferences.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File__MultipleParsing.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Dummy.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Other.cpp" />
@@ -427,6 +428,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyze_MinimizeSize.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Base.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Duplicate.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\File__HasReferences.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File__MultipleParsing.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Dummy.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Other.h" />

--- a/Project/MSVC2017/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2017/Library/MediaInfoLib.vcxproj.filters
@@ -770,6 +770,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_MiXml.cpp">
       <Filter>Source Files\Multiple</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\File__HasReferences.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyse_Automatic.h">
@@ -1437,6 +1440,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\Multiple\File_Wtv.h">
       <Filter>Header Files\Multiple</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\File__HasReferences.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Source/MediaInfo/Audio/File_Ac3.cpp
+++ b/Source/MediaInfo/Audio/File_Ac3.cpp
@@ -4213,8 +4213,6 @@ bool File_Ac3::FrameSynchPoint_Test()
             Save_Buffer_Offset=Buffer_Offset;
             Save_Buffer_Size=Buffer_Size;
 
-            //Exception handling
-            try
             {
                 int8u* Buffer_Little=new int8u[Size];
                 for (size_t Pos=0; Pos+1<Size; Pos+=2)
@@ -4240,9 +4238,6 @@ bool File_Ac3::FrameSynchPoint_Test()
                 }
 
                 delete[] Buffer_Little;
-            }
-            catch(...)
-            {
             }
             Buffer=Save_Buffer; Save_Buffer=NULL;
             Buffer_Offset=Save_Buffer_Offset;

--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -3350,7 +3350,11 @@ void File__Analyze::GoToFromEnd (int64u GoToFromEnd)
     if (File_Size==(int64u)-1)
     {
         #if MEDIAINFO_SEEK
-            if (Config->File_IgnoreSequenceFileSize_Get() && GoToFromEnd)
+            if (
+                #if MEDIAINFO_ADVANCED
+                Config->File_IgnoreSequenceFileSize_Get() &&
+                #endif //MEDIAINFO_ADVANCED
+                GoToFromEnd)
             {
                 File_GoTo=Config->File_Names.size()-1;
                 File_Offset=(int64u)-1;

--- a/Source/MediaInfo/File__Analyze_Element.cpp
+++ b/Source/MediaInfo/File__Analyze_Element.cpp
@@ -20,7 +20,6 @@
 #include "MediaInfo/File__Analyze.h"
 #include "MediaInfo/File__Analyze_Element.h"
 #include "MediaInfo/MediaInfo_Internal.h"
-#include <iostream>
 #include <iomanip>
 #include <cstring>
 #include "ThirdParty/base64/base64.h"

--- a/Source/MediaInfo/File__HasReferences.cpp
+++ b/Source/MediaInfo/File__HasReferences.cpp
@@ -1,0 +1,80 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//---------------------------------------------------------------------------
+// Pre-compilation
+#include "MediaInfo/PreComp.h"
+#ifdef __BORLANDC__
+    #pragma hdrstop
+#endif
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/Setup.h"
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#if defined(MEDIAINFO_REFERENCES_YES)
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/File__HasReferences.h"
+#include "MediaInfo/Multiple/File__ReferenceFilesHelper.h"
+//---------------------------------------------------------------------------
+
+namespace MediaInfoLib
+{
+
+//***************************************************************************
+// Constructor/Destructor
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+File__HasReferences::File__HasReferences()
+: ReferenceFiles(NULL)
+{
+}
+
+//---------------------------------------------------------------------------
+File__HasReferences::~File__HasReferences()
+{
+    delete ReferenceFiles;
+}
+
+//***************************************************************************
+// Streams management
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+void File__HasReferences::ReferenceFiles_Accept(File__Analyze* MI, MediaInfo_Config_MediaInfo* Config)
+{
+    ReferenceFiles=new File__ReferenceFilesHelper(MI, Config);
+}
+
+//---------------------------------------------------------------------------
+void File__HasReferences::ReferenceFiles_Finish()
+{
+    ReferenceFiles->ParseReferences();
+}
+
+//***************************************************************************
+// Buffer - Global
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+#if defined(MEDIAINFO_REFERENCES_YES) && MEDIAINFO_SEEK
+size_t File__HasReferences::ReferenceFiles_Seek(size_t Method, int64u Value, int64u ID)
+{
+    if (ReferenceFiles==NULL)
+        return 0;
+
+    return ReferenceFiles->Seek(Method, Value, ID);
+}
+#endif //MEDIAINFO_SEEK
+
+} //NameSpace
+
+#endif

--- a/Source/MediaInfo/File__HasReferences.h
+++ b/Source/MediaInfo/File__HasReferences.h
@@ -6,47 +6,47 @@
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 //
-// Information about DASH (.mpd) files
+// Helper class for parser having references to external files
 //
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 //---------------------------------------------------------------------------
-#ifndef MediaInfo_File_DashMpdH
-#define MediaInfo_File_DashMpdH
+#ifndef MediaInfo_File__HasReferencesH
+#define MediaInfo_File__HasReferencesH
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
-#include "MediaInfo/File__Analyze.h"
-#include "MediaInfo/File__HasReferences.h"
+#include "MediaInfo/Setup.h"
+class File__ReferenceFilesHelper;
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
 //***************************************************************************
-// Class File_DashMpd
+// Class File__HasReferences
 //***************************************************************************
 
-class File_DashMpd : public File__Analyze, File__HasReferences
+class File__HasReferences
 {
-public :
+public:
     //Constructor/Destructor
-    File_DashMpd();
+    File__HasReferences();
+    ~File__HasReferences();
 
-private :
-    //Streams management
-    void Streams_Finish () {ReferenceFiles_Finish();}
+    // Streams management
+    void ReferenceFiles_Accept(File__Analyze* MI, MediaInfo_Config_MediaInfo* Config);
+    void ReferenceFiles_Finish();
 
-    //Buffer - Global
-    #if MEDIAINFO_SEEK
-    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID) {return ReferenceFiles_Seek(Method, Value, ID);}
-    #endif //MEDIAINFO_SEEK
+    // Buffer - Global
+    size_t ReferenceFiles_Seek(size_t Method, int64u Value, int64u ID);
 
-    //Buffer - File header
-    bool FileHeader_Begin();
+    //Temp
+    #if defined(MEDIAINFO_REFERENCES_YES)
+    File__ReferenceFilesHelper*     ReferenceFiles;
+    #endif //MEDIAINFO_REFERENCES_YES
 };
 
 } //NameSpace
 
 #endif
-

--- a/Source/MediaInfo/File__HasReferences.h
+++ b/Source/MediaInfo/File__HasReferences.h
@@ -17,16 +17,22 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/Setup.h"
-class File__ReferenceFilesHelper;
+#include "ZenLib/Conf.h"
+using namespace ZenLib;
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
+class File__ReferenceFilesHelper;
+class File__Analyze;
+class MediaInfo_Config_MediaInfo;
+
 //***************************************************************************
 // Class File__HasReferences
 //***************************************************************************
 
+#if defined(MEDIAINFO_REFERENCES_YES)
 class File__HasReferences
 {
 public:
@@ -42,10 +48,20 @@ public:
     size_t ReferenceFiles_Seek(size_t Method, int64u Value, int64u ID);
 
     //Temp
-    #if defined(MEDIAINFO_REFERENCES_YES)
     File__ReferenceFilesHelper*     ReferenceFiles;
-    #endif //MEDIAINFO_REFERENCES_YES
 };
+#else //defined(MEDIAINFO_REFERENCES_YES)
+class File__HasReferences
+{
+public:
+    // Streams management
+    void ReferenceFiles_Accept(File__Analyze*, MediaInfo_Config_MediaInfo*) {}
+    void ReferenceFiles_Finish() {}
+
+    // Buffer - Global
+    size_t ReferenceFiles_Seek(size_t Method, int64u Value, int64u ID) {return (size_t)-1;}
+};
+#endif //defined(MEDIAINFO_REFERENCES_YES)
 
 } //NameSpace
 

--- a/Source/MediaInfo/Multiple/File_Aaf.cpp
+++ b/Source/MediaInfo/Multiple/File_Aaf.cpp
@@ -68,15 +68,12 @@ static const char* AAf_tagDECOLOR (int8u tagDECOLOR)
 
 //---------------------------------------------------------------------------
 File_Aaf::File_Aaf()
-:File__Analyze()
+:File__Analyze(), File__HasReferences()
 {
     #if MEDIAINFO_EVENTS
         ParserIDs[0]=MediaInfo_Parser_Aaf;
         StreamIDs_Width[0]=16;
     #endif //MEDIAINFO_EVENTS
-
-    //Temp
-    ReferenceFiles=NULL;
 }
 
 //---------------------------------------------------------------------------
@@ -84,37 +81,7 @@ File_Aaf::~File_Aaf()
 {
     for (size_t Pos=0; Pos<Streams.size(); Pos++)
         delete Streams[Pos];
-
-    delete ReferenceFiles; //ReferenceFiles=NULL;
 }
-
-//***************************************************************************
-// Streams management
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-void File_Aaf::Streams_Finish()
-{
-    if (ReferenceFiles==NULL)
-        return;
-
-    ReferenceFiles->ParseReferences();
-}
-
-//***************************************************************************
-// Buffer - Global
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-#if MEDIAINFO_SEEK
-size_t File_Aaf::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
-{
-    if (ReferenceFiles==NULL)
-        return 0;
-
-    return ReferenceFiles->Seek(Method, Value, ID);
-}
-#endif //MEDIAINFO_SEEK
 
 //***************************************************************************
 // Buffer - File header
@@ -171,7 +138,7 @@ bool File_Aaf::FileHeader_Begin()
     Fill(Stream_General, 0, General_Format, "AAF");
 
     Step=Step_None;
-    ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+    ReferenceFiles_Accept(this, Config);
 
     //All should be OK...
     return true;

--- a/Source/MediaInfo/Multiple/File_Aaf.cpp
+++ b/Source/MediaInfo/Multiple/File_Aaf.cpp
@@ -611,9 +611,11 @@ void File_Aaf::NetworkLocator()
     Ztring Data;
     Get_UTF16L(xxxSize, Data,                                   "Data");
 
+    #if defined(MEDIAINFO_REFERENCES_YES)
     sequence* Sequence=new sequence;
     Sequence->AddFileName(Data);
     ReferenceFiles->AddSequence(Sequence);
+    #endif //MEDIAINFO_REFERENCES_YES
 
     //Locators[Streams[Streams_Pos]->Directory_Pos].EssenceLocator=Data;
 }

--- a/Source/MediaInfo/Multiple/File_Aaf.h
+++ b/Source/MediaInfo/Multiple/File_Aaf.h
@@ -17,19 +17,17 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
-#include <vector>
+#include "MediaInfo/File__HasReferences.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_Aaf
 //***************************************************************************
 
-class File_Aaf : public File__Analyze
+class File_Aaf : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
@@ -38,11 +36,11 @@ public :
 
 private :
     //Streams management
-    void Streams_Finish ();
+    void Streams_Finish() {ReferenceFiles_Finish();}
 
     //Buffer - Global
     #if MEDIAINFO_SEEK
-    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID);
+    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID) {return ReferenceFiles_Seek(Method, Value, ID);}
     #endif //MEDIAINFO_SEEK
     void Read_Buffer_Continue ();
 
@@ -129,7 +127,6 @@ private :
     size_t Streams_Pos;
     size_t Streams_Pos2;
     size_t Directory_Pos;
-    File__ReferenceFilesHelper*     ReferenceFiles;
 
     //Descriptor
     /*

--- a/Source/MediaInfo/Multiple/File_DashMpd.cpp
+++ b/Source/MediaInfo/Multiple/File_DashMpd.cpp
@@ -437,44 +437,7 @@ File_DashMpd::File_DashMpd()
         ParserIDs[0]=MediaInfo_Parser_DashMpd;
         StreamIDs_Width[0]=16;
     #endif //MEDIAINFO_EVENTS
-
-    //Temp
-    ReferenceFiles=NULL;
 }
-
-//---------------------------------------------------------------------------
-File_DashMpd::~File_DashMpd()
-{
-    delete ReferenceFiles; //ReferenceFiles=NULL;
-}
-
-//***************************************************************************
-// Streams management
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-void File_DashMpd::Streams_Finish()
-{
-    if (ReferenceFiles==NULL)
-        return;
-
-    ReferenceFiles->ParseReferences();
-}
-
-//***************************************************************************
-// Buffer - Global
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-#if MEDIAINFO_SEEK
-size_t File_DashMpd::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
-{
-    if (ReferenceFiles==NULL)
-        return 0;
-
-    return ReferenceFiles->Seek(Method, Value, ID);
-}
-#endif //MEDIAINFO_SEEK
 
 //***************************************************************************
 // Buffer - File header
@@ -505,7 +468,7 @@ bool File_DashMpd::FileHeader_Begin()
             Fill(Stream_General, 0, General_Format, "DASH MPD");
             Config->File_ID_OnlyRoot_Set(false);
 
-            ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+            ReferenceFiles_Accept(this, Config);
 
             //Parsing main elements
             Ztring BaseURL;

--- a/Source/MediaInfo/Multiple/File_DashMpd.cpp
+++ b/Source/MediaInfo/Multiple/File_DashMpd.cpp
@@ -44,6 +44,7 @@ using namespace tinyxml2;
 namespace MediaInfoLib
 {
 
+#if defined(MEDIAINFO_REFERENCES_YES)
 //---------------------------------------------------------------------------
 static void DashMpd_Transform (Ztring &Value, std::map<Ztring, Ztring> &Attributes)
 {
@@ -424,6 +425,7 @@ void template_generic::Decode()
             Sequence->AddFileName(BaseURL+media);
     }
 }
+#endif //MEDIAINFO_REFERENCES_YES
 
 //***************************************************************************
 // Constructor/Destructor
@@ -470,6 +472,7 @@ bool File_DashMpd::FileHeader_Begin()
 
             ReferenceFiles_Accept(this, Config);
 
+            #if defined(MEDIAINFO_REFERENCES_YES)
             //Parsing main elements
             Ztring BaseURL;
 
@@ -654,6 +657,7 @@ bool File_DashMpd::FileHeader_Begin()
                     }
                 }
             }
+            #endif //MEDIAINFO_REFERENCES_YES
         }
         else
         {

--- a/Source/MediaInfo/Multiple/File_DcpAm.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpAm.cpp
@@ -116,6 +116,7 @@ bool File_DcpAm::FileHeader_Begin()
     Accept("DcpAm");
     Fill(Stream_General, 0, General_Format, "DCP AM");
     Fill(Stream_General, 0, General_Format_Version, FmtVersion);
+    #if defined(MEDIAINFO_REFERENCES_YES)
     Config->File_ID_OnlyRoot_Set(false);
 
     //Parsing main elements
@@ -191,7 +192,6 @@ bool File_DcpAm::FileHeader_Begin()
         if (!strcmp(AmItemName, "Issuer"))
             Fill(Stream_General, 0, General_EncodedBy, AssetMap_Item->GetText());
     }
-    Element_Offset=File_Size;
 
     //Merging with PKL
     if (PKL_Pos<Streams.size() && Streams[PKL_Pos].ChunkList.size()==1)
@@ -244,8 +244,10 @@ bool File_DcpAm::FileHeader_Begin()
 
         ReferenceFiles->FilesForStorage=true;
     }
+    #endif //MEDIAINFO_REFERENCES_YES
 
     //All should be OK...
+    Element_Offset=File_Size;
     return true;
 }
 

--- a/Source/MediaInfo/Multiple/File_DcpAm.h
+++ b/Source/MediaInfo/Multiple/File_DcpAm.h
@@ -17,24 +17,22 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
+#include "MediaInfo/File__HasReferences.h"
 #include "MediaInfo/Multiple/File_DcpPkl.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_DcpAm
 //***************************************************************************
 
-class File_DcpAm : public File__Analyze
+class File_DcpAm : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
     File_DcpAm();
-    ~File_DcpAm();
 
     //Streams
     File_DcpPkl::streams Streams;
@@ -45,7 +43,7 @@ private :
 
     //Buffer - Global
     #if MEDIAINFO_SEEK
-    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID);
+    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID) {return ReferenceFiles_Seek(Method, Value, ID);}
     #endif //MEDIAINFO_SEEK
 
     //Buffer - File header
@@ -54,9 +52,6 @@ private :
     //PKL
     size_t PKL_Pos;
     void MergeFromPkl (File_DcpPkl::streams &StreamsToMerge);
-
-    //Temp
-    File__ReferenceFilesHelper*     ReferenceFiles;
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Multiple/File_DcpCpl.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpCpl.cpp
@@ -24,6 +24,7 @@
 #include "MediaInfo/Multiple/File_DcpCpl.h"
 #include "MediaInfo/Multiple/File_DcpAm.h"
 #include "MediaInfo/MediaInfo.h"
+#include "MediaInfo/MediaInfo_Config_MediaInfo.h"
 #include "MediaInfo/Multiple/File__ReferenceFilesHelper.h"
 #include "MediaInfo/XmlUtils.h"
 #include "ZenLib/Dir.h"
@@ -120,6 +121,7 @@ bool File_DcpCpl::FileHeader_Begin()
 
     Accept("DcpCpl");
     Fill(Stream_General, 0, General_Format, IsDcp?"DCP CPL":"IMF CPL");
+    #if defined(MEDIAINFO_REFERENCES_YES)
     Config->File_ID_OnlyRoot_Set(false);
 
     ReferenceFiles_Accept(this, Config);
@@ -396,8 +398,6 @@ bool File_DcpCpl::FileHeader_Begin()
         }
     }
 
-    Element_Offset=File_Size;
-
     //Getting files names
     FileName Directory(File_Name);
     Ztring DirPath = Directory.Path_Get();
@@ -441,7 +441,10 @@ bool File_DcpCpl::FileHeader_Begin()
                 ReferenceFiles->UpdateMetaDataFromSourceEncoding(EssenceDescriptor->first, "Format_Profile", Jpeg2000_Rsiz((*SubDescriptor)->Jpeg2000_Rsiz));
     #endif //MEDIAINFO_ADVANCED
 
+    #endif //MEDIAINFO_REFERENCES_YES
+
     //All should be OK...
+    Element_Offset=File_Size;
     return true;
 }
 
@@ -450,12 +453,14 @@ bool File_DcpCpl::FileHeader_Begin()
 //***************************************************************************
 
 //---------------------------------------------------------------------------
+#if defined(MEDIAINFO_REFERENCES_YES)
 void File_DcpCpl::MergeFromAm (File_DcpPkl::streams &StreamsToMerge)
 {
     for (File_DcpPkl::streams::iterator StreamToMerge=StreamsToMerge.begin(); StreamToMerge!=StreamsToMerge.end(); ++StreamToMerge)
         if (!StreamToMerge->ChunkList.empty()) // Note: ChunkLists with more than 1 file are not yet supported)
             ReferenceFiles->UpdateFileName(Ztring().From_UTF8(StreamToMerge->Id), Ztring().From_UTF8(StreamToMerge->ChunkList[0].Path));
 }
+#endif //MEDIAINFO_REFERENCES_YES
 
 } //NameSpace
 

--- a/Source/MediaInfo/Multiple/File_DcpCpl.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpCpl.cpp
@@ -58,45 +58,9 @@ File_DcpCpl::File_DcpCpl()
         Demux_EventWasSent_Accept_Specific=true;
     #endif //MEDIAINFO_DEMUX
 
-    //Temp
-    ReferenceFiles=NULL;
     //PKL
     PKL_Pos = (size_t)-1;
 }
-
-//---------------------------------------------------------------------------
-File_DcpCpl::~File_DcpCpl()
-{
-    delete ReferenceFiles; //ReferenceFiles=NULL;
-}
-
-//***************************************************************************
-// Streams management
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-void File_DcpCpl::Streams_Finish()
-{
-    if (ReferenceFiles==NULL)
-        return;
-
-    ReferenceFiles->ParseReferences();
-}
-
-//***************************************************************************
-// Buffer - Global
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-#if MEDIAINFO_SEEK
-size_t File_DcpCpl::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
-{
-    if (ReferenceFiles==NULL)
-        return 0;
-
-    return ReferenceFiles->Seek(Method, Value, ID);
-}
-#endif //MEDIAINFO_SEEK
 
 //---------------------------------------------------------------------------
 
@@ -158,7 +122,7 @@ bool File_DcpCpl::FileHeader_Begin()
     Fill(Stream_General, 0, General_Format, IsDcp?"DCP CPL":"IMF CPL");
     Config->File_ID_OnlyRoot_Set(false);
 
-    ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+    ReferenceFiles_Accept(this, Config);
 
     //Parsing main elements
     for (XMLElement* CompositionPlaylist_Item=Root->FirstChildElement(); CompositionPlaylist_Item; CompositionPlaylist_Item=CompositionPlaylist_Item->NextSiblingElement())

--- a/Source/MediaInfo/Multiple/File_DcpCpl.h
+++ b/Source/MediaInfo/Multiple/File_DcpCpl.h
@@ -17,33 +17,30 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
+#include "MediaInfo/File__HasReferences.h"
 #include "MediaInfo/Multiple/File_DcpPkl.h"
-#include <vector>
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_DcpCpl
 //***************************************************************************
 
-class File_DcpCpl : public File__Analyze
+class File_DcpCpl : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
     File_DcpCpl();
-    ~File_DcpCpl();
 
 private :
     //Streams management
-    void Streams_Finish ();
+    void Streams_Finish() {ReferenceFiles_Finish();}
 
     //Buffer - Global
     #if MEDIAINFO_SEEK
-    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID);
+    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID) {return ReferenceFiles_Seek(Method, Value, ID);}
     #endif //MEDIAINFO_SEEK
 
     //Buffer - File header
@@ -54,7 +51,6 @@ private :
     void MergeFromAm (File_DcpPkl::streams &StreamsToMerge);
 
     //Temp
-    File__ReferenceFilesHelper*     ReferenceFiles;
     #if MEDIAINFO_ADVANCED
         struct descriptor
         {

--- a/Source/MediaInfo/Multiple/File_DcpPkl.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpPkl.cpp
@@ -123,6 +123,7 @@ bool File_DcpPkl::FileHeader_Begin()
 
     Accept("DcpPkl");
     Fill(Stream_General, 0, General_Format, "DCP PKL");
+    #if defined(MEDIAINFO_REFERENCES_YES)
     Config->File_ID_OnlyRoot_Set(false);
 
     //Parsing main elements
@@ -177,7 +178,6 @@ bool File_DcpPkl::FileHeader_Begin()
             }
         }
     }
-    Element_Offset=File_Size;
 
     //Merging with Assetmap
     if (!Config->File_IsReferenced_Get())
@@ -234,8 +234,10 @@ bool File_DcpPkl::FileHeader_Begin()
 
         ReferenceFiles->FilesForStorage=true;
     }
+    #endif //MEDIAINFO_REFERENCES_YES
 
     //All should be OK...
+    Element_Offset=File_Size;
     return true;
 }
 

--- a/Source/MediaInfo/Multiple/File_DcpPkl.cpp
+++ b/Source/MediaInfo/Multiple/File_DcpPkl.cpp
@@ -44,7 +44,7 @@ namespace MediaInfoLib
 
 //---------------------------------------------------------------------------
 File_DcpPkl::File_DcpPkl()
-:File__Analyze()
+:File__Analyze(), File__HasReferences()
 {
     #if MEDIAINFO_EVENTS
         ParserIDs[0]=MediaInfo_Parser_DcpPkl;
@@ -53,15 +53,6 @@ File_DcpPkl::File_DcpPkl()
     #if MEDIAINFO_DEMUX
         Demux_EventWasSent_Accept_Specific=true;
     #endif //MEDIAINFO_DEMUX
-
-    //Temp
-    ReferenceFiles=NULL;
-}
-
-//---------------------------------------------------------------------------
-File_DcpPkl::~File_DcpPkl()
-{
-    delete ReferenceFiles; //ReferenceFiles=NULL;
 }
 
 //***************************************************************************
@@ -71,10 +62,10 @@ File_DcpPkl::~File_DcpPkl()
 //---------------------------------------------------------------------------
 void File_DcpPkl::Streams_Finish()
 {
-    if (Config->File_IsReferenced_Get() || ReferenceFiles==NULL)
+    if (Config->File_IsReferenced_Get())
         return;
 
-    ReferenceFiles->ParseReferences();
+    ReferenceFiles_Finish();
 
     // Detection of IMF CPL
     bool IsImf=false;
@@ -97,10 +88,10 @@ void File_DcpPkl::Streams_Finish()
 #if MEDIAINFO_SEEK
 size_t File_DcpPkl::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
 {
-    if (Config->File_IsReferenced_Get() || ReferenceFiles==NULL)
+    if (Config->File_IsReferenced_Get())
         return 0;
 
-    return ReferenceFiles->Seek(Method, Value, ID);
+    return ReferenceFiles_Seek(Method, Value, ID);
 }
 #endif //MEDIAINFO_SEEK
 
@@ -229,7 +220,7 @@ bool File_DcpPkl::FileHeader_Begin()
     //Creating the playlist
     if (!Config->File_IsReferenced_Get())
     {
-        ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+        ReferenceFiles_Accept(this, Config);
 
         for (File_DcpPkl::streams::iterator Stream=Streams.begin(); Stream!=Streams.end(); ++Stream)
             if (Stream->StreamKind==(stream_t)(Stream_Max+1) && Stream->ChunkList.size()==1) // Means CPL

--- a/Source/MediaInfo/Multiple/File_DcpPkl.h
+++ b/Source/MediaInfo/Multiple/File_DcpPkl.h
@@ -17,24 +17,21 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
-#include <vector>
+#include "MediaInfo/File__HasReferences.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_DcpPkl
 //***************************************************************************
 
-class File_DcpPkl : public File__Analyze
+class File_DcpPkl : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
     File_DcpPkl();
-    ~File_DcpPkl();
 
     //Streams
     struct stream
@@ -73,9 +70,6 @@ private :
 
     //AM
     void MergeFromAm (File_DcpPkl::streams &StreamsToMerge);
-
-    //Temp
-    File__ReferenceFilesHelper*     ReferenceFiles;
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Multiple/File_Dxw.cpp
+++ b/Source/MediaInfo/Multiple/File_Dxw.cpp
@@ -49,44 +49,7 @@ File_Dxw::File_Dxw()
     #if MEDIAINFO_DEMUX
         Demux_EventWasSent_Accept_Specific=true;
     #endif //MEDIAINFO_DEMUX
-
-    //Temp
-    ReferenceFiles=NULL;
 }
-
-//---------------------------------------------------------------------------
-File_Dxw::~File_Dxw()
-{
-    delete ReferenceFiles; //ReferenceFiles=NULL;
-}
-
-//***************************************************************************
-// Streams management
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-void File_Dxw::Streams_Finish()
-{
-    if (ReferenceFiles==NULL)
-        return;
-
-    ReferenceFiles->ParseReferences();
-}
-
-//***************************************************************************
-// Buffer - Global
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-#if MEDIAINFO_SEEK
-size_t File_Dxw::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
-{
-    if (ReferenceFiles==NULL)
-        return 0;
-
-    return ReferenceFiles->Seek(Method, Value, ID);
-}
-#endif //MEDIAINFO_SEEK
 
 //***************************************************************************
 // Buffer - File header
@@ -113,7 +76,7 @@ bool File_Dxw::FileHeader_Begin()
             Accept("DXW");
             Fill(Stream_General, 0, General_Format, "DXW");
 
-            ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+            ReferenceFiles_Accept(this, Config);
 
             XMLElement* Track=Root->FirstChildElement();
             while (Track)

--- a/Source/MediaInfo/Multiple/File_Dxw.cpp
+++ b/Source/MediaInfo/Multiple/File_Dxw.cpp
@@ -78,6 +78,7 @@ bool File_Dxw::FileHeader_Begin()
 
             ReferenceFiles_Accept(this, Config);
 
+            #if defined(MEDIAINFO_REFERENCES_YES)
             XMLElement* Track=Root->FirstChildElement();
             while (Track)
             {
@@ -156,6 +157,7 @@ bool File_Dxw::FileHeader_Begin()
 
                 Track=Track->NextSiblingElement();
             }
+            #endif //MEDIAINFO_REFERENCES_YES
         }
         else
         {

--- a/Source/MediaInfo/Multiple/File_Dxw.h
+++ b/Source/MediaInfo/Multiple/File_Dxw.h
@@ -17,39 +17,33 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
-#include <vector>
+#include "MediaInfo/File__HasReferences.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_Dxw
 //***************************************************************************
 
-class File_Dxw : public File__Analyze
+class File_Dxw : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
     File_Dxw();
-    ~File_Dxw();
 
 private :
     //Streams management
-    void Streams_Finish ();
+    void Streams_Finish() {ReferenceFiles_Finish();}
 
     //Buffer - Global
     #if MEDIAINFO_SEEK
-    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID);
+    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID) {return ReferenceFiles_Seek(Method, Value, ID);}
     #endif //MEDIAINFO_SEEK
 
     //Buffer - File header
     bool FileHeader_Begin();
-
-    //Temp
-    File__ReferenceFilesHelper*     ReferenceFiles;
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Multiple/File_HdsF4m.cpp
+++ b/Source/MediaInfo/Multiple/File_HdsF4m.cpp
@@ -40,50 +40,13 @@ namespace MediaInfoLib
 
 //---------------------------------------------------------------------------
 File_HdsF4m::File_HdsF4m()
-:File__Analyze()
+:File__Analyze(), File__HasReferences()
 {
     #if MEDIAINFO_EVENTS
         ParserIDs[0]=MediaInfo_Parser_HdsF4m;
         StreamIDs_Width[0]=16;
     #endif //MEDIAINFO_EVENTS
-
-    //Temp
-    ReferenceFiles=NULL;
 }
-
-//---------------------------------------------------------------------------
-File_HdsF4m::~File_HdsF4m()
-{
-    delete ReferenceFiles; //ReferenceFiles=NULL;
-}
-
-//***************************************************************************
-// Streams management
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-void File_HdsF4m::Streams_Finish()
-{
-    if (ReferenceFiles==NULL)
-        return;
-
-    ReferenceFiles->ParseReferences();
-}
-
-//***************************************************************************
-// Buffer - Global
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-#if MEDIAINFO_SEEK
-size_t File_HdsF4m::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
-{
-    if (ReferenceFiles==NULL)
-        return 0;
-
-    return ReferenceFiles->Seek(Method, Value, ID);
-}
-#endif //MEDIAINFO_SEEK
 
 //***************************************************************************
 // Buffer - File header
@@ -111,7 +74,7 @@ bool File_HdsF4m::FileHeader_Begin()
             Fill(Stream_General, 0, General_Format, "HDS F4M");
             Config->File_ID_OnlyRoot_Set(false);
 
-            ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+            ReferenceFiles_Accept(this, Config);
 
             //Parsing main elements
             Ztring BaseURL;

--- a/Source/MediaInfo/Multiple/File_HdsF4m.cpp
+++ b/Source/MediaInfo/Multiple/File_HdsF4m.cpp
@@ -76,6 +76,7 @@ bool File_HdsF4m::FileHeader_Begin()
 
             ReferenceFiles_Accept(this, Config);
 
+            #if defined(MEDIAINFO_REFERENCES_YES)
             //Parsing main elements
             Ztring BaseURL;
 
@@ -101,6 +102,7 @@ bool File_HdsF4m::FileHeader_Begin()
                     ReferenceFiles->AddSequence(Sequence);
                 }
             }
+            #endif //MEDIAINFO_REFERENCES_YES
         }
         else
         {

--- a/Source/MediaInfo/Multiple/File_HdsF4m.h
+++ b/Source/MediaInfo/Multiple/File_HdsF4m.h
@@ -17,42 +17,33 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
-#include <vector>
+#include "MediaInfo/File__HasReferences.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_HdsF4m
 //***************************************************************************
 
-class File_HdsF4m : public File__Analyze
+class File_HdsF4m : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
     File_HdsF4m();
-    ~File_HdsF4m();
 
 private :
     //Streams management
-    void Streams_Finish ();
+    void Streams_Finish() {ReferenceFiles_Finish();}
 
     //Buffer - Global
     #if MEDIAINFO_SEEK
-    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID);
+    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID) {return ReferenceFiles_Seek(Method, Value, ID);}
     #endif //MEDIAINFO_SEEK
 
     //Buffer - File header
     bool FileHeader_Begin();
-
-    //Helpers
-    void Representation();
-
-    //Temp
-    File__ReferenceFilesHelper*     ReferenceFiles;
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Multiple/File_Hls.cpp
+++ b/Source/MediaInfo/Multiple/File_Hls.cpp
@@ -23,6 +23,7 @@
 //---------------------------------------------------------------------------
 #include "MediaInfo/Multiple/File_Hls.h"
 #include "MediaInfo/MediaInfo.h"
+#include "MediaInfo/MediaInfo_Config_MediaInfo.h"
 #include "MediaInfo/Multiple/File__ReferenceFilesHelper.h"
 #include "ZenLib/File.h"
 #include "ZenLib/Dir.h"
@@ -99,6 +100,8 @@ bool File_Hls::FileHeader_Begin()
     Fill(Stream_General, 0, General_Format, "HLS");
 
     ReferenceFiles_Accept(this, Config);
+
+    #if defined(MEDIAINFO_REFERENCES_YES)
     if (!IsSub)
         ReferenceFiles->ContainerHasNoId=true;
 
@@ -190,6 +193,7 @@ bool File_Hls::FileHeader_Begin()
     {
         Fill(Stream_General, 0, General_Format_Profile, "Master");
     }
+    #endif //MEDIAINFO_REFERENCES_YES
 
     Element_Offset=File_Size;
 

--- a/Source/MediaInfo/Multiple/File_Hls.cpp
+++ b/Source/MediaInfo/Multiple/File_Hls.cpp
@@ -38,7 +38,7 @@ namespace MediaInfoLib
 
 //---------------------------------------------------------------------------
 File_Hls::File_Hls()
-:File__Analyze()
+:File__Analyze(), File__HasReferences()
 {
     #if MEDIAINFO_EVENTS
         ParserIDs[0]=MediaInfo_Parser_Hls;
@@ -47,44 +47,7 @@ File_Hls::File_Hls()
     #if MEDIAINFO_DEMUX
         Demux_EventWasSent_Accept_Specific=true;
     #endif //MEDIAINFO_DEMUX
-
-    //Temp
-    ReferenceFiles=NULL;
 }
-
-//---------------------------------------------------------------------------
-File_Hls::~File_Hls()
-{
-    delete ReferenceFiles; //ReferenceFiles=NULL;
-}
-
-//***************************************************************************
-// Streams management
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-void File_Hls::Streams_Finish()
-{
-    if (ReferenceFiles==NULL)
-        return;
-
-    ReferenceFiles->ParseReferences();
-}
-
-//***************************************************************************
-// Buffer - Global
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-#if MEDIAINFO_SEEK
-size_t File_Hls::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
-{
-    if (ReferenceFiles==NULL)
-        return 0;
-
-    return ReferenceFiles->Seek(Method, Value, ID);
-}
-#endif //MEDIAINFO_SEEK
 
 //***************************************************************************
 // Buffer - File header
@@ -135,7 +98,7 @@ bool File_Hls::FileHeader_Begin()
     Accept("HLS");
     Fill(Stream_General, 0, General_Format, "HLS");
 
-    ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+    ReferenceFiles_Accept(this, Config);
     if (!IsSub)
         ReferenceFiles->ContainerHasNoId=true;
 

--- a/Source/MediaInfo/Multiple/File_Hls.h
+++ b/Source/MediaInfo/Multiple/File_Hls.h
@@ -17,39 +17,33 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
-#include <vector>
+#include "MediaInfo/File__HasReferences.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_Hls
 //***************************************************************************
 
-class File_Hls : public File__Analyze
+class File_Hls : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
     File_Hls();
-    ~File_Hls();
 
 private :
     //Streams management
-    void Streams_Finish ();
+    void Streams_Finish() {ReferenceFiles_Finish();}
 
     //Buffer - Global
     #if MEDIAINFO_SEEK
-    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID);
+    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID) {return ReferenceFiles_Seek(Method, Value, ID);}
     #endif //MEDIAINFO_SEEK
 
     //Buffer - File header
     bool FileHeader_Begin();
-
-    //Temp
-    File__ReferenceFilesHelper*     ReferenceFiles;
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Multiple/File_Ibi.cpp
+++ b/Source/MediaInfo/Multiple/File_Ibi.cpp
@@ -568,18 +568,16 @@ void File_Ibi::CompressedIndex()
     //Sizes
     unsigned long Source_Size=(unsigned long)(Element_Size-Element_Offset);
     unsigned long Dest_Size=(unsigned long)UncompressedSize;
+    if (Dest_Size>=64*1024*1024)
+    {
+        Reject("Ibi");
+        return;
+    }
 
     //Uncompressing
     int8u* Dest;
-    try
     {
         Dest=new int8u[Dest_Size];
-    }
-    catch (...)
-    {
-        //Memory error
-        Reject();
-        return;
     }
     if (uncompress((Bytef*)Dest, &Dest_Size, (const Bytef*)Buffer+Buffer_Offset+(size_t)Element_Offset, Source_Size)<0)
     {

--- a/Source/MediaInfo/Multiple/File_Ism.cpp
+++ b/Source/MediaInfo/Multiple/File_Ism.cpp
@@ -41,7 +41,7 @@ namespace MediaInfoLib
 
 //---------------------------------------------------------------------------
 File_Ism::File_Ism()
-:File__Analyze()
+:File__Analyze(), File__HasReferences()
 {
     #if MEDIAINFO_EVENTS
         ParserIDs[0]=MediaInfo_Parser_Ism;
@@ -50,15 +50,6 @@ File_Ism::File_Ism()
     #if MEDIAINFO_DEMUX
         Demux_EventWasSent_Accept_Specific=true;
     #endif //MEDIAINFO_DEMUX
-
-    //Temp
-    ReferenceFiles=NULL;
-}
-
-//---------------------------------------------------------------------------
-File_Ism::~File_Ism()
-{
-    delete ReferenceFiles; //ReferenceFiles=NULL;
 }
 
 //***************************************************************************
@@ -70,30 +61,6 @@ void File_Ism::Streams_Accept()
 {
     Fill(Stream_General, 0, General_Format, "ISM");
 }
-
-//---------------------------------------------------------------------------
-void File_Ism::Streams_Finish()
-{
-    if (ReferenceFiles==NULL)
-        return;
-
-    ReferenceFiles->ParseReferences();
-}
-
-//***************************************************************************
-// Buffer - Global
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-#if MEDIAINFO_SEEK
-size_t File_Ism::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
-{
-    if (ReferenceFiles==NULL)
-        return 0;
-
-    return ReferenceFiles->Seek(Method, Value, ID);
-}
-#endif //MEDIAINFO_SEEK
 
 //***************************************************************************
 // Buffer - File header
@@ -110,7 +77,7 @@ bool File_Ism::FileHeader_Begin()
         XMLElement* Root=document.FirstChildElement("smil");
         if (Root)
         {
-            ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+            ReferenceFiles_Accept(this, Config);
 
             std::set<Ztring> FileNames;
 

--- a/Source/MediaInfo/Multiple/File_Ism.cpp
+++ b/Source/MediaInfo/Multiple/File_Ism.cpp
@@ -60,6 +60,7 @@ File_Ism::File_Ism()
 void File_Ism::Streams_Accept()
 {
     Fill(Stream_General, 0, General_Format, "ISM");
+    ReferenceFiles_Accept(this, Config);
 }
 
 //***************************************************************************
@@ -77,9 +78,9 @@ bool File_Ism::FileHeader_Begin()
         XMLElement* Root=document.FirstChildElement("smil");
         if (Root)
         {
-            ReferenceFiles_Accept(this, Config);
-
+            #if defined(MEDIAINFO_REFERENCES_YES)
             std::set<Ztring> FileNames;
+            #endif //MEDIAINFO_REFERENCES_YES
 
             XMLElement* Body=Root->FirstChildElement();
             while (Body)
@@ -93,6 +94,7 @@ bool File_Ism::FileHeader_Begin()
                         {
                             Accept("ISM");
 
+                            #if defined(MEDIAINFO_REFERENCES_YES)
                             XMLElement* Stream=Switch->FirstChildElement();
                             while (Stream)
                             {
@@ -137,6 +139,7 @@ bool File_Ism::FileHeader_Begin()
 
                                 Stream=Stream->NextSiblingElement();
                             }
+                            #endif //MEDIAINFO_REFERENCES_YES
                         }
 
                         Switch=Switch->NextSiblingElement();

--- a/Source/MediaInfo/Multiple/File_Ism.h
+++ b/Source/MediaInfo/Multiple/File_Ism.h
@@ -17,39 +17,34 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
+#include "MediaInfo/File__HasReferences.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_Ism
 //***************************************************************************
 
-class File_Ism : public File__Analyze
+class File_Ism : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
     File_Ism();
-    ~File_Ism();
 
 private :
     //Streams management
     void Streams_Accept ();
-    void Streams_Finish ();
+    void Streams_Finish() {ReferenceFiles_Finish();}
 
     //Buffer - Global
     #if MEDIAINFO_SEEK
-    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID);
+    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID) {return ReferenceFiles_Seek(Method, Value, ID);}
     #endif //MEDIAINFO_SEEK
 
     //Buffer - File header
     bool FileHeader_Begin();
-
-    //Temp
-    File__ReferenceFilesHelper*     ReferenceFiles;
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -199,7 +199,7 @@ extern const char* Mpeg4_chan_Layout(int16u Ordering);
 
 //---------------------------------------------------------------------------
 File_Mpeg4::File_Mpeg4()
-:File__Analyze()
+:File__Analyze(), File__HasReferences()
 {
     //Configuration
     ParserName="MPEG-4";
@@ -229,9 +229,6 @@ File_Mpeg4::File_Mpeg4()
     IsFragmented=false;
     StreamOrder=0;
     moov_trak_tkhd_TrackID=(int32u)-1;
-    #if defined(MEDIAINFO_REFERENCES_YES)
-        ReferenceFiles=NULL;
-    #endif //defined(MEDIAINFO_REFERENCES_YES)
     mdat_Pos_NormalParsing=false;
     moof_traf_base_data_offset=(int64u)-1;
     data_offset_present=true;
@@ -1200,7 +1197,7 @@ void File_Mpeg4::Streams_Finish()
             if (!Stream->second.File_Name.empty())
             {
                 if (ReferenceFiles==NULL)
-                    ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+                    ReferenceFiles_Accept(this, Config);
 
                 sequence* Sequence=new sequence;
                 const Ztring& Format=Retrieve(Stream->second.StreamKind, Stream->second.StreamPos, Fill_Parameter(Stream->second.StreamKind, Generic_Format));

--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -11,6 +11,7 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
+#include "MediaInfo/File__HasReferences.h"
 #include "MediaInfo/MediaInfo_Internal.h"
 class File_MpegPs;
 //---------------------------------------------------------------------------
@@ -18,13 +19,11 @@ class File_MpegPs;
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_Mpeg4
 //***************************************************************************
 
-class File_Mpeg4 : public File__Analyze
+class File_Mpeg4 : public File__Analyze, File__HasReferences
 {
 protected :
     //Streams management
@@ -535,9 +534,6 @@ private :
     typedef std::map<int32u, stream> streams;
     streams             Streams;
     streams::iterator   Stream;
-    #if defined(MEDIAINFO_REFERENCES_YES)
-        File__ReferenceFilesHelper* ReferenceFiles;
-    #endif //defined(MEDIAINFO_REFERENCES_YES)
     #if MEDIAINFO_NEXTPACKET
         bool                    ReferenceFiles_IsParsing;
     #endif //MEDIAINFO_NEXTPACKET

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -2136,7 +2136,7 @@ static string Mxf_AcquisitionMetadata_Sony_MonitoringBaseCurve(int128u Value)
 
 //---------------------------------------------------------------------------
 File_Mxf::File_Mxf()
-:File__Analyze()
+:File__Analyze(), File__HasReferences()
 {
     //Configuration
     ParserName="MXF";
@@ -2203,7 +2203,6 @@ File_Mxf::File_Mxf()
     #if MEDIAINFO_ADVANCED
         Footer_Position=(int64u)-1;
     #endif //MEDIAINFO_ADVANCED
-    ReferenceFiles=NULL;
     #if MEDIAINFO_NEXTPACKET
         ReferenceFiles_IsParsing=false;
     #endif //MEDIAINFO_NEXTPACKET
@@ -2240,9 +2239,6 @@ File_Mxf::File_Mxf()
 //---------------------------------------------------------------------------
 File_Mxf::~File_Mxf()
 {
-    #if defined(MEDIAINFO_REFERENCES_YES)
-        delete ReferenceFiles;
-    #endif //defined(MEDIAINFO_REFERENCES_YES)
     #if defined(MEDIAINFO_ANCILLARY_YES)
         if (!Ancillary_IsBinded)
             delete Ancillary;
@@ -17114,7 +17110,7 @@ void File_Mxf::Locators_Test()
 
     if (!Locators.empty() && ReferenceFiles==NULL)
     {
-        ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+        ReferenceFiles_Accept(this, Config);
 
         for (locators::iterator Locator=Locators.begin(); Locator!=Locators.end(); ++Locator)
             if (!Locator->second.IsTextLocator && !Locator->second.EssenceLocator.empty())

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -2411,7 +2411,7 @@ void File_Mxf::Streams_Finish()
 
     //Parsing locators
     Locators_Test();
-    #if MEDIAINFO_NEXTPACKET
+    #if defined(MEDIAINFO_REFERENCES_YES) && MEDIAINFO_NEXTPACKET
         if (Config->NextPacket_Get() && ReferenceFiles)
         {
             ReferenceFiles_IsParsing=true;
@@ -4430,6 +4430,7 @@ void File_Mxf::Read_Buffer_CheckFileModifications()
                                                 Buffer_End=MI.Get(Stream_General, 0, General_FileSize).To_int64u()-MI.Get(Stream_General, 0, General_FooterSize).To_int64u();
                                                 Buffer_End_IsUpdated=true;
                                             }
+                                            #if defined(MEDIAINFO_REFERENCES_YES)
                                             if (!Config->File_IsReferenced_Get() && ReferenceFiles && Retrieve(Stream_General, 0, General_StreamSize).To_int64u())
                                             {
                                                 //Playlist file size is not correctly modified
@@ -4437,6 +4438,7 @@ void File_Mxf::Read_Buffer_CheckFileModifications()
                                                 File_Size=Retrieve(Stream_General, 0, General_StreamSize).To_int64u();
                                                 Config->File_Size+=File_Size;
                                             }
+                                            #endif //MEDIAINFO_REFERENCES_YES
                                         }
                                         }
                                         break;

--- a/Source/MediaInfo/Multiple/File_Mxf.h
+++ b/Source/MediaInfo/Multiple/File_Mxf.h
@@ -17,6 +17,7 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
+#include "MediaInfo/File__HasReferences.h"
 #if defined(MEDIAINFO_ANCILLARY_YES)
     #include <MediaInfo/Multiple/File_Ancillary.h>
 #endif //defined(MEDIAINFO_ANCILLARY_YES)
@@ -30,13 +31,11 @@
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_Mxf
 //***************************************************************************
 
-class File_Mxf : public File__Analyze
+class File_Mxf : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
@@ -924,7 +923,6 @@ protected :
     };
     typedef std::map<int128u, locator> locators; //Key is InstanceUID of the locator
     locators Locators;
-    File__ReferenceFilesHelper* ReferenceFiles;
     #if MEDIAINFO_NEXTPACKET
         bool                    ReferenceFiles_IsParsing;
     #endif //MEDIAINFO_NEXTPACKET

--- a/Source/MediaInfo/Multiple/File_P2_Clip.cpp
+++ b/Source/MediaInfo/Multiple/File_P2_Clip.cpp
@@ -39,7 +39,7 @@ namespace MediaInfoLib
 
 //---------------------------------------------------------------------------
 File_P2_Clip::File_P2_Clip()
-:File__Analyze()
+:File__Analyze(), File__HasReferences()
 {
     #if MEDIAINFO_EVENTS
         ParserIDs[0]=MediaInfo_Parser_None; //TODO
@@ -48,44 +48,7 @@ File_P2_Clip::File_P2_Clip()
     #if MEDIAINFO_DEMUX
         Demux_EventWasSent_Accept_Specific=true;
     #endif //MEDIAINFO_DEMUX
-
-    //Temp
-    ReferenceFiles=NULL;
 }
-
-//---------------------------------------------------------------------------
-File_P2_Clip::~File_P2_Clip()
-{
-    delete ReferenceFiles; //ReferenceFiles=NULL;
-}
-
-//***************************************************************************
-// Streams management
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-void File_P2_Clip::Streams_Finish()
-{
-    if (ReferenceFiles==NULL)
-        return;
-
-    ReferenceFiles->ParseReferences();
-}
-
-//***************************************************************************
-// Buffer - Global
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-#if MEDIAINFO_SEEK
-size_t File_P2_Clip::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
-{
-    if (ReferenceFiles==NULL)
-        return 0;
-
-    return ReferenceFiles->Seek(Method, Value, ID);
-}
-#endif //MEDIAINFO_SEEK
 
 //***************************************************************************
 // Buffer - File header
@@ -123,7 +86,7 @@ bool File_P2_Clip::FileHeader_Begin()
             Accept("P2_Clip");
             Fill(Stream_General, 0, General_Format, "P2 Clip");
 
-            ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+            ReferenceFiles_Accept(this, Config);
 
             XMLElement* ClipContent=Root->FirstChildElement("ClipContent");
             if (ClipContent)

--- a/Source/MediaInfo/Multiple/File_P2_Clip.cpp
+++ b/Source/MediaInfo/Multiple/File_P2_Clip.cpp
@@ -88,6 +88,7 @@ bool File_P2_Clip::FileHeader_Begin()
 
             ReferenceFiles_Accept(this, Config);
 
+            #if defined(MEDIAINFO_REFERENCES_YES)
             XMLElement* ClipContent=Root->FirstChildElement("ClipContent");
             if (ClipContent)
             {
@@ -380,6 +381,7 @@ bool File_P2_Clip::FileHeader_Begin()
                     }
                 }
             }
+            #endif //MEDIAINFO_REFERENCES_YES
         }
         else
         {

--- a/Source/MediaInfo/Multiple/File_P2_Clip.h
+++ b/Source/MediaInfo/Multiple/File_P2_Clip.h
@@ -17,40 +17,34 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
-#include <vector>
+#include "MediaInfo/File__HasReferences.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_P2_Clip
 //***************************************************************************
-class File_P2_Clip : public File__Analyze
+class File_P2_Clip : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
     File_P2_Clip();
-    ~File_P2_Clip();
 
 private :
     //Streams management
-    void Streams_Finish ();
+    void Streams_Finish() {ReferenceFiles_Finish();}
 
     //Buffer - Global
     #if MEDIAINFO_SEEK
-    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID);
+    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID) {return ReferenceFiles_Seek(Method, Value, ID);}
     #endif //MEDIAINFO_SEEK
 
     //Buffer - File header
     bool FileHeader_Begin();
 
     void FillContentDate(tinyxml2::XMLElement* Access, const char* Node, general Parameter);
-
-    //Temp
-    File__ReferenceFilesHelper*     ReferenceFiles;
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Multiple/File_Ptx.cpp
+++ b/Source/MediaInfo/Multiple/File_Ptx.cpp
@@ -458,6 +458,7 @@ void File_Ptx::Read_Buffer_Continue()
         Fill(Stream_General, 0, General_Encoded_Library_Name, LibraryName);
         Fill(Stream_General, 0, General_Encoded_Library_Version, LibraryVersion);
 
+        #if defined(MEDIAINFO_REFERENCES_YES)
         // Role==2 + Purpose==EWAV + listed
         if (Names.size()>1 || FileNames.size()==1)
         {
@@ -601,6 +602,7 @@ void File_Ptx::Read_Buffer_Continue()
                 }
             }
         }
+        #endif //MEDIAINFO_REFERENCES_YES
     FILLING_END();
 }
 

--- a/Source/MediaInfo/Multiple/File_Ptx.cpp
+++ b/Source/MediaInfo/Multiple/File_Ptx.cpp
@@ -35,44 +35,13 @@ namespace MediaInfoLib
 
 //---------------------------------------------------------------------------
 File_Ptx::File_Ptx()
-:File__Analyze()
+:File__Analyze(), File__HasReferences()
 {
     #if MEDIAINFO_EVENTS
         ParserIDs[0]=MediaInfo_Parser_Ptx;
         StreamIDs_Width[0]=sizeof(size_t);
     #endif //MEDIAINFO_EVENTS
-
-    //Temp
-    ReferenceFiles=NULL;
 }
-
-//---------------------------------------------------------------------------
-File_Ptx::~File_Ptx()
-{
-    delete ReferenceFiles; //ReferenceFiles=NULL;
-}
-
-//***************************************************************************
-// Streams management
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-void File_Ptx::Streams_Finish()
-{
-    ReferenceFiles->ParseReferences();
-}
-
-//***************************************************************************
-// Buffer - Global
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-#if MEDIAINFO_SEEK
-size_t File_Ptx::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
-{
-    return ReferenceFiles->Seek(Method, Value, ID);
-}
-#endif //MEDIAINFO_SEEK
 
 //***************************************************************************
 // Buffer - File header
@@ -117,7 +86,7 @@ bool File_Ptx::FileHeader_Begin()
     if (Buffer_Size<File_Size)
         return false; //Must wait for more data
 
-    ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+    ReferenceFiles_Accept(this, Config);
 
     //All should be OK...
     return true;

--- a/Source/MediaInfo/Multiple/File_Ptx.h
+++ b/Source/MediaInfo/Multiple/File_Ptx.h
@@ -17,41 +17,34 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
-#include <vector>
+#include "MediaInfo/File__HasReferences.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_Ptx
 //***************************************************************************
 
-class File_Ptx : public File__Analyze
+class File_Ptx : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
     File_Ptx();
-    ~File_Ptx();
 
 private :
     //Streams management
-    void Streams_Finish ();
+    void Streams_Finish() {ReferenceFiles_Finish();}
 
     //Buffer - Global
     #if MEDIAINFO_SEEK
-    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID);
+    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID) {return ReferenceFiles_Seek(Method, Value, ID);}
     #endif //MEDIAINFO_SEEK
     void Read_Buffer_Continue ();
 
     //Buffer - File header
     bool FileHeader_Begin();
-
-    //Temp
-    File__ReferenceFilesHelper*     ReferenceFiles;
-    friend class File_DpcCpl;   //Theses classes need access to internal structure for optimization. There is recursivity with theses formats
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Multiple/File_SequenceInfo.cpp
+++ b/Source/MediaInfo/Multiple/File_SequenceInfo.cpp
@@ -69,6 +69,7 @@ bool File_SequenceInfo::FileHeader_Begin()
 
             ReferenceFiles_Accept(this, Config);
 
+            #if defined(MEDIAINFO_REFERENCES_YES)
             sequence* Sequence=new sequence;
             Sequence->StreamKind=Stream_Video;
 
@@ -190,6 +191,7 @@ bool File_SequenceInfo::FileHeader_Begin()
                         ReferenceFiles->AddSequence(Sequence);
                 }
             }
+            #endif //MEDIAINFO_REFERENCES_YES
         }
         else
         {

--- a/Source/MediaInfo/Multiple/File_SequenceInfo.cpp
+++ b/Source/MediaInfo/Multiple/File_SequenceInfo.cpp
@@ -42,49 +42,12 @@ namespace MediaInfoLib
 
 //---------------------------------------------------------------------------
 File_SequenceInfo::File_SequenceInfo()
-:File__Analyze()
+:File__Analyze(), File__HasReferences()
 {
     #if MEDIAINFO_DEMUX
         Demux_EventWasSent_Accept_Specific=true;
     #endif //MEDIAINFO_DEMUX
-
-    //Temp
-    ReferenceFiles=NULL;
 }
-
-//---------------------------------------------------------------------------
-File_SequenceInfo::~File_SequenceInfo()
-{
-    delete ReferenceFiles; //ReferenceFiles=NULL;
-}
-
-//***************************************************************************
-// Streams management
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-void File_SequenceInfo::Streams_Finish()
-{
-    if (ReferenceFiles==NULL)
-        return;
-
-    ReferenceFiles->ParseReferences();
-}
-
-//***************************************************************************
-// Buffer - Global
-//***************************************************************************
-
-//---------------------------------------------------------------------------
-#if MEDIAINFO_SEEK
-size_t File_SequenceInfo::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
-{
-    if (ReferenceFiles==NULL)
-        return 0;
-
-    return ReferenceFiles->Seek(Method, Value, ID);
-}
-#endif //MEDIAINFO_SEEK
 
 //***************************************************************************
 // Buffer - File header
@@ -104,7 +67,7 @@ bool File_SequenceInfo::FileHeader_Begin()
             Accept("SequenceInfo");
             Fill(Stream_General, 0, General_Format, "SequenceInfo");
 
-            ReferenceFiles=new File__ReferenceFilesHelper(this, Config);
+            ReferenceFiles_Accept(this, Config);
 
             sequence* Sequence=new sequence;
             Sequence->StreamKind=Stream_Video;

--- a/Source/MediaInfo/Multiple/File_SequenceInfo.h
+++ b/Source/MediaInfo/Multiple/File_SequenceInfo.h
@@ -17,39 +17,33 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
-#include <vector>
+#include "MediaInfo/File__HasReferences.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
-class File__ReferenceFilesHelper;
-
 //***************************************************************************
 // Class File_SequenceInfo
 //***************************************************************************
 
-class File_SequenceInfo : public File__Analyze
+class File_SequenceInfo : public File__Analyze, File__HasReferences
 {
 public :
     //Constructor/Destructor
     File_SequenceInfo();
-    ~File_SequenceInfo();
 
 private :
     //Streams management
-    void Streams_Finish ();
+    void Streams_Finish() {ReferenceFiles_Finish();}
 
     //Buffer - Global
     #if MEDIAINFO_SEEK
-    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID);
+    size_t Read_Buffer_Seek (size_t Method, int64u Value, int64u ID) {return ReferenceFiles_Seek(Method, Value, ID);}
     #endif //MEDIAINFO_SEEK
 
     //Buffer - File header
     bool FileHeader_Begin();
-
-    //Temp
-    File__ReferenceFilesHelper*     ReferenceFiles;
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.h
+++ b/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.h
@@ -9,6 +9,8 @@
 #define File__ReferenceFilesHelperH
 //---------------------------------------------------------------------------
 
+#if defined(MEDIAINFO_REFERENCES_YES)
+
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
 #include "MediaInfo/MediaInfo_Internal.h"
@@ -104,5 +106,7 @@ private :
 };
 
 } //NameSpace
+
+#endif //MEDIAINFO_REFERENCES_YES
 
 #endif


### PR DESCRIPTION
Slightly reduce size
Avoid system errors when there is no file API (e.g. JavaScript)