### PR TITLE
Add matching #ifdefs to bring the headers and code in line (to fix bu…

### DIFF
--- a/Source/MediaInfo/MediaInfo_Internal.cpp
+++ b/Source/MediaInfo/MediaInfo_Internal.cpp
@@ -1146,6 +1146,7 @@ Ztring MediaInfo_Internal::Get(stream_t StreamKind, size_t StreamPos, const Stri
 
     //Special cases
     //-Inform for a stream
+#if defined(MEDIAINFO_TEXT_YES) || defined(MEDIAINFO_HTML_YES) || defined(MEDIAINFO_XML_YES) || defined(MEDIAINFO_CSV_YES) || defined(MEDIAINFO_CUSTOM_YES)
     if (Parameter==__T("Inform"))
     {
         CS.Leave();
@@ -1155,6 +1156,7 @@ Ztring MediaInfo_Internal::Get(stream_t StreamKind, size_t StreamPos, const Stri
         if (Pos!=Error)
             Stream[StreamKind][StreamPos](Pos)=InformZtring;
     }
+#endif
 
     //Case of specific info
     size_t ParameterI=MediaInfoLib::Config.Info_Get(StreamKind).Find(Parameter, KindOfSearch);

--- a/Source/MediaInfo/MediaInfo_Internal.h
+++ b/Source/MediaInfo/MediaInfo_Internal.h
@@ -79,7 +79,9 @@ public :
 
     //General information
     Ztring  Inform ();
+#if defined(MEDIAINFO_TEXT_YES) || defined(MEDIAINFO_HTML_YES) || defined(MEDIAINFO_XML_YES) || defined(MEDIAINFO_CSV_YES) || defined(MEDIAINFO_CUSTOM_YES)
     Ztring  Inform (stream_t StreamKind, size_t StreamNumber, bool IsDirect); //All about only a specific stream
+#endif
 
     //Get
     Ztring Get (stream_t StreamKind, size_t StreamNumber, size_t Parameter, info_t InfoKind=Info_Text);

--- a/Source/MediaInfo/Multiple/File_MpegPs.cpp
+++ b/Source/MediaInfo/Multiple/File_MpegPs.cpp
@@ -2163,7 +2163,7 @@ void File_MpegPs::Header_Parse_PES_packet_MPEG2(int8u stream_id)
                     Open_Buffer_Init(Streams_Private1[private_stream_1_ID].Parsers[0]);
                     Streams_Private1[private_stream_1_ID].StreamRegistration_Count++;
                 }
-#if MEDIAINFO_ARIBSTDB24B37_YES
+#if defined(MEDIAINFO_ARIBSTDB24B37_YES)
                 if (Streams_Private1[private_stream_1_ID].Parsers.size()==1)
                 {
                     File_AribStdB24B37* Parser=(File_AribStdB24B37*)Streams_Private1[private_stream_1_ID].Parsers[0];

--- a/Source/MediaInfo/Multiple/File_MpegPs.cpp
+++ b/Source/MediaInfo/Multiple/File_MpegPs.cpp
@@ -2163,7 +2163,7 @@ void File_MpegPs::Header_Parse_PES_packet_MPEG2(int8u stream_id)
                     Open_Buffer_Init(Streams_Private1[private_stream_1_ID].Parsers[0]);
                     Streams_Private1[private_stream_1_ID].StreamRegistration_Count++;
                 }
-
+#if MEDIAINFO_ARIBSTDB24B37_YES
                 if (Streams_Private1[private_stream_1_ID].Parsers.size()==1)
                 {
                     File_AribStdB24B37* Parser=(File_AribStdB24B37*)Streams_Private1[private_stream_1_ID].Parsers[0];
@@ -2171,6 +2171,7 @@ void File_MpegPs::Header_Parse_PES_packet_MPEG2(int8u stream_id)
                     Open_Buffer_Continue(Parser, Buffer+Buffer_Offset+(size_t)Element_Offset, 16);
                 }
                 else
+#endif
                     Skip_B16(                                   "PES_private_data");
            }
             else


### PR DESCRIPTION
…ild errors from mismatches when many options are turned off)

Hi, please accept these changes if you would - just simple matching up of adding the corresponding #ifdefs where there were build issues with the following settings:

#define MEDIAINFO_MINIMIZESIZE
#define MEDIAINFO_MINIMAL_YES
#define MEDIAINFO_ARCHIVE_NO 
#define MEDIAINFO_IMAGE_NO 
#define MEDIAINFO_TAG_NO 
#define MEDIAINFO_TEXT_NO 
#define MEDIAINFO_SWF_NO 
#define MEDIAINFO_FLV_NO 
#define MEDIAINFO_HDSF4M_NO 
#define MEDIAINFO_CDXA_NO 
#define MEDIAINFO_DPG_NO 
#define MEDIAINFO_PMP_NO 
#define MEDIAINFO_RM_NO 
#define MEDIAINFO_WTV_NO 
#define MEDIAINFO_MXF_NO 
#define MEDIAINFO_DCP_NO 
#define MEDIAINFO_AAF_NO 
#define MEDIAINFO_BDAV_NO 
#define MEDIAINFO_BDMV_NO 
#define MEDIAINFO_DVDV_NO 
#define MEDIAINFO_GXF_NO 
#define MEDIAINFO_MIXML_NO 
#define MEDIAINFO_SKM_NO 
#define MEDIAINFO_NUT_NO 
#define MEDIAINFO_TSP_NO 
#define MEDIAINFO_HLS_NO 
#define MEDIAINFO_DXW_NO 
#define MEDIAINFO_DVDIF_NO 
#define MEDIAINFO_DASHMPD_NO 
#define MEDIAINFO_AIC_NO 
#define MEDIAINFO_AVSV_NO 
#define MEDIAINFO_CANOPUS_NO 
#define MEDIAINFO_FFV1_NO 
#define MEDIAINFO_FLIC_NO 
#define MEDIAINFO_HUFFYUV_NO 
#define MEDIAINFO_PRORES_NO 
#define MEDIAINFO_Y4M_NO 
#define MEDIAINFO_ADPCM_NO 
#define MEDIAINFO_AMR_NO 
#define MEDIAINFO_AMV_NO 
#define MEDIAINFO_APE_NO 
#define MEDIAINFO_AU_NO 
#define MEDIAINFO_LA_NO 
#define MEDIAINFO_CELT_NO 
#define MEDIAINFO_MIDI_NO 
#define MEDIAINFO_MPC_NO 
#define MEDIAINFO_OPENMG_NO 
#define MEDIAINFO_PCM_NO 
#define MEDIAINFO_PS2A_NO 
#define MEDIAINFO_RKAU_NO 
#define MEDIAINFO_SPEEX_NO 
#define MEDIAINFO_TAK_NO 
#define MEDIAINFO_TTA_NO 
#define MEDIAINFO_TWINVQ_NO 
#define MEDIAINFO_REFERENCES_NO 

#define MEDIAINFO_ADVANCED_NO 
#define MEDIAINFO_ADVANCED2_NO  
#define MEDIAINFO_OTHER_NO  
#define MEDIAINFO_ANCILLARY_NO 
#define MEDIAINFO_SEQUENCEINFO_NO 
#define MEDIAINFO_AFDBARDATA_NO 
#define MEDIAINFO_MPCSV8_NO 
#define MEDIAINFO_S3M_NO 
#define MEDIAINFO_DOLBYE_NO 
#define MEDIAINFO_CAF_NO 
#define MEDIAINFO_IT_NO 
#define MEDIAINFO_PCMVOB_NO 
#define MEDIAINFO_MOD_NO 
#define MEDIAINFO_DIRAC_NO 
#define MEDIAINFO_FRAPS_NO 
#define MEDIAINFO_LAGARITH_NO 
#define MEDIAINFO_LXF_NO 
#define MEDIAINFO_PTX_NO 
#define MEDIAINFO_ISM_NO 
#define MEDIAINFO_P2_NO 
#define MEDIAINFO_IVF_NO 
#define MEDIAINFO_VBI_NO 
#define MEDIAINFO_XDCAM_NO 
#define MEDIAINFO_TIMECODE_NO 
#define MEDIAINFO_XM_NO 
#define MEDIAINFO_VORBISCOM_NO