### PR TITLE
PBCore 2.1 template

### DIFF
--- a/Source/MediaInfo/Export/Export_PBCore2.cpp
+++ b/Source/MediaInfo/Export/Export_PBCore2.cpp
@@ -251,12 +251,15 @@ Ztring ToReturn;
 }
 
 //---------------------------------------------------------------------------
-Ztring Export_PBCore2::Transform(MediaInfo_Internal &MI)
+Ztring Export_PBCore2::Transform(MediaInfo_Internal &MI, version Version)
 {
     Ztring ToReturn;
 
     Node Node_Main("pbcoreInstantiationDocument");
-    Node_Main.Add_Attribute("xsi:schemaLocation", "http://www.pbcore.org/PBCore/PBCoreNamespace.html http://pbcore.org/xsd/pbcore-2.0.xsd");
+    if (Version==Version_2_0)
+        Node_Main.Add_Attribute("xsi:schemaLocation", "http://www.pbcore.org/PBCore/PBCoreNamespace.html http://pbcore.org/xsd/pbcore-2.0.xsd");
+    else
+        Node_Main.Add_Attribute("xsi:schemaLocation", "http://www.pbcore.org/PBCore/PBCoreNamespace.html https://raw.githubusercontent.com/WGBH/PBCore_2.1/master/pbcore-2.1.xsd"); //TODO: better URL
     Node_Main.Add_Attribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
     Node_Main.Add_Attribute("xmlns", "http://www.pbcore.org/PBCore/PBCoreNamespace.html");
 

--- a/Source/MediaInfo/Export/Export_PBCore2.h
+++ b/Source/MediaInfo/Export/Export_PBCore2.h
@@ -28,7 +28,13 @@ public :
     ~Export_PBCore2 ();
 
     //Input
-    Ztring Transform(MediaInfo_Internal &MI);
+    enum version
+    {
+        Version_2_0,
+        Version_2_1,
+        Version_Max
+    };
+    Ztring Transform(MediaInfo_Internal &MI, version Version=version(Version_Max-1));
 };
 
 } //NameSpace

--- a/Source/MediaInfo/MediaInfo_Config.cpp
+++ b/Source/MediaInfo/MediaInfo_Config.cpp
@@ -186,7 +186,7 @@ static const char* OutputFormats_JSONFields[output_formats_item_size] =
     "mime",
 };
 typedef const char* output_formats_item[output_formats_item_size];
-static const size_t output_formats_size = 12;
+static const size_t output_formats_size = 13;
 static output_formats_item OutputFormats[output_formats_size] =
 {
     { "Text",                   "Text",                                                         "text/plain",       },
@@ -199,6 +199,7 @@ static output_formats_item OutputFormats[output_formats_size] =
     { "EBUCore_1.6",            "EBUCore 1.6",                                                  "text/xml",         },
     { "FIMS_1.3",               "FIMS 1.3",                                                     "text/xml",         },
     { "MPEG-7",                 "MPEG-7",                                                       "text/xml",         },
+    { "PBCore_2.1",             "PBCore 2.1",                                                   "text/xml",         },
     { "PBCore_2.0",             "PBCore 2.0",                                                   "text/xml",         },
     { "PBCore_1.2",             "PBCore 1.2",                                                   "text/xml",         },
 };

--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -157,9 +157,17 @@ Ztring MediaInfo_Internal::Inform()
             return Export_Mpeg7().Transform(*this);
     #endif //defined(MEDIAINFO_MPEG7_YES)
     #if defined(MEDIAINFO_PBCORE_YES)
-        if (MediaInfoLib::Config.Inform_Get()==__T("PBCore") || MediaInfoLib::Config.Inform_Get()==__T("PBCore_1.2"))
+        if (MediaInfoLib::Config.Inform_Get()==__T("PBCore_1") || MediaInfoLib::Config.Inform_Get()==__T("PBCore1")) // 1.x
             return Export_PBCore().Transform(*this);
-        if (MediaInfoLib::Config.Inform_Get()==__T("PBCore2") || MediaInfoLib::Config.Inform_Get()==__T("PBCore_2.0"))
+        if (MediaInfoLib::Config.Inform_Get()==__T("PBCore_1.2"))
+            return Export_PBCore().Transform(*this);
+        if (MediaInfoLib::Config.Inform_Get()==__T("PBCore_2") ||MediaInfoLib::Config.Inform_Get()==__T("PBCore2")) //2.x
+            return Export_PBCore2().Transform(*this);
+        if (MediaInfoLib::Config.Inform_Get()==__T("PBCore_2.0"))
+            return Export_PBCore2().Transform(*this, Export_PBCore2::Version_2_0);
+        if (MediaInfoLib::Config.Inform_Get()==__T("PBCore_2.1"))
+            return Export_PBCore2().Transform(*this, Export_PBCore2::Version_2_1);
+        if (MediaInfoLib::Config.Inform_Get()==__T("PBCore")) //x.x
             return Export_PBCore2().Transform(*this);
     #endif //defined(MEDIAINFO_PBCORE_YES)
     #if defined(MEDIAINFO_REVTMD_YES)


### PR DESCRIPTION
With a change in output option behavior in order to be coherent with other output options (FIMS, EBUCore) :
- `--Output=PBCore` redirects now on `PBCore` latest version (currently 2.1) instead of PBCore1

Template currently only modifying the XSD location. cc @dericed 