### PR TITLE
pbcore_2 - maps General_Format to instantiationStandard https://githu…

### DIFF
--- a/Source/MediaInfo/Export/Export_PBCore2.cpp
+++ b/Source/MediaInfo/Export/Export_PBCore2.cpp
@@ -330,7 +330,10 @@ Ztring Export_PBCore2::Transform(MediaInfo_Internal &MI, version Version)
     else
         Format=__T("application/x-")+Ztring(MI.Get(Stream_General, 0, __T("Format"))).MakeLowerCase();
     Node_Main.Add_Child("instantiationDigital", Format);
-
+    
+    //formatStandard
+    Node_Main.Add_Child("instantiationStandard", MI.Get(Stream_General, 0, General_Format));
+    
     //formatLocation
     Node_Main.Add_Child("instantiationLocation", MI.Get(Stream_General, 0, General_CompleteName));
 


### PR DESCRIPTION
…b.com/MediaArea/MediaInfoLib/issues/786

Hey, I tried building mediainfolib and mediainfo on osx and I couldn't see the changes appear - possibly i'm doing something wrong with the build or these changes are not enough.

Anyhow, does this look like it could work?
https://github.com/MediaArea/MediaInfoLib/issues/786