### PR TITLE
Consumer camera recording date/time, update

### DIFF
--- a/Source/MediaInfo/Multiple/File_MpegPs.h
+++ b/Source/MediaInfo/Multiple/File_MpegPs.h
@@ -315,6 +315,7 @@ private :
     void Streams_Fill_PerStream_PerKind(size_t StreamID, ps_stream &Temp, kindofstream KindOfStream, size_t Count);
     void Streams_Finish_PerStream(size_t StreamID, ps_stream &Temp, kindofstream KindOfStream);
     void xxx_stream_Parse(ps_stream &Temp, int8u &stream_Count);
+    void MergeGeneral(File__Analyze* Parser, general Parameter);
 
     //Output buffer
     size_t Output_Buffer_Get (const String &Value);

--- a/Source/MediaInfo/Multiple/File_MpegTs.h
+++ b/Source/MediaInfo/Multiple/File_MpegTs.h
@@ -137,6 +137,7 @@ private :
     void Streams_Update_Duration_End();
     void SetAllToPES();
     void transport_private_data(int8u transport_private_data_length);
+    void MergeGeneral(complete_stream::stream* Parser, general Parameter);
 
     #if MEDIAINFO_DUPLICATE
         //File__Duplicate

--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -3226,7 +3226,7 @@ void File_Avc::sei_message_user_data_unregistered_bluray_MDPM(int32u payloadSize
 
     Element_Info1("Modified Digital Video Pack Metadata");
 
-    Skip_B1(                                                    "Count?");
+    Skip_B1(                                                    "Count");
     payloadSize--;
     string DateTime0, DateTime1, DateTime2, Model0, Model1, Model2;
     int16u MakeName=(int16u)-1;
@@ -3333,7 +3333,7 @@ void File_Avc::sei_message_user_data_unregistered_bluray_MDPM(int32u payloadSize
         Skip_XX(payloadSize, "Unknown");
 
     FILLING_BEGIN();
-        if (!Frame_Count)
+        if (!Frame_Count && !seq_parameter_sets.empty() && !pic_parameter_sets.empty())
         {
             if (!DateTime0.empty() && !DateTime1.empty())
                 Fill(Stream_General, 0, General_Recorded_Date, DateTime0+DateTime1+DateTime2);


### PR DESCRIPTION
https://github.com/MediaArea/MediaInfoLib/pull/788 was permitting to show new meta only in raw AVC.
Now also in MPEG-TS, and ignore non decodable P/B frames before the 1st I-frame