### PR TITLE
FFV1: remove sar_den test must be 0 if sar_num is 0

### DIFF
--- a/Source/MediaInfo/Video/File_Ffv1.cpp
+++ b/Source/MediaInfo/Video/File_Ffv1.cpp
@@ -1402,7 +1402,7 @@ bool File_Ffv1::SliceHeader(states &States)
         Param_Error("FFV1-SLICE-picture_structure:1");
     Get_RU (States, sample_aspect_ratio_num,                "sar_num");
     Get_RU (States, sample_aspect_ratio_den,                "sar_den");
-    if ((sample_aspect_ratio_num && !sample_aspect_ratio_den) || (!sample_aspect_ratio_num && sample_aspect_ratio_den))
+    if ((sample_aspect_ratio_num && !sample_aspect_ratio_den)) // || (!sample_aspect_ratio_num && sample_aspect_ratio_den)) // Second part is deactivated because FFmpeg creates such file when SAR is unknown
         Param_Error("FFV1-SLICE-sar_den:1");
     if (version > 3)
     {


### PR DESCRIPTION
[Spec is currently not clear](https://github.com/FFmpeg/FFV1/issues/109) and FFmpeg creates such stream
(0/1 if unknown, e.g. with `./ffmpeg -f lavfi -i testsrc -vframes 1 -c:v ffv1 -level 3 -vf setsar=0/2 a.mkv`)

[FFV1-SLICE-sar_den test description](https://github.com/MediaArea/groundtruth/blob/master/matroska/54.md) needs to be updated.

[Reported by user](https://github.com/MediaArea/MediaConch/issues/210) and detected by me at the same period.