### PR TITLE
Attachments: do not provide anymore attachments content in XML by default

### DIFF
--- a/Source/MediaInfo/Audio/File_Flac.cpp
+++ b/Source/MediaInfo/Audio/File_Flac.cpp
@@ -263,8 +263,6 @@ void File_Flac::PICTURE()
     Get_B4 (Data_Size,                                          "Data size");
     if (Element_Offset+Data_Size>Element_Size)
         return; //There is a problem
-    std::string Data_Raw((const char*)(Buffer+(size_t)(Buffer_Offset+Element_Offset)), Data_Size);
-    std::string Data_Base64(Base64::encode(Data_Raw));
     Skip_XX(Element_Size-Element_Offset, "Data");
 
     //Filling
@@ -272,7 +270,14 @@ void File_Flac::PICTURE()
     Fill(Stream_General, 0, General_Cover_Description, Description);
     Fill(Stream_General, 0, General_Cover_Type, Id3v2_PictureType((int8u)PictureType));
     Fill(Stream_General, 0, General_Cover_Mime, MimeType);
-    Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+    #if MEDIAINFO_ADVANCED
+        if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))
+        {
+            std::string Data_Raw((const char*)(Buffer+(size_t)(Buffer_Offset+Element_Offset)), Data_Size);
+            std::string Data_Base64(Base64::encode(Data_Raw));
+            Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+        }
+    #endif //MEDIAINFO_ADVANCED
 }
 
 } //NameSpace

--- a/Source/MediaInfo/MediaInfo_Config.cpp
+++ b/Source/MediaInfo/MediaInfo_Config.cpp
@@ -291,6 +291,9 @@ void MediaInfo_Config::Init()
     #if MEDIAINFO_FIXITY
         TryToFix=false;
     #endif //MEDIAINFO_FIXITY
+    #if MEDIAINFO_FLAG1
+        Flags1=0;
+    #endif //MEDIAINFO_FLAGX
     #if MEDIAINFO_FLAGX
         FlagsX=0;
     #endif //MEDIAINFO_FLAGX
@@ -764,6 +767,16 @@ Ztring MediaInfo_Config::Option (const String &Option, const String &Value_Raw)
     {
         return Inform_Get();
     }
+    #if MEDIAINFO_ADVANCED
+        if (Option_Lower==__T("cover_data"))
+        {
+            return Cover_Data_Set(Value.c_str());
+        }
+        if (Option_Lower==__T("cover_data_get"))
+        {
+            return Cover_Data_Get();
+        }
+    #endif //MEDIAINFO_COMPRESS
     #if MEDIAINFO_COMPRESS
         if (Option_Lower==__T("inform_compress"))
         {
@@ -2074,6 +2087,38 @@ ZtringListList MediaInfo_Config::Inform_Replace_Get_All ()
     CriticalSectionLocker CSL(CS);
     return Custom_View_Replace;
 }
+
+//---------------------------------------------------------------------------
+#if MEDIAINFO_ADVANCED
+Ztring MediaInfo_Config::Cover_Data_Set (const Ztring &NewValue_)
+{
+    Ztring NewValue(NewValue_);
+    transform(NewValue.begin(), NewValue.end(), NewValue.begin(), (int(*)(int))tolower); //(int(*)(int)) is a patch for unix
+    const int64u Mask=~((1<<Flags_Cover_Data_base64));
+    int64u Value;
+    if (NewValue.empty())
+        Value=0;
+    else if (NewValue==__T("base64"))
+        Value=(1<< Flags_Cover_Data_base64);
+    else
+        return __T("Unsupported");
+
+    CriticalSectionLocker CSL(CS);
+    Flags1&=Mask;
+    Flags1|=Value;
+    return Ztring();
+}
+
+Ztring MediaInfo_Config::Cover_Data_Get ()
+{
+    CriticalSectionLocker CSL(CS);
+    Ztring ToReturn;
+    if (Flags1&(1<< Flags_Cover_Data_base64))
+        ToReturn=__T("base64");
+
+    return ToReturn;
+}
+#endif //MEDIAINFO_ADVANCED
 
 //---------------------------------------------------------------------------
 #if MEDIAINFO_COMPRESS

--- a/Source/MediaInfo/MediaInfo_Config.h
+++ b/Source/MediaInfo/MediaInfo_Config.h
@@ -46,6 +46,15 @@ enum basicformat
     BasicFormat_XML,
     BasicFormat_JSON,
 };
+#if MEDIAINFO_ADVANCED
+    #define MEDIAINFO_FLAG1 1
+    enum config_flags1
+    {
+        Flags_Cover_Data_base64,
+    };
+#else //MEDIAINFO_COMPRESS
+    #define MEDIAINFO_FLAG1 0
+#endif //MEDIAINFO_COMPRESS
 
 #if MEDIAINFO_COMPRESS
     #define MEDIAINFO_FLAGX 1
@@ -181,12 +190,19 @@ public :
           void      Inform_Replace_Set (const ZtringListList &NewInform_Replace);
           ZtringListList Inform_Replace_Get_All ();
 
+          #if MEDIAINFO_ADVANCED
+          Ztring    Cover_Data_Set (const Ztring &NewValue);
+          Ztring    Cover_Data_Get ();
+          #endif //MEDIAINFO_ADVANCED
           #if MEDIAINFO_COMPRESS
           Ztring    Inform_Compress_Set (const Ztring &NewInform);
           Ztring    Inform_Compress_Get ();
           Ztring    Input_Compressed_Set(const Ztring &NewInform);
           Ztring    Input_Compressed_Get();
           #endif //MEDIAINFO_COMPRESS
+          #if MEDIAINFO_FLAG1
+          bool      Flags1_Get(config_flags1 Flag) { return Flags1&(1 << Flag); }
+          #endif //MEDIAINFO_FLAGX
           #if MEDIAINFO_FLAGX
           bool      FlagsX_Get(config_flagsX Flag) { return FlagsX&(1 << Flag); }
           #endif //MEDIAINFO_FLAGX
@@ -393,6 +409,9 @@ private :
     Translation     Language; //ex. : "KB;Ko"
     ZtringListList  Custom_View; //Definition of "General", "Video", "Audio", "Text", "Other", "Image"
     ZtringListList  Custom_View_Replace; //ToReplace;ReplaceBy
+    #if MEDIAINFO_FLAG1
+        int64u      Flags1;
+    #endif //MEDIAINFO_FLAG1
     #if MEDIAINFO_FLAGX
         int64u      FlagsX;
     #endif //MEDIAINFO_FLAGX

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -31,6 +31,9 @@
 #if defined(MEDIAINFO_MPEG4V_YES)
     #include "MediaInfo/Video/File_Mpeg4v.h"
 #endif
+#if defined(MEDIAINFO_AV1_YES)
+    #include "MediaInfo/Video/File_Av1.h"
+#endif
 #if defined(MEDIAINFO_AVC_YES)
     #include "MediaInfo/Video/File_Avc.h"
 #endif
@@ -2153,10 +2156,14 @@ void File_Mk::Segment_Attachments_AttachedFile_FileData()
 
         if (!CoverIsSetFromAttachment && CurrentAttachmentIsCover)
         {
-            std::string Data_Base64(Base64::encode(Data_Raw));
-
             //Filling
-            Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+            #if MEDIAINFO_ADVANCED
+                if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))
+                {
+                    std::string Data_Base64(Base64::encode(Data_Raw));
+                    Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+                }
+            #endif //MEDIAINFO_ADVANCED
             Fill(Stream_General, 0, General_Cover, "Yes");
             CoverIsSetFromAttachment=true;
         }
@@ -4033,7 +4040,7 @@ void File_Mk::CodecID_Manage()
     stream& streamItem = Stream[TrackNumber];
 
     //Creating the parser
-    #if defined(MEDIAINFO_MPEG4V_YES) || defined(MEDIAINFO_AVC_YES) || defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_VC1_YES) || defined(MEDIAINFO_DIRAC_YES) || defined(MEDIAINFO_MPEGV_YES) || defined(MEDIAINFO_VP8_YES) || defined(MEDIAINFO_OGG_YES) || defined(MEDIAINFO_DTS_YES)
+    #if defined(MEDIAINFO_MPEG4V_YES) || defined(MEDIAINFO_AV1_YES) || defined(MEDIAINFO_AVC_YES) || defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_VC1_YES) || defined(MEDIAINFO_DIRAC_YES) || defined(MEDIAINFO_MPEGV_YES) || defined(MEDIAINFO_VP8_YES) || defined(MEDIAINFO_OGG_YES) || defined(MEDIAINFO_DTS_YES)
         const Ztring &Format=MediaInfoLib::Config.CodecID_Get(StreamKind_Last, InfoCodecID_Format_Type, CodecID, InfoCodecID_Format);
     #endif
         if (0);
@@ -4042,6 +4049,14 @@ void File_Mk::CodecID_Manage()
     {
         streamItem.Parser=new File_Mpeg4v;
         ((File_Mpeg4v*)streamItem.Parser)->FrameIsAlwaysComplete=true;
+    }
+    #endif
+    #if defined(MEDIAINFO_AV1_YES)
+    else if (Format==__T("AV1"))
+    {
+        File_Av1* Parser=new File_Av1;
+        Parser->FrameIsAlwaysComplete=true;
+        streamItem.Parser=Parser;
     }
     #endif
     #if defined(MEDIAINFO_AVC_YES)

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -2519,12 +2519,17 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                             return;
                         case Elements::moov_meta__covr :
                             {
-                            std::string Data_Raw((const char*)(Buffer+(size_t)(Buffer_Offset+Element_Offset)), (size_t)(Element_Size-Element_Offset));
-                            std::string Data_Base64(Base64::encode(Data_Raw));
                             Skip_XX(Element_Size-Element_Offset, "Data");
 
                             //Filling
-                            Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+                            #if MEDIAINFO_ADVANCED
+                                if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))
+                                {
+                                    std::string Data_Raw((const char*)(Buffer+(size_t)(Buffer_Offset+Element_Offset)), (size_t)(Element_Size-Element_Offset));
+                                    std::string Data_Base64(Base64::encode(Data_Raw));
+                                    Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+                                }
+                            #endif //MEDIAINFO_ADVANCED
                             Fill(Stream_General, 0, General_Cover, "Yes");
                             }
                             return;
@@ -2576,12 +2581,17 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                     {
                         case Elements::moov_meta__covr :
                             {
-                            std::string Data_Raw((const char*)(Buffer+(size_t)(Buffer_Offset+Element_Offset)), (size_t)(Element_Size-Element_Offset));
-                            std::string Data_Base64(Base64::encode(Data_Raw));
                             Skip_XX(Element_Size-Element_Offset, "Data");
 
                             //Filling
-                            Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+                            #if MEDIAINFO_ADVANCED
+                                if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))
+                                {
+                                    std::string Data_Raw((const char*)(Buffer+(size_t)(Buffer_Offset+Element_Offset)), (size_t)(Element_Size-Element_Offset));
+                                    std::string Data_Base64(Base64::encode(Data_Raw));
+                                    Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+                                }
+                            #endif //MEDIAINFO_ADVANCED
                             Fill(Stream_General, 0, General_Cover, "Yes");
                             }
                             return;
@@ -2595,12 +2605,17 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                     {
                         case Elements::moov_meta__covr :
                             {
-                            std::string Data_Raw((const char*)(Buffer+(size_t)(Buffer_Offset+Element_Offset)), (size_t)(Element_Size-Element_Offset));
-                            std::string Data_Base64(Base64::encode(Data_Raw));
                             Skip_XX(Element_Size-Element_Offset, "Data");
 
                             //Filling
-                            Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+                            #if MEDIAINFO_ADVANCED
+                                if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))
+                                {
+                                    std::string Data_Raw((const char*)(Buffer+(size_t)(Buffer_Offset+Element_Offset)), (size_t)(Element_Size-Element_Offset));
+                                    std::string Data_Base64(Base64::encode(Data_Raw));
+                                    Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+                                }
+                            #endif //MEDIAINFO_ADVANCED
                             Fill(Stream_General, 0, General_Cover, "Yes");
                             }
                             return;

--- a/Source/MediaInfo/Tag/File_Id3v2.cpp
+++ b/Source/MediaInfo/Tag/File_Id3v2.cpp
@@ -954,15 +954,20 @@ void File_Id3v2::APIC()
     }
     if (Element_Offset>Element_Size)
         return; //There is a problem
-    std::string Data_Raw((const char*)(Buffer+(size_t)(Buffer_Offset+Element_Offset)), (size_t)(Element_Size-Element_Offset));
-    std::string Data_Base64(Base64::encode(Data_Raw));
 
     //Filling
     Fill_Name();
     Fill(Stream_General, 0, General_Cover_Description, Description);
     Fill(Stream_General, 0, General_Cover_Type, Id3v2_PictureType(PictureType));
     Fill(Stream_General, 0, General_Cover_Mime, Mime);
-    Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+    #if MEDIAINFO_ADVANCED
+        if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))
+        {
+            std::string Data_Raw((const char*)(Buffer+(size_t)(Buffer_Offset+Element_Offset)), (size_t)(Element_Size-Element_Offset));
+            std::string Data_Base64(Base64::encode(Data_Raw));
+            Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
+        }
+    #endif //MEDIAINFO_ADVANCED
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Reducing XML output size

Still available with an option