### PR TITLE
Attachments: do not provide anymore attachments content in XML by default, fixes

### DIFF
--- a/Source/MediaInfo/Audio/File_Flac.cpp
+++ b/Source/MediaInfo/Audio/File_Flac.cpp
@@ -263,7 +263,6 @@ void File_Flac::PICTURE()
     Get_B4 (Data_Size,                                          "Data size");
     if (Element_Offset+Data_Size>Element_Size)
         return; //There is a problem
-    Skip_XX(Element_Size-Element_Offset, "Data");
 
     //Filling
     Fill(Stream_General, 0, General_Cover, "Yes");
@@ -278,6 +277,10 @@ void File_Flac::PICTURE()
             Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
         }
     #endif //MEDIAINFO_ADVANCED
+
+    Skip_XX(Data_Size,                                          "Data");
+    if (Element_Offset<Element_Size)
+        Skip_XX(Element_Size-Element_Offset,                    "?");
 }
 
 } //NameSpace

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -2519,8 +2519,6 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                             return;
                         case Elements::moov_meta__covr :
                             {
-                            Skip_XX(Element_Size-Element_Offset, "Data");
-
                             //Filling
                             #if MEDIAINFO_ADVANCED
                                 if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))
@@ -2531,6 +2529,8 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                                 }
                             #endif //MEDIAINFO_ADVANCED
                             Fill(Stream_General, 0, General_Cover, "Yes");
+
+                            Skip_XX(Element_Size-Element_Offset, "Data");
                             }
                             return;
                         case Elements::moov_meta__gnre :
@@ -2581,8 +2581,6 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                     {
                         case Elements::moov_meta__covr :
                             {
-                            Skip_XX(Element_Size-Element_Offset, "Data");
-
                             //Filling
                             #if MEDIAINFO_ADVANCED
                                 if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))
@@ -2593,6 +2591,8 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                                 }
                             #endif //MEDIAINFO_ADVANCED
                             Fill(Stream_General, 0, General_Cover, "Yes");
+
+                            Skip_XX(Element_Size-Element_Offset, "Data");
                             }
                             return;
                         default:
@@ -2605,8 +2605,6 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                     {
                         case Elements::moov_meta__covr :
                             {
-                            Skip_XX(Element_Size-Element_Offset, "Data");
-
                             //Filling
                             #if MEDIAINFO_ADVANCED
                                 if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))
@@ -2617,6 +2615,8 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                                 }
                             #endif //MEDIAINFO_ADVANCED
                             Fill(Stream_General, 0, General_Cover, "Yes");
+
+                            Skip_XX(Element_Size-Element_Offset, "Data");
                             }
                             return;
                         default:

--- a/Source/MediaInfo/Tag/File_Id3v2.cpp
+++ b/Source/MediaInfo/Tag/File_Id3v2.cpp
@@ -968,6 +968,8 @@ void File_Id3v2::APIC()
             Fill(Stream_General, 0, General_Cover_Data, Data_Base64);
         }
     #endif //MEDIAINFO_ADVANCED
+
+    Skip_XX(Element_Size-Element_Offset, "Data");
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes for https://github.com/MediaArea/MediaInfoLib/pull/801.
Reported by @lordmulder  in https://github.com/MediaArea/MediaInfo/issues/227