### PR TITLE
MasteringDisplay_ColorPrimaries: unfreeze

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -81,9 +81,6 @@ void File__Analyze::Get_MasteringDisplayColorVolume(Ztring &MasteringDisplay_Col
             B=1;
             R=2;
         }
-        x[G] = 15000;  x[B] = 7500 ; x[R] = 32000 ; x[3] = 15635
-            ; y[G] = 30000; y[B] = 3000; y[R] = 16500; y[3] = 16450;
-
              if (x[G]==15000 && x[B]== 7500 && x[R]==32000 && x[3]==15635
               && y[G]==30000 && y[B]== 3000 && y[R]==16500 && y[3]==16450)
             MasteringDisplay_ColorPrimaries=Mpegv_colour_primaries(1); // BT.709


### PR DESCRIPTION
After commit 222d9eece548769efd51e8932ad28392342b292e,
all MasteringDisplay_ColorPrimaries are forced to be `BT.709`.
This would allow MasteringDisplay_ColorPrimaries other then `BT.709` being displayed.