### PR TITLE
Fix C++Builder 10.1

### DIFF
--- a/Source/MediaInfo/Export/Export_Mpeg7.cpp
+++ b/Source/MediaInfo/Export/Export_Mpeg7.cpp
@@ -1226,7 +1226,7 @@ Ztring Export_Mpeg7::Transform(MediaInfo_Internal &MI)
             if (!MI.Get(Stream_General, 0, General_Track_Position).empty())
             {
                  Ztring Total=MI.Get(Stream_General, 0, General_Track_Position_Total);
-                 Value=MI.Get(Stream_General, 0, General_Track_Position)+(Total.empty()?__T(""):(__T("/")+Total));
+                 Value=MI.Get(Stream_General, 0, General_Track_Position)+(Total.empty()?Ztring():(__T("/")+Total));
 
                  Node_Creation->Add_Child("mpeg7:Title", Value, "type", std::string("urn:x-mpeg7-mediainfo:cs:TitleTypeCS:2009:TRACK"));
             }

--- a/Source/MediaInfo/MediaInfo_Config.h
+++ b/Source/MediaInfo/MediaInfo_Config.h
@@ -227,7 +227,7 @@ public :
     const ZtringListList &Info_Get(stream_t KindOfStream); //Should not be, but too difficult to hide it
 
           Ztring    Info_Parameters_Get (bool Complete=false);
-          Ztring    HideShowParameter   (const Ztring &Value, Char Show);
+          Ztring    HideShowParameter   (const Ztring &Value, ZenLib::Char Show);
           Ztring    Info_OutputFormats_Get(basicformat Format);
           Ztring    Info_Tags_Get       () const;
           Ztring    Info_CodecsID_Get   ();


### PR DESCRIPTION
 [bcc32 Error] MediaInfo_Config.h(231): E2015 Ambiguity between 'MediaInfoLib::Char' and 'ZenLib::Char'
 [bcc32 Error] Export_Mpeg7.cpp(1229): E2354 Two operands must evaluate to the same type