### PR TITLE
HEVC: Trying to better support buggy SEIs (missing rbsp_stop_one_bit)

### DIFF
--- a/Source/MediaInfo/Video/File_Hevc.cpp
+++ b/Source/MediaInfo/Video/File_Hevc.cpp
@@ -1836,6 +1836,8 @@ void File_Hevc::sei()
         Element_End0();
     }
     BS_Begin();
+    if (!Peek_SB())
+        Fill(Stream_Video, 0, "SEI_rbsp_stop_one_bit", "Missing", Unlimited, true, true);
     Mark_1(                                                     );
     BS_End();
 }

--- a/Source/MediaInfo/Video/File_Hevc.cpp
+++ b/Source/MediaInfo/Video/File_Hevc.cpp
@@ -1861,6 +1861,23 @@ void File_Hevc::sei_message(int32u &seq_parameter_set_id)
         while(payload_size_byte==0xFF);
     Element_End0();
 
+    //Manage buggy files not having final bit stop
+    const int8u* Buffer_Buggy;
+    int64u Buffer_Offset_Buggy, Element_Size_Buggy;
+    if (Element_Offset+payloadSize>Element_Size)
+    {
+        Buffer_Buggy=Buffer;
+        Buffer_Offset_Buggy=Buffer_Offset;
+        Element_Size_Buggy=Element_Size;
+        Element_Size=Element_Offset+payloadSize;
+        Buffer=new int8u[(size_t)Element_Size];
+        Buffer_Offset=0;
+        memcpy((void*)Buffer, Buffer_Buggy+Buffer_Offset, (size_t)Element_Size_Buggy);
+        memset((void*)(Buffer+(size_t)Element_Size_Buggy), 0x00, (size_t)(Element_Size-Element_Size_Buggy)); //Last 0x00 bytes are discarded, we recreate them
+    }
+    else
+        Buffer_Buggy=NULL;
+
     int64u Element_Offset_Save=Element_Offset+payloadSize;
     if (Element_Offset_Save>Element_Size)
     {
@@ -1889,6 +1906,15 @@ void File_Hevc::sei_message(int32u &seq_parameter_set_id)
     }
     Element_Offset=Element_Offset_Save; //Positionning in the right place.
     Element_Size=Element_Size_Save; //Positionning in the right place.
+
+    //Manage buggy files not having final bit stop
+    if (Buffer_Buggy)
+    {
+        delete[] Buffer;
+        Buffer=Buffer_Buggy;
+        Buffer_Offset=Buffer_Offset_Buggy;
+        Element_Size=Element_Size_Buggy;
+    }
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
At some point we should add messages when there is an error in the bitstream, but for the moment I didn't figure the best approach (with generic code for handling errors as much as possible, and not poluting the default output)

From vote https://mediaarea.net/Vote/Support-Buggy-Hevc-H-265-Sei-171
Issue from encoder, see https://github.com/rigaya/NVEnc/issues/51#issuecomment-393130636