### PR TITLE
WAV: Support of CodecID 19D

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -2660,6 +2660,7 @@ void MediaInfo_Config_CodecID_Audio_Riff (InfoMap &Info)
     "178;ADPCM;Knowledge Adventure, Inc.;;;\n"
     "180;AAC;Fraunhofer IIS;;;\n"
     "190;DTS;;Digital Theater Systems;;\n"
+    "19D;FLAC;;\n"
     "200;ADPCM;Creative Labs;;;\n"
     "202;Fast Speech 8;Creative Labs\n"
     "203;Fast Speech 10;Creative Labs\n"

--- a/Source/Resource/Text/DataBase/CodecID_Audio_Riff.csv
+++ b/Source/Resource/Text/DataBase/CodecID_Audio_Riff.csv
@@ -141,6 +141,7 @@ FF;AAC;;;;
 178;ADPCM;Knowledge Adventure, Inc.;;;;
 180;AAC;Fraunhofer IIS;;;;
 190;DTS;;Digital Theater Systems;;;
+19D;FLAC;;;
 200;ADPCM;Creative Labs;;;;
 202;Fast Speech 8;Creative Labs;
 203;Fast Speech 10;Creative Labs;


### PR DESCRIPTION
fix for https://github.com/MediaArea/MediaInfoLib/issues/594 (is a MOV but use WAV CodecIDs)
@Sami32 