### PR TITLE
 Fix of segfault infinite loop

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -1684,7 +1684,7 @@ void File__Analyze::Video_FrameRate_Rounding(size_t Pos, video Parameter)
     else if (FrameRate>29.940*2 && FrameRate<=29.985*2) FrameRate=29.970*2;
     else if (FrameRate>29.970*2 && FrameRate<=30.030*2) FrameRate=30.000*2;
 
-    if (std::fabs(FrameRate-FrameRate_Sav) > 0.01)
+    if (std::fabs(FrameRate-FrameRate_Sav)>=0.000999999)
         Fill(Stream_Video, Pos, Parameter, FrameRate, 3, true);
 }
 


### PR DESCRIPTION
Due to https://github.com/MediaArea/MediaInfoLib/pull/921 while fixing https://github.com/MediaArea/MediaInfoLib/issues/913.
@pavel-pimenov the test is too much as we have a 0.001 precision. I changed the value, still an ugly fix of an ugly code though.
@frebib I installed Alpine Linux 3.8.0, installed g++/make/zlib-dev and compiled MediaInfo 18.05, but I can not reproduce the segfault, so please test this version. 
