### PR TITLE
LegacyStreamDisplay option set to false by default

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config.cpp
+++ b/Source/MediaInfo/MediaInfo_Config.cpp
@@ -276,7 +276,7 @@ void MediaInfo_Config::Init()
     Language_Raw=false;
     ReadByHuman=true;
     Legacy=true;
-    LegacyStreamDisplay=true;
+    LegacyStreamDisplay=false;
     SkipBinaryData=false;
     Demux=0;
     LineSeparator=EOL;


### PR DESCRIPTION
No more display of how legacy decoders handle streams with additional features e.g. AAC LC with SBR and PS now only display 48 KHz / 2 channels instead of also showing 24 kHz / 1 channel as handled by a non SBR/PS aware decoder.