### PR TITLE
CarriageReturnReplace option

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -374,16 +374,20 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Paramete
     #endif //MEDIAINFO_ADVANCED
 
     //Handling values with \r\n inside
-    if (Value.find(__T('\r'))!=string::npos || Value.find(__T('\n'))!=string::npos)
+    if (Value.find_first_of(__T("\r\n"))!=string::npos)
     {
-        Ztring NewValue=Value;
-        NewValue.FindAndReplace(__T("\r\n"), __T(" / "), 0, Ztring_Recursive);
-        NewValue.FindAndReplace(__T("\r"), __T(" / "), 0, Ztring_Recursive);
-        NewValue.FindAndReplace(__T("\n"), __T(" / "), 0, Ztring_Recursive);
-        if (NewValue.size()>=3 && NewValue.rfind(__T(" / "))==NewValue.size()-3)
-            NewValue.resize(NewValue.size()-3);
-        Fill(StreamKind, StreamPos, Parameter, NewValue, Replace);
-        return;
+        Ztring CarriageReturnReplace=MediaInfoLib::Config.CarriageReturnReplace_Get();
+        if (!CarriageReturnReplace.empty())
+        {
+            Ztring NewValue=Value;
+            NewValue.FindAndReplace(__T("\r\n"), CarriageReturnReplace, 0, Ztring_Recursive);
+            NewValue.FindAndReplace(__T("\r"), CarriageReturnReplace, 0, Ztring_Recursive);
+            NewValue.FindAndReplace(__T("\n"), CarriageReturnReplace, 0, Ztring_Recursive);
+            if (NewValue.size()>=CarriageReturnReplace.size() && NewValue.rfind(CarriageReturnReplace)==NewValue.size()-CarriageReturnReplace.size())
+                NewValue.resize(NewValue.size()-CarriageReturnReplace.size());
+            Fill(StreamKind, StreamPos, Parameter, NewValue, Replace);
+            return;
+        }
     }
 
     //Handle Value before StreamKind
@@ -1015,16 +1019,20 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, const char* Par
         return;
 
     //Handling values with \r\n inside
-    if (Value.find(__T('\r'))!=string::npos || Value.find(__T('\n'))!=string::npos)
+    if (Value.find_first_of(__T("\r\n"))!=string::npos)
     {
-        Ztring NewValue=Value;
-        NewValue.FindAndReplace(__T("\r\n"), __T(" / "), 0, Ztring_Recursive);
-        NewValue.FindAndReplace(__T("\r"), __T(" / "), 0, Ztring_Recursive);
-        NewValue.FindAndReplace(__T("\n"), __T(" / "), 0, Ztring_Recursive);
-        if (NewValue.size()>=3 && NewValue.rfind(__T(" / "))==NewValue.size()-3)
-            NewValue.resize(NewValue.size()-3);
-        Fill(StreamKind, StreamPos, Parameter, NewValue, Replace);
-        return;
+        Ztring CarriageReturnReplace=MediaInfoLib::Config.CarriageReturnReplace_Get();
+        if (!CarriageReturnReplace.empty())
+        {
+            Ztring NewValue=Value;
+            NewValue.FindAndReplace(__T("\r\n"), CarriageReturnReplace, 0, Ztring_Recursive);
+            NewValue.FindAndReplace(__T("\r"), CarriageReturnReplace, 0, Ztring_Recursive);
+            NewValue.FindAndReplace(__T("\n"), CarriageReturnReplace, 0, Ztring_Recursive);
+            if (NewValue.size()>=CarriageReturnReplace.size() && NewValue.rfind(CarriageReturnReplace)==NewValue.size()-CarriageReturnReplace.size())
+                NewValue.resize(NewValue.size()-CarriageReturnReplace.size());
+            Fill(StreamKind, StreamPos, Parameter, NewValue, Replace);
+            return;
+        }
     }
 
     //Handle Value before StreamKind

--- a/Source/MediaInfo/MediaInfo_Config.cpp
+++ b/Source/MediaInfo/MediaInfo_Config.cpp
@@ -285,6 +285,7 @@ void MediaInfo_Config::Init()
     Quote=__T("\"");
     DecimalPoint=__T(".");
     ThousandsPoint=Ztring();
+    CarriageReturnReplace=__T(" / ");
     #if MEDIAINFO_EVENTS
         Event_CallBackFunction=NULL;
         Event_UserHandler=NULL;
@@ -725,6 +726,17 @@ Ztring MediaInfo_Config::Option (const String &Option, const String &Value_Raw)
     if (Option_Lower==__T("thousandspoint_get"))
     {
         return ThousandsPoint_Get();
+    }
+    if (Option_Lower==__T("carriagereturnreplace"))
+    {
+        if (Value.find_first_of(__T("\r\n"))!=string::npos)
+            return __T("\\r or \\n in CarriageReturnReplace is not supported");
+        CarriageReturnReplace_Set(Value);
+        return Ztring();
+    }
+    if (Option_Lower==__T("carriagereturnreplace_get"))
+    {
+        return CarriageReturnReplace_Get();
     }
     if (Option_Lower==__T("streammax"))
     {
@@ -1764,6 +1776,19 @@ Ztring MediaInfo_Config::ThousandsPoint_Get ()
 {
     CriticalSectionLocker CSL(CS);
     return ThousandsPoint;
+}
+
+//---------------------------------------------------------------------------
+void MediaInfo_Config::CarriageReturnReplace_Set (const Ztring &NewValue)
+{
+    CriticalSectionLocker CSL(CS);
+    CarriageReturnReplace=NewValue;
+}
+
+Ztring MediaInfo_Config::CarriageReturnReplace_Get ()
+{
+    CriticalSectionLocker CSL(CS);
+    return CarriageReturnReplace;
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/MediaInfo_Config.h
+++ b/Source/MediaInfo/MediaInfo_Config.h
@@ -174,6 +174,9 @@ public :
           void      ThousandsPoint_Set (const Ztring &NewValue);
           Ztring    ThousandsPoint_Get ();
 
+          void      CarriageReturnReplace_Set (const Ztring &NewValue);
+          Ztring    CarriageReturnReplace_Get ();
+
           void      StreamMax_Set (const ZtringListList &NewValue);
           Ztring    StreamMax_Get ();
 
@@ -408,6 +411,7 @@ private :
     Ztring          Quote;
     Ztring          DecimalPoint;
     Ztring          ThousandsPoint;
+    Ztring          CarriageReturnReplace;
     Translation     Language; //ex. : "KB;Ko"
     ZtringListList  Custom_View; //Definition of "General", "Video", "Audio", "Text", "Other", "Image"
     ZtringListList  Custom_View_Replace; //ToReplace;ReplaceBy


### PR DESCRIPTION
Quick and dirty code for being able to disable carriage return replacement when reading metadata.
@Sami32 add MediaInfo::Option("CarriageReturnReplace", "") in your code before calling MediaInfo::Open and you'll get the field as is (without modifications, so containing carriage returns)