### PR TITLE
HighestFormat option set to true by default

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -157,7 +157,7 @@ MediaInfo_Config_MediaInfo::MediaInfo_Config_MediaInfo()
         File_Source_List=false;
         File_RiskyBitRateEstimation=false;
         File_MergeBitRateInfo=true;
-        File_HighestFormat=false;
+        File_HighestFormat=true;
         File_ChannelLayout=false;
         #if MEDIAINFO_DEMUX
             File_Demux_Unpacketize_StreamLayoutChange_Skip=false;


### PR DESCRIPTION
Show the highest format detected, instead of the lowest one.
Examples:
- "AAC LC SBR PS" instead of "AAC" because a LC decoder with SBR and PS support is needed for fully decoding it (else only the 24 kHz / 1 channel part is decoded)
- "E-AC-3 JOC" instead of "E-AC-3" because an E-AC-3 decoder with JOC (Atmos) support is needed for fully decoding it (else the Atmos part is ignored)