### PR TITLE
+ Fix #1005: Obey edit list in QuickTime Timecode track

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -4131,6 +4131,22 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_tmcd()
         Parser->NumberOfFrames=NumberOfFrames; //tc->FrameDuration?(((float64)tc->TimeScale)/tc->FrameDuration):0;
         Parser->DropFrame=tc->DropFrame;
         Parser->NegativeTimes=tc->NegativeTimes;
+
+        //Get delay from timecode track's edit list
+        int64s FrameDurationInMediaUnits = tc->FrameDuration * Streams[moov_trak_tkhd_TrackID].mdhd_TimeScale;
+        if (FrameDurationInMediaUnits > 0)
+        {
+            for (size_t i = 0; i < Streams[moov_trak_tkhd_TrackID].edts.size(); ++i)
+            {
+                const stream::edts_struct& Edit = Streams[moov_trak_tkhd_TrackID].edts[i];
+                if (Edit.Delay != (int32u)-1)
+                {
+                    //Inform parser of offset (in TC frames) due to edit list
+                    Parser->FirstEditOffset = Edit.Delay * tc->TimeScale / FrameDurationInMediaUnits;
+                    break;
+                }
+            }
+        }
         Streams[moov_trak_tkhd_TrackID].Parsers.push_back(Parser);
         mdat_MustParse=true; //Data is in MDAT
     FILLING_ELSE();

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
@@ -40,6 +40,7 @@ File_Mpeg4_TimeCode::File_Mpeg4_TimeCode()
     //Out
     Pos=(int32u)-1;
 
+    FirstEditOffset=0;
     NumberOfFrames=0;
     DropFrame=false;
     NegativeTimes=false;
@@ -99,7 +100,7 @@ void File_Mpeg4_TimeCode::Read_Buffer_Continue()
         Get_B4 (Position,                                       "Position");
         if (Pos==(int32u)-1) //First time code
         {
-            Pos=Position;
+            Pos=Position + FirstEditOffset;
             if (NegativeTimes)
                 Pos=(int32s)Position;
             if (Config->ParseSpeed<=1.0 && Element_Offset!=Element_Size)

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
@@ -27,6 +27,7 @@ public :
     int8u   NumberOfFrames;
     bool    DropFrame;
     bool    NegativeTimes;
+    int64s  FirstEditOffset;
 
     //Out
     int64s  Pos;


### PR DESCRIPTION
Obey edit list in QuickTime timecode tracks. Fixes reporting for the sample file in:
https://sourceforge.net/p/mediainfo/bugs/1005/

Signed-off-by: Peter Chapman <peterc@telestream.net>