### PR TITLE
ChannelLayout: same name whatever is the format by default 

### DIFF
--- a/Source/MediaInfo/Audio/File_Ac3.cpp
+++ b/Source/MediaInfo/Audio/File_Ac3.cpp
@@ -172,11 +172,11 @@ const char*  AC3_ChannelLayout_lfeoff[]=
     "M M",
     "C",
     "L R",
-    "L C R",
+    "L R C",
     "L R S",
-    "L C R Cs",
+    "L R C Cs",
     "L R Ls Rs",
-    "L C R Ls Rs",
+    "L R C Ls Rs",
 };
 
 //---------------------------------------------------------------------------
@@ -185,11 +185,11 @@ const char*  AC3_ChannelLayout_lfeon[]=
     "1+1 LFE",
     "C LFE",
     "L R LFE",
-    "L C R LFE",
+    "L R C LFE",
     "L R S LFE",
-    "L C R LFE Cs",
+    "L R C LFE Cs",
     "L R LFE Ls Rs",
-    "L C R LFE Ls Rs",
+    "L R C LFE Ls Rs",
 };
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Audio/File_Dts.cpp
+++ b/Source/MediaInfo/Audio/File_Dts.cpp
@@ -120,7 +120,7 @@ const char*  DTS_ChannelPositions2[16]=
 static const char*  DTS_ChannelLayout[16]=
 {
     "C",
-    "1+1",
+    "M M",
     "L R",
     "L R",
     "Lt Rt",

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -158,7 +158,7 @@ MediaInfo_Config_MediaInfo::MediaInfo_Config_MediaInfo()
         File_RiskyBitRateEstimation=false;
         File_MergeBitRateInfo=true;
         File_HighestFormat=true;
-        File_ChannelLayout=false;
+        File_ChannelLayout=true;
         #if MEDIAINFO_DEMUX
             File_Demux_Unpacketize_StreamLayoutChange_Skip=false;
         #endif //MEDIAINFO_DEMUX

--- a/Source/MediaInfo/MediaInfo_Internal.cpp
+++ b/Source/MediaInfo/MediaInfo_Internal.cpp
@@ -277,22 +277,74 @@ extern const Char* MediaInfo_Version;
 //***************************************************************************
 // Modifiers - ChannelLayout_2018
 //***************************************************************************
-static const size_t ChannelLayout_2018_Size=13;
+static const size_t ChannelLayout_2018_Size=65;
 static const char* ChannelLayout_2018[ChannelLayout_2018_Size][2] =
 {
+    { "BC", "Cb" },
+    { "BL", "Lb" },
+    { "BR", "Lr" },
+    { "CI", "Bfc" },
+    { "CL", "Ls" },
+    { "CR", "Rs" },
+    { "Ch", "Tfc" },
+    { "Chr", "Tbc" },
+    { "Cl", "Ls" },
+    { "Cr", "Rs" },
     { "Cs", "Cb" },
+    { "Cv", "Tfc" },
+    { "Cvr", "Tbc" },
+    { "FC", "C" },
+    { "FL", "L" },
+    { "FLC", "Lscr" },
+    { "FR", "R" },
+    { "FRC", "Rscr" },
+    { "LI", "Bfl" },
     { "Lc", "Lscr" },
+    { "Lfh", "Tfl" },
+    { "Lh", "Vhl" },
+    { "Lhr", "Tbl" },
+    { "Lhs", "Tfl" },
     { "Lrh", "Tbl" },
     { "Lrs", "Lb" },
+    { "Lsc", "Lscr" },
+    { "Lsr", "Lb" },
+    { "Ltm", "Tsl" },
     { "Lts", "Tsl" },
+    { "Lv", "Tfl" },
     { "Lvh", "Tfl" },
+    { "Lvr", "Tbl" },
+    { "Lvs", "Tsl" },
+    { "Lvss", "Tll" },
+    { "Oh", "Tc" },
     { "Rc", "Rscr" },
+    { "Rfh", "Tfrr" },
+    { "Rh", "Vhr" },
+    { "Rhr", "Tbr" },
+    { "Rhs", "Tfr" },
+    { "RI", "Bfr" },
     { "Rrh", "Tbr" },
     { "Rrs", "Rb" },
+    { "Rsc", "Rscr" },
+    { "Rsr", "Rb" },
+    { "Rtm", "Tsr" },
     { "Rts", "Tsr" },
+    { "Rv", "Tfr" },
     { "Rvh", "Tfr" },
-    { "Vhc", "Tfc" },
+    { "Rvr", "Tbr" },
+    { "Rvs", "Tsr" },
+    { "Rvss", "Tsr" },
+    { "S", "Cb" },
+    { "SL", "Ls" },
+    { "SR", "Rs" },
+    { "TBC", "Tbc" },
+    { "TBL", "Tbl" },
+    { "TBR", "Tbr" },
+    { "TC", "Tc" },
+    { "TFC", "Tfc" },
+    { "TFL", "Tfl" },
+    { "TFR", "Tfr" },
     { "Ts", "Tc" },
+    { "Vhc", "Tfc" },
 };
 Ztring ChannelLayout_2018_Rename(const Ztring& Channels)
 {
@@ -308,7 +360,6 @@ Ztring ChannelLayout_2018_Rename(const Ztring& Channels)
                 ChannelName.From_UTF8(ChannelLayout_2018[j][1]);
     }
     Ztring ToReturn=List.Read();
-    ToReturn.FindAndReplace(__T("L C R"), __T("L R C"));
     return ToReturn;
 }
 Ztring ChannelLayout_2018_Rename(stream_t StreamKind, size_t Parameter, ZtringList& Info, bool &ShouldReturn)


### PR DESCRIPTION
Trying to get the same channel names in ChannelLayout whatever is the format.
Goal with ChannelLayout is also to get the decoder channel order (to be confirmed).

Use option ` --ChannelLayout=0` for having names for the spec of each format