### PR TITLE
New format "Directory" when image sequence + audio file is detected

### DIFF
--- a/Source/MediaInfo/File__Analyze.h
+++ b/Source/MediaInfo/File__Analyze.h
@@ -1326,8 +1326,10 @@ protected :
 public:
     #if defined(MEDIAINFO_FILE_YES)
     void TestContinuousFileNames(size_t CountOfFiles=24, Ztring FileExtension=Ztring(), bool SkipComputeDelay=false);
+    void TestDirectory();
     #else //defined(MEDIAINFO_FILE_YES)
     void TestContinuousFileNames(size_t =24, Ztring =Ztring(), bool =false) {}
+    void TestDirectory() {}
     #endif //defined(MEDIAINFO_FILE_YES)
     #if MEDIAINFO_FIXITY
     bool FixFile(int64u FileOffsetForWriting, const int8u* ToWrite, const size_t ToWrite_Size);

--- a/Source/MediaInfo/File__Analyze_MinimizeSize.h
+++ b/Source/MediaInfo/File__Analyze_MinimizeSize.h
@@ -1262,8 +1262,10 @@ protected :
 public:
     #if defined(MEDIAINFO_FILE_YES)
     void TestContinuousFileNames(size_t CountOfFiles=24, Ztring FileExtension=Ztring(), bool SkipComputeDelay=false);
+    void TestDirectory();
     #else //defined(MEDIAINFO_FILE_YES)
     void TestContinuousFileNames(size_t =24, Ztring =Ztring(), bool =false) {}
+    void TestDirectory() {}
     #endif //defined(MEDIAINFO_FILE_YES)
     #if MEDIAINFO_FIXITY
     bool FixFile(int64u FileOffsetForWriting, const int8u* ToWrite, const size_t ToWrite_Size);

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -573,7 +573,7 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Paramete
         }
 
         //General Format
-        if (Parameter==Fill_Parameter(StreamKind, Generic_Format) && Retrieve(Stream_General, 0, General_Format).empty() && !Value.empty())
+        if (Parameter==Fill_Parameter(StreamKind, Generic_Format) && Retrieve(Stream_General, 0, General_Format).empty() && !Value.empty() && Count_Get(Stream_Video)+Count_Get(Stream_Audio)+Count_Get(Stream_Text)+Count_Get(Stream_Other)+Count_Get(Stream_Image)==1)
             Fill(Stream_General, 0, General_Format, Value); //If not already filled, we are filling with the stream format
 
         //ID
@@ -1369,6 +1369,7 @@ size_t File__Analyze::Merge(MediaInfo_Internal &ToAdd, bool)
             {
                 if (StreamKind!=Stream_General
                  || !(Pos==General_CompleteName
+                   || Pos==General_CompleteName_Last
                    || Pos==General_FolderName
                    || Pos==General_FileName
                    || Pos==General_FileExtension

--- a/Source/MediaInfo/MediaInfoList_Internal.cpp
+++ b/Source/MediaInfo/MediaInfoList_Internal.cpp
@@ -153,6 +153,31 @@ size_t MediaInfoList_Internal::Open(const String &File_Name, const fileoptions_t
     }
 }
 
+#if defined(MEDIAINFO_FILE_YES)
+static size_t RemoveFilesFromList(std::queue<String>& ToParse, Ztring CompleteName_Begin, const Ztring &CompleteName_Last)
+{
+    size_t Removed=0;
+    size_t Pos=0;
+    for (; Pos<CompleteName_Begin.size(); Pos++)
+    {
+        if (Pos>=CompleteName_Last.size())
+            break;
+        if (CompleteName_Begin[Pos]!=CompleteName_Last[Pos])
+            break;
+    }
+    if (Pos<CompleteName_Begin.size())
+    {
+        CompleteName_Begin.resize(Pos);
+        while (!ToParse.empty() && ToParse.front().find(CompleteName_Begin)==0)
+        {
+            ToParse.pop();
+            Removed++;
+        }
+    }
+    return Removed;
+}
+#endif //defined(MEDIAINFO_FILE_YES)
+
 void MediaInfoList_Internal::Entry()
 {
     if (ToParse_Total==0)
@@ -165,6 +190,21 @@ void MediaInfoList_Internal::Entry()
         {
             Ztring FileName=ToParse.front();
             ToParse.pop();
+            #if defined(MEDIAINFO_FILE_YES)
+                bool Skip=false;
+                for (size_t i=0; i<ToParse_ToIgnore.size(); i++)
+                {
+                    if (ToParse_ToIgnore[i]==FileName)
+                    {
+                        ToParse_ToIgnore.erase(ToParse_ToIgnore.begin()+i);
+                        ToParse_AlreadyDone++;
+                        Skip=true;
+                        continue;
+                    }
+                }
+                if (Skip)
+                    continue;
+            #endif //defined(MEDIAINFO_FILE_YES)
             MediaInfo_Internal* MI=new MediaInfo_Internal();
             for (std::map<String, String>::iterator Config_MediaInfo_Item=Config_MediaInfo_Items.begin(); Config_MediaInfo_Item!=Config_MediaInfo_Items.end(); ++Config_MediaInfo_Item)
                 MI->Option(Config_MediaInfo_Item->first, Config_MediaInfo_Item->second);
@@ -192,34 +232,60 @@ void MediaInfoList_Internal::Entry()
             CS.Enter();
             ToParse_AlreadyDone++;
 
-            //Removing sequences of files from the list
-            if (!MI->Get(Stream_General, 0, General_CompleteName_Last).empty())
-            {
-                Ztring CompleteName_Begin=MI->Get(Stream_General, 0, General_CompleteName);
-                Ztring CompleteName_Last=MI->Get(Stream_General, 0, General_CompleteName_Last);
-                size_t Pos=0;
-                for (; Pos<CompleteName_Begin.size(); Pos++)
+            #if defined(MEDIAINFO_FILE_YES)
+                //Removing sequences of files from the list
+                if (!MI->Get(Stream_General, 0, General_CompleteName_Last).empty())
+                    ToParse_AlreadyDone+=RemoveFilesFromList(ToParse, MI->Get(Stream_General, 0, General_CompleteName),
+                                                                      MI->Get(Stream_General, 0, General_CompleteName_Last));
+                if (MI->Config.File_TestDirectory_Get() && MI->Get(Stream_General, 0, General_Format)==__T("Directory"))
                 {
-                    if (Pos>=CompleteName_Last.size())
-                        break;
-                    if (CompleteName_Begin[Pos]!=CompleteName_Last[Pos])
-                        break;
+                    for (size_t StreamKind=Stream_General+1; StreamKind<Stream_Max; StreamKind++)
+                        for (size_t StreamPos=0; StreamPos<MI->Count_Get((stream_t)StreamKind); StreamPos++)
+                        {
+                            if (!MI->Get((stream_t)StreamKind, StreamPos, __T("Source_Last")).empty())
+                                ToParse_AlreadyDone+=RemoveFilesFromList(ToParse, MI->Get(Stream_General, 0, General_CompleteName)+MI->Get((stream_t)StreamKind, StreamPos, __T("Source")),
+                                                                                  MI->Get(Stream_General, 0, General_CompleteName)+MI->Get((stream_t)StreamKind, StreamPos, __T("Source_Last")));
+                            else
+                            {
+                                Ztring Source=MI->Get((stream_t)StreamKind, StreamPos, __T("Source"));
+                                if (!Source.empty())
+                                {
+                                    Ztring Dir=MI->Get(Stream_General, 0, General_CompleteName);
+                                    if (!Dir.empty() && Dir[Dir.size()-1]!=__T('/') && Dir[Dir.size()-1]!=__T('\\'))
+                                    {
+                                        size_t Separator_Pos=Dir.find_last_of(__T("\\/"));
+                                        if (Separator_Pos!=string::npos)
+                                            Dir.resize(Separator_Pos+1);
+                                        else
+                                            Dir.clear();
+                                    }
+                                    size_t i;
+                                    if (PathSeparator!=__T('/'))
+                                        while ((i=Source.find(__T('/')))!=string::npos)
+                                            Source[i]=PathSeparator;
+                                    if (PathSeparator!=__T('\\'))
+                                        while ((i=Source.find(__T('\\')))!=string::npos)
+                                            Source[i]=PathSeparator;
+                                    Source=Dir+Source;
+                                    i=0;
+                                    for (; i<Info.size(); i++)
+                                        if (Info[i]->Get(Stream_General, 0, General_CompleteName)==Source)
+                                        {
+                                            delete Info[i];
+                                            Info.erase(Info.begin()+i);
+                                        }
+                                    if (i>=Info.size())
+                                        ToParse_ToIgnore.push_back(Source);
+                                }
+                            }
+                        }
                 }
-                if (Pos<CompleteName_Begin.size())
-                {
-                    CompleteName_Begin.resize(Pos);
-                    while (!ToParse.empty() && ToParse.front().find(CompleteName_Begin)==0)
-                    {
-                        ToParse.pop();
-                        ToParse_Total--;
-                    }
-                }
-            }
-
-            State=ToParse_AlreadyDone*10000/ToParse_Total;
-            //if ((ToParse_AlreadyDone%10)==0)
-            //    printf("%f done (%i/%i %s)\n", ((float)State)/100, (int)ToParse_AlreadyDone, (int)ToParse_Total, Ztring(ToParse.front()).To_UTF8().c_str());
+            #endif //defined(MEDIAINFO_FILE_YES)
         }
+
+        State=ToParse_AlreadyDone*10000/ToParse_Total;
+        //if ((ToParse_AlreadyDone%10)==0)
+        //    printf("%f done (%i/%i %s)\n", ((float)State)/100, (int)ToParse_AlreadyDone, (int)ToParse_Total, Ztring(ToParse.front()).To_UTF8().c_str());
         if (IsTerminating() || State==10000)
         {
             CS.Leave();

--- a/Source/MediaInfo/MediaInfoList_Internal.h
+++ b/Source/MediaInfo/MediaInfoList_Internal.h
@@ -61,6 +61,9 @@ public :
 
 private :
     std::vector<MediaInfo_Internal*> Info;
+    #if defined(MEDIAINFO_FILE_YES)
+    std::vector<String> ToParse_ToIgnore;
+    #endif //defined(MEDIAINFO_FILE_YES)
     std::queue<String> ToParse;
     std::map<String, String> Config_MediaInfo_Items; //Config per file
     size_t  ToParse_AlreadyDone;

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -143,6 +143,7 @@ MediaInfo_Config_MediaInfo::MediaInfo_Config_MediaInfo()
     FileIsDetectingDuration=false;
     FileIsReferenced=false;
     FileTestContinuousFileNames=true;
+    FileTestDirectory=true;
     FileKeepInfo=false;
     FileStopAfterFilled=false;
     FileStopSubStreamAfterFilled=false;
@@ -380,6 +381,15 @@ Ztring MediaInfo_Config_MediaInfo::Option (const String &Option, const String &V
     else if (Option_Lower==__T("file_testcontinuousfilenames_get"))
     {
         return File_TestContinuousFileNames_Get()?"1":"0";
+    }
+    if (Option_Lower==__T("file_testdirectory"))
+    {
+        File_TestDirectory_Set(!(Value==__T("0") || Value.empty()));
+        return __T("");
+    }
+    else if (Option_Lower==__T("file_testdirectory_get"))
+    {
+        return File_TestDirectory_Get()?"1":"0";
     }
     if (Option_Lower==__T("file_keepinfo"))
     {
@@ -1360,6 +1370,19 @@ bool MediaInfo_Config_MediaInfo::File_TestContinuousFileNames_Get ()
 {
     CriticalSectionLocker CSL(CS);
     return FileTestContinuousFileNames;
+}
+
+//---------------------------------------------------------------------------
+void MediaInfo_Config_MediaInfo::File_TestDirectory_Set (bool NewValue)
+{
+    CriticalSectionLocker CSL(CS);
+    FileTestDirectory=NewValue;
+}
+
+bool MediaInfo_Config_MediaInfo::File_TestDirectory_Get ()
+{
+    CriticalSectionLocker CSL(CS);
+    return FileTestDirectory;
 }
 
 //***************************************************************************

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
@@ -99,6 +99,9 @@ public :
     void          File_TestContinuousFileNames_Set (bool NewValue);
     bool          File_TestContinuousFileNames_Get ();
 
+    void          File_TestDirectory_Set (bool NewValue);
+    bool          File_TestDirectory_Get ();
+
     void          File_KeepInfo_Set (bool NewValue);
     bool          File_KeepInfo_Get ();
 
@@ -427,6 +430,7 @@ private :
     bool                    FileIsDetectingDuration;
     bool                    FileIsReferenced;
     bool                    FileTestContinuousFileNames;
+    bool                    FileTestDirectory;
     bool                    FileKeepInfo;
     bool                    FileStopAfterFilled;
     bool                    FileStopSubStreamAfterFilled;

--- a/Source/MediaInfo/Multiple/File_Hls.cpp
+++ b/Source/MediaInfo/Multiple/File_Hls.cpp
@@ -200,6 +200,7 @@ bool File_Hls::FileHeader_Begin()
 
     //All should be OK...
     Config->File_TestContinuousFileNames_Set(false);
+    Config->File_TestDirectory_Set(false);
     return true;
 }
 

--- a/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
+++ b/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
@@ -1603,6 +1603,8 @@ MediaInfo_Internal* File__ReferenceFilesHelper::MI_Create()
         MI_Temp->Config.File_Names_RootDirectory=FileName(MI->File_Name).Path_Get();
         if (!Config->File_TestContinuousFileNames_Get() || Sequences[Sequences_Current]->FileNames.size()>1)
             MI_Temp->Option(__T("File_TestContinuousFileNames"), __T("0"));
+        if (!Config->File_TestDirectory_Get())
+            MI_Temp->Option(__T("File_TestDirectory"), __T("0"));
         ZtringListList SubFile_IDs;
         if (Sequences[Sequences_Current]->IsMain)
             HasMainFile=true;


### PR DESCRIPTION
Detect that an image sequence and an audio file are in a directory and are part of a package.
Classic usage : DPX + WAV.

As directory structure depends on the supplier, we need to adapt per supplier.
We start with this structure:
```
 title-of-work/
     title-of-work.wav
     dpx/
         title-of-work_0086880.dpx
         title-of-work_0086881.dpx
         ... etc ...
```