### PR TITLE
MPEG2 variable GOP detectin fix

### DIFF
--- a/Source/MediaInfo/Video/File_Mpegv.cpp
+++ b/Source/MediaInfo/Video/File_Mpegv.cpp
@@ -2380,7 +2380,7 @@ void File_Mpegv::picture_start()
         TemporalReference[TemporalReference_Offset+temporal_reference]->IsValid=true;
 
         //picture_coding_types
-        if (picture_coding_type==1) //I-Frame
+        if (picture_coding_type==1  && !FirstFieldFound) //I-Frame
         {
             if (!picture_coding_types_Current.empty())
             {
@@ -2409,7 +2409,7 @@ void File_Mpegv::picture_start()
             }
             picture_coding_types_Current='I';
         }
-        else if (!picture_coding_types_Current.empty()) //If an I-Frame is already found
+        else if (!picture_coding_types_Current.empty() && !FirstFieldFound) //If an I-Frame is already found
             picture_coding_types_Current+=Mpegv_picture_coding_type[picture_coding_type];
 
         //Detecting streams with only I-Frames


### PR DESCRIPTION
For MPEG2 streams, when a frame is encoded in the form of separate fields, MediaInfo erroneously detects second filed of an I-frame as a beginning of a new GOP. That leads to picture_coding_types being populated with I-frame only GOP consisting of I-frame's first fields and the remainder of the GOP with all but first frames being duplicated. That eventually breaks variable GOP detection.

I suggest considering only the first filed in calculations, in order to achieve expected behavior. In my tests, proposed changes didn't brake neither progressive stream handling, nor interlaced streams with picture structure "frame".