### PR TITLE
MPEG-4: use ISO 8859-1 locale when showing atom codes

### DIFF
--- a/Source/MediaInfo/File__Analyze_Buffer.cpp
+++ b/Source/MediaInfo/File__Analyze_Buffer.cpp
@@ -1570,7 +1570,7 @@ void File__Analyze::Get_C4(int32u &Info, const char* Name)
 {
     INTEGRITY_SIZE_ATLEAST_INT(4);
     Info=CC4(Buffer+Buffer_Offset+(size_t)Element_Offset);
-    if (Trace_Activated) Param(Name, Buffer+Buffer_Offset+(size_t)Element_Offset, 4, false);
+    if (Trace_Activated) Param(Name, Ztring().From_ISO_8859_1((const char*)Buffer+Buffer_Offset+(size_t)Element_Offset, 4), false);
     Element_Offset+=4;
 }
 

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -1900,7 +1900,7 @@ void File_Mpeg4::Header_Parse()
     }
 
     //Filling
-    Header_Fill_Code(Name, Ztring().From_CC4(Name));
+    Header_Fill_Code(Name, Ztring().From_ISO_8859_1((const char*)Buffer+Buffer_Offset+4, 4));
     Header_Fill_Size(Size);
 
     if (Name==0x6D6F6F76 && Buffer_Offset+Size>Buffer_Size-Buffer_Offset) //moov


### PR DESCRIPTION
Using the system locale is faster but fails with e.g. © (not pure ASCII) when the locale is UTF-8 (nowadays all systems except Windows), when showing atom codes in the output e.g. MediaTrace.

TODO: current code for ISO 8859-1 locale is slower but can be accelerated.

Additional fix for https://github.com/MediaArea/MediaConch_SourceCode/issues/630 on non Windows machine.
cc @dericed .