### PR TITLE
 MXF: display information when wrapper/essence values are detected as not same

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -17391,7 +17391,7 @@ void File_Mxf::ColorLevels_Compute(descriptors::iterator Descriptor, bool Force,
     std::map<std::string, Ztring>::iterator Info=Descriptor->second.Infos.find("BitDepth");
     if (Info!=Descriptor->second.Infos.end())
     {
-        if (BitDepth==(int32u)-1)
+        if (BitDepth==0 || BitDepth==(int32u)-1)
             BitDepth=Info->second.To_int32u();
         else if (Force && BitDepth!=Info->second.To_int32u())
             Fill(StreamKind_Last, StreamPos_Last, "BitDepth_Container", Info->second);


### PR DESCRIPTION
additions to https://github.com/MediaArea/MediaInfoLib/pull/1021