### PR TITLE
Small fix

### DIFF
--- a/Source/MediaInfo/Export/Export_Niso.cpp
+++ b/Source/MediaInfo/Export/Export_Niso.cpp
@@ -76,7 +76,7 @@ void ComputeSamplingFrequency(Node* Parent, Ztring& Value)
         Value.resize(Value.size()-1);
 
     int32u SamplingFrequencyDenominator=0;
-    size_t Dot=Value.find(__T("."));
+    size_t Dot=Value.find(__T('.'));
     if (Dot!=std::string::npos)
     {
         Value.erase(Dot, 1);

--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -477,7 +477,6 @@ Ztring MediaInfo_Internal::Inform (stream_t StreamKind, size_t StreamPos, bool I
         bool XML=false;
         bool XML_0_7_78=false;
         bool JSON=false;
-        std::vector<Node*> Nodes;
         #endif //MEDIAINFO_XML_YES || MEDIAINFO_JSON_YES
 
         #if defined(MEDIAINFO_HTML_YES)


### PR DESCRIPTION
V808 'Nodes' object of 'vector' type was created but was not utilized. MediaInfo_Inform.cpp 480
V817 It is more efficient to seek '.' character rather than a string. Export_Niso.cpp 79