### PR TITLE
PBCore2: fix essenceFrameSize with non Video tracks

### DIFF
--- a/Source/MediaInfo/Export/Export_PBCore2.cpp
+++ b/Source/MediaInfo/Export/Export_PBCore2.cpp
@@ -210,9 +210,7 @@ Ztring ToReturn;
     Node_EssenceTrack->Add_Child_IfNotEmpty(MI, StreamKind, StreamPos, "BitDepth", "essenceTrackBitDepth");
 
     //essenceTrackFrameSize
-    if (!MI.Get(StreamKind, StreamPos, Video_Width).empty())
-        Node_EssenceTrack->Add_Child("essenceTrackFrameSize", MI.Get(StreamKind, StreamPos, Video_Width)+__T("x")+MI.Get(StreamKind, StreamPos, Video_Height));
-    else if (!MI.Get(StreamKind, StreamPos, __T("Width")).empty())
+    if (!MI.Get(StreamKind, StreamPos, __T("Width")).empty())
     {
         Ztring framesize;
         framesize=MI.Get(StreamKind, StreamPos, __T("Width"));


### PR DESCRIPTION
Fix #1032.
Remove test dedicated to Video (but without testing if the track is a video one), the generic test is enough.