### PR TITLE
DCP: support of multi-reel DCP

### DIFF
--- a/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
+++ b/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
@@ -305,6 +305,71 @@ void File__ReferenceFilesHelper::AddSequence(sequence* NewSequence)
 }
 
 //---------------------------------------------------------------------------
+void File__ReferenceFilesHelper::DetectSameReels(vector<size_t> &ReelCount)
+{
+    if (ReelCount.size()<=1)
+        return;
+
+    // Finding the max count of streams per stream kind
+    size_t StreamCounts_Max[Stream_Max+1];
+    size_t StreamCounts[Stream_Max+1];
+    vector<size_t> Sequence_Pos_PerKind[Stream_Max+1];
+    memset(StreamCounts_Max, 0x00, (Stream_Max+1)*sizeof(size_t));
+    size_t Sequence_Pos=0;
+    for (size_t r=0; r<ReelCount.size(); r++)
+    {
+        memset(StreamCounts, 0x00, (Stream_Max+1)*sizeof(size_t));
+        for (size_t i=0; i<ReelCount[r]; i++)
+        {
+            if (Sequence_Pos_PerKind[Sequences[Sequence_Pos]->StreamKind].size()<=StreamCounts[Sequences[Sequence_Pos]->StreamKind])
+                Sequence_Pos_PerKind[Sequences[Sequence_Pos]->StreamKind].push_back(Sequence_Pos);
+            StreamCounts[Sequences[Sequence_Pos]->StreamKind]++;
+            Sequence_Pos++;
+        }
+        for (size_t i=0; i<Stream_Max+1; i++)
+            if (StreamCounts[i] && StreamCounts[i]!=StreamCounts_Max[i])
+            {
+                if (StreamCounts_Max[i])
+                    return; // incoherent count of streams per stream kind, we do nothing
+                StreamCounts_Max[i]=StreamCounts[i];
+            }
+    }
+
+    //Merge resources from different reels
+    Sequence_Pos=ReelCount[0];
+    vector<size_t> Sequence_Pos_toDelete;
+    for (size_t r=1; r<ReelCount.size(); r++)
+    {
+        memset(StreamCounts, 0x00, (Stream_Max+1)*sizeof(size_t));
+        for (size_t i=0; i<ReelCount[r]; i++)
+        {
+            if (Sequences[Sequence_Pos]->StreamKind!=Stream_Max)
+            {
+                size_t Sequence_Pos_First=Sequence_Pos_PerKind[Sequences[Sequence_Pos]->StreamKind][StreamCounts[Sequences[Sequence_Pos]->StreamKind]];
+                if (Sequence_Pos!=Sequence_Pos_First)
+                {
+                    Sequences[Sequence_Pos_First]->Resources.insert(Sequences[Sequence_Pos_First]->Resources.end(), Sequences[Sequence_Pos]->Resources.begin(), Sequences[Sequence_Pos]->Resources.end());
+                    Sequence_Pos_toDelete.push_back(Sequence_Pos);
+                }
+            }
+            StreamCounts[Sequences[Sequence_Pos]->StreamKind]++;
+            Sequence_Pos++;
+        }
+    }
+
+    // Remove other reels
+    for (size_t i=Sequence_Pos_toDelete.size()-1; i!=(size_t)-1; i--)
+    {
+        delete Sequences[Sequence_Pos_toDelete[i]];
+        Sequences.erase(Sequences.begin()+Sequence_Pos_toDelete[i]);
+    }
+
+    // Fake StreamIDs
+    for (size_t i=0; i<Sequences.size(); i++)
+        Sequences[i]->StreamID=i+1;
+}
+
+//---------------------------------------------------------------------------
 void File__ReferenceFilesHelper::UpdateFileName(const Ztring& OldFileName, const Ztring& NewFileName)
 {
     size_t Sequences_Size=Sequences.size();

--- a/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.h
+++ b/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.h
@@ -34,6 +34,7 @@ public :
 
     //In
     void                            AddSequence(sequence* NewSequence);
+    void                            DetectSameReels(vector<size_t> &ReelCount);
     void                            UpdateFileName(const Ztring& OldFileName, const Ztring& NewFileName);
     void                            UpdateMetaDataFromSourceEncoding(const string& SourceEncoding, const string& Name, const string& Value);
     bool                            TestContinuousFileNames;


### PR DESCRIPTION
Fix #992.

@kieranjol, I "merge" MXF files duration when I detect the same count of files per reel and the same kind of file in the same order for each reel (if reel 1 has Video then Audio, other reels must have Video then Audio too), in order to simplify the algorithm.
If count of files per reel or file kind order is different, I keep displaying each file in its each part, as I don't know yet how I would like to display that in MediaInfo in a readable way (how should it be actually displayed?), if I decide to support such kind of content one day.

I also display only the first file in the "Source" line, I am reluctant to display 10 file names in this MediaInfo field when there are 10 reels. The issue is not really technical and is not new (already implemented for IMF packages having several resources for a track), just that the MediaInfo output in text may be huge if I list all file names in 1 shot (some IMF packages have hundreds of files for a single track)

So result is e.g. for a multi-reel package with 1mn20s + 40s content:

```
General
Complete name                            : Jerome_FTR-1-25_F-133_2K_20180912_SMPTE_OV\cpl_baf3403d-c7cf-490f-8b47-3a09521bdc5a.xml
Format                                   : DCP CPL
File size                                : 1.05 GiB
Duration                                 : 2 min 0 s
Overall bit rate                         : 74.9 Mb/s

Video
ID                                       : 1-2
Format                                   : JPEG 2000
Format profile                           : D-Cinema 2k
Format settings, wrapping mode           : Frame
Muxing mode                              : MXF
Codec ID                                 : 0D010301020C0100-0401020203010103
Duration                                 : 2 min 0 s
Bit rate                                 : 68.0 Mb/s
Width                                    : 1 998 pixels
Height                                   :  pixel0
Original height                          : 1 080 pixels
Display aspect ratio                     : 1.85:1
Frame rate                               : 25.000 FPS
Color space                              : XYZ
Chroma subsampling                       : 4:4:4
Bit depth                                : 12 bits
Scan type                                : Progressive
Stream size                              : 973 MiB (91%)
Title                                    : Picture Track
Color range                              : Full
Source                                   : j2c_304cc461-bb25-4976-8117-c33d0ccbe3eb.mxf

Audio
ID                                       : 2-2
Format                                   : PCM
Format settings                          : Little
Format settings, wrapping mode           : Frame (BWF)
Muxing mode                              : MXF
Codec ID                                 : 0D01030102060100-0000000000000000
Duration                                 : 2 min 0 s
Bit rate mode                            : Constant
Bit rate                                 : 6 912 kb/s
Channel(s)                               : 6 channels
Sampling rate                            : 48.0 kHz
Frame rate                               : 25.000 FPS (1920 SPF)
Bit depth                                : 24 bits
Stream size                              : 98.9 MiB (9%)
Title                                    : Sound Track
Source                                   : pcm_ed08d089-6f26-4d12-aef6-3d060dad53a7.mxf
Locked                                   : No
```
