### PR TITLE
C++17, windows.h, using namespace std

### DIFF
--- a/Source/MediaInfo/Reader/Reader_File.cpp
+++ b/Source/MediaInfo/Reader/Reader_File.cpp
@@ -28,7 +28,10 @@
 #include "ZenLib/FileName.h"
 #ifdef WINDOWS
     #undef __TEXT
-    #include "Windows.h"
+    namespace WindowsNamespace
+    {
+    #include "windows.h"
+    }
 #endif //WINDOWS
 using namespace ZenLib;
 using namespace std;
@@ -721,7 +724,7 @@ size_t Reader_File::Format_Test_PerParser_Continue (MediaInfo_Internal* MI)
                     }
 
                     #ifdef WINDOWS
-                        Sleep(1000);
+                        WindowsNamespace::Sleep(1000);
                     #endif //WINDOWS
                 }
 

--- a/Source/MediaInfo/Reader/Reader_File.h
+++ b/Source/MediaInfo/Reader/Reader_File.h
@@ -25,7 +25,10 @@
 #if MEDIAINFO_READTHREAD
     #ifdef WINDOWS
         #undef __TEXT
-        #include "Windows.h"
+        namespace WindowsNamespace
+        {
+        #include "windows.h"
+        }
     #endif //WINDOWS
 #endif //MEDIAINFO_READTHREAD
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Reader/Reader_libcurl.cpp
+++ b/Source/MediaInfo/Reader/Reader_libcurl.cpp
@@ -1150,7 +1150,7 @@ size_t Reader_libcurl::Format_Test_PerParser_Continue (MediaInfo_Internal* MI)
 
                                     Curl_Data->CountOfSeconds++;
                                     #ifdef WINDOWS
-                                        Sleep(1000);
+                                        WindowsNamespace::Sleep(1000);
                                     #endif //WINDOWS
 
                                     continue;
@@ -1234,7 +1234,7 @@ size_t Reader_libcurl::Format_Test_PerParser_Continue (MediaInfo_Internal* MI)
                             if (FileSize_Old==Curl_Data->FileSize)
                             {
                                 #ifdef WINDOWS
-                                    Sleep(1000);
+                                    WindowsNamespace::Sleep(1000);
                                 #endif //WINDOWS
                             }
                         }
@@ -1360,7 +1360,7 @@ bool Reader_libcurl::Load(const Ztring File_Name)
                 #ifdef WINDOWS_UWP
                     libcurl_Module=LoadPackagedLibrary(MEDIAINFODLL_NAME, 0);
                 #else
-                    libcurl_Module=LoadLibrary(MEDIAINFODLL_NAME);
+                    libcurl_Module=WindowsNamespace::LoadLibrary(MEDIAINFODLL_NAME);
                 #endif
             #else
                 libcurl_Module=dlopen(MEDIAINFODLL_NAME, RTLD_LAZY);

--- a/Source/MediaInfo/Reader/Reader_libcurl_Include.h
+++ b/Source/MediaInfo/Reader/Reader_libcurl_Include.h
@@ -926,8 +926,11 @@ extern "C"
     static GModule* libcurl_Module=NULL;
 #elif defined (_WIN32) || defined (WIN32)
     #undef __TEXT
-    #include <windows.h>
-    static HMODULE  libcurl_Module=NULL;
+    namespace WindowsNamespace
+    {
+    #include "windows.h"
+    }
+    static WindowsNamespace::HMODULE  libcurl_Module=NULL;
 #else
     #include <dlfcn.h>
     static void*    libcurl_Module=NULL;

--- a/Source/MediaInfo/Text/File_AribStdB24B37.cpp
+++ b/Source/MediaInfo/Text/File_AribStdB24B37.cpp
@@ -28,7 +28,10 @@
 #include <vector>
 #ifdef __WINDOWS__
     #undef __TEXT
+    namespace WindowsNamespace
+    {
     #include "windows.h"
+    }
 #endif // __WINDOWS__
 
 #if MEDIAINFO_EVENTS
@@ -813,7 +816,7 @@ void File_AribStdB24B37::JIS (int8u Row, int8u Column)
             ShiftJIS[1]=Column+126;
 
         wchar_t Temp[2];
-        int CharSize=MultiByteToWideChar(932, 0, ShiftJIS, 2, Temp, 2); //932 = Shift-JIS (Windows-31J)
+        int CharSize=WindowsNamespace::MultiByteToWideChar(932, 0, ShiftJIS, 2, Temp, 2); //932 = Shift-JIS (Windows-31J)
         if (CharSize>0)
         {
             Temp[CharSize]=__T('\0');


### PR DESCRIPTION
Fix compilation issue when there is the combo C++17, windows.h, using namespace std

```
rpcndr.h(192): error C2872: 'byte': ambiguous symbol
```