### PR TITLE
C++17, windows.h, using namespace std (update)

### DIFF
--- a/Source/MediaInfo/Reader/Reader_File.cpp
+++ b/Source/MediaInfo/Reader/Reader_File.cpp
@@ -28,10 +28,15 @@
 #include "ZenLib/FileName.h"
 #ifdef WINDOWS
     #undef __TEXT
-    namespace WindowsNamespace
-    {
+    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+        namespace WindowsNamespace
+        {
+    #endif
     #include "windows.h"
-    }
+    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+        }
+        using namespace WindowsNamespace;
+    #endif
 #endif //WINDOWS
 using namespace ZenLib;
 using namespace std;
@@ -724,7 +729,7 @@ size_t Reader_File::Format_Test_PerParser_Continue (MediaInfo_Internal* MI)
                     }
 
                     #ifdef WINDOWS
-                        WindowsNamespace::Sleep(1000);
+                        Sleep(1000);
                     #endif //WINDOWS
                 }
 

--- a/Source/MediaInfo/Reader/Reader_File.h
+++ b/Source/MediaInfo/Reader/Reader_File.h
@@ -25,10 +25,15 @@
 #if MEDIAINFO_READTHREAD
     #ifdef WINDOWS
         #undef __TEXT
-        namespace WindowsNamespace
-        {
+        #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+            namespace WindowsNamespace
+            {
+        #endif
         #include "windows.h"
-        }
+        #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+            }
+            using namespace WindowsNamespace;
+        #endif
     #endif //WINDOWS
 #endif //MEDIAINFO_READTHREAD
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Reader/Reader_libcurl.cpp
+++ b/Source/MediaInfo/Reader/Reader_libcurl.cpp
@@ -1150,7 +1150,7 @@ size_t Reader_libcurl::Format_Test_PerParser_Continue (MediaInfo_Internal* MI)
 
                                     Curl_Data->CountOfSeconds++;
                                     #ifdef WINDOWS
-                                        WindowsNamespace::Sleep(1000);
+                                        Sleep(1000);
                                     #endif //WINDOWS
 
                                     continue;
@@ -1234,7 +1234,7 @@ size_t Reader_libcurl::Format_Test_PerParser_Continue (MediaInfo_Internal* MI)
                             if (FileSize_Old==Curl_Data->FileSize)
                             {
                                 #ifdef WINDOWS
-                                    WindowsNamespace::Sleep(1000);
+                                    Sleep(1000);
                                 #endif //WINDOWS
                             }
                         }
@@ -1360,7 +1360,7 @@ bool Reader_libcurl::Load(const Ztring File_Name)
                 #ifdef WINDOWS_UWP
                     libcurl_Module=LoadPackagedLibrary(MEDIAINFODLL_NAME, 0);
                 #else
-                    libcurl_Module=WindowsNamespace::LoadLibrary(MEDIAINFODLL_NAME);
+                    libcurl_Module=LoadLibrary(MEDIAINFODLL_NAME);
                 #endif
             #else
                 libcurl_Module=dlopen(MEDIAINFODLL_NAME, RTLD_LAZY);

--- a/Source/MediaInfo/Reader/Reader_libcurl_Include.h
+++ b/Source/MediaInfo/Reader/Reader_libcurl_Include.h
@@ -926,11 +926,16 @@ extern "C"
     static GModule* libcurl_Module=NULL;
 #elif defined (_WIN32) || defined (WIN32)
     #undef __TEXT
-    namespace WindowsNamespace
-    {
+    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+        namespace WindowsNamespace
+        {
+    #endif
     #include "windows.h"
-    }
-    static WindowsNamespace::HMODULE  libcurl_Module=NULL;
+    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+        }
+        using namespace WindowsNamespace;
+    #endif
+    static HMODULE  libcurl_Module=NULL;
 #else
     #include <dlfcn.h>
     static void*    libcurl_Module=NULL;

--- a/Source/MediaInfo/Text/File_AribStdB24B37.cpp
+++ b/Source/MediaInfo/Text/File_AribStdB24B37.cpp
@@ -28,10 +28,15 @@
 #include <vector>
 #ifdef __WINDOWS__
     #undef __TEXT
-    namespace WindowsNamespace
-    {
+    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+        namespace WindowsNamespace
+        {
+    #endif
     #include "windows.h"
-    }
+    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+        }
+        using namespace WindowsNamespace;
+    #endif
 #endif // __WINDOWS__
 
 #if MEDIAINFO_EVENTS
@@ -816,7 +821,7 @@ void File_AribStdB24B37::JIS (int8u Row, int8u Column)
             ShiftJIS[1]=Column+126;
 
         wchar_t Temp[2];
-        int CharSize=WindowsNamespace::MultiByteToWideChar(932, 0, ShiftJIS, 2, Temp, 2); //932 = Shift-JIS (Windows-31J)
+        int CharSize=MultiByteToWideChar(932, 0, ShiftJIS, 2, Temp, 2); //932 = Shift-JIS (Windows-31J)
         if (CharSize>0)
         {
             Temp[CharSize]=__T('\0');


### PR DESCRIPTION
Issue reported in https://github.com/MediaArea/MediaInfoLib/issues/1079 about https://github.com/MediaArea/MediaInfoLib/pull/1076, trying another method.

`_MSVC_LANG` is there because [Microsoft decided to not comply to __cplusplus part of the C++ spec](https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus), for the moment [by default](https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus/) (so it still doesn't comply in most cases).