### PR TITLE
MPEG Audio: protection_bit was not correctly handled

### DIFF
--- a/Source/MediaInfo/Audio/File_Mpega.cpp
+++ b/Source/MediaInfo/Audio/File_Mpega.cpp
@@ -1034,7 +1034,7 @@ void File_Mpega::Data_Parse()
     }
 
     //error_check
-    if (protection_bit)
+    if (!protection_bit)
     {
         Element_Begin1("error_check");
         Skip_B2(                                                "crc_check");


### PR DESCRIPTION
Impact is only on the [MediaTrace](https://mediaarea.net/MediaTrace) feature.