### PR TITLE
Typos in language file, update

### DIFF
--- a/Source/MediaInfo/File_Dummy.cpp
+++ b/Source/MediaInfo/File_Dummy.cpp
@@ -165,7 +165,7 @@ void File_Dummy::Fill_Dummy_General()
     Fill(Stream_General, 0, General_ExecutiveProducer, "ExecutiveProducer");
     Fill(Stream_General, 0, General_ProductionDesigner, "ProductionDesigner");
     Fill(Stream_General, 0, General_CostumeDesigner, "CostumeDesigner");
-    Fill(Stream_General, 0, General_Choreographer, "Choregrapher");
+    Fill(Stream_General, 0, General_Choreographer, "Choreographer");
     Fill(Stream_General, 0, General_SoundEngineer, "SoundEngineer");
     Fill(Stream_General, 0, General_MasteredBy, "MasteredBy");
     Fill(Stream_General, 0, General_RemixedBy, "RemixedBy");

--- a/Source/MediaInfo/MediaInfo_Internal.cpp
+++ b/Source/MediaInfo/MediaInfo_Internal.cpp
@@ -1749,6 +1749,8 @@ Ztring MediaInfo_Internal::Get(stream_t StreamKind, size_t StreamPos, const Stri
         return Get(StreamKind, StreamPos, __T("DisplayAspectRatio"), KindOfInfo, KindOfSearch);
     if (Parameter==__T("AspectRatio/String"))
         return Get(StreamKind, StreamPos, __T("DisplayAspectRatio/String"), KindOfInfo, KindOfSearch);
+    if (Parameter==__T("Choregrapher"))
+        return Get(StreamKind, StreamPos, __T("Choreographer"), KindOfInfo, KindOfSearch);
     if (Parameter==__T("Chroma"))
         return Get(StreamKind, StreamPos, __T("Colorimetry"), KindOfInfo, KindOfSearch);
     if (Parameter==__T("PlayTime"))


### PR DESCRIPTION
from https://github.com/MediaArea/MediaInfoLib/pull/1106#discussion_r273226825 + handle the typo in `MediaInfo::Get()` for legacy tools.