### PR TITLE
Miscellaneous fixes

### DIFF
--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -789,19 +789,19 @@ void File__Analyze::Open_Buffer_Continue (const int8u* ToAdd, size_t ToAdd_Size)
             else
             #endif //MEDIAINFO_DEMUX
             {
-                if (Buffer_Temp!=NULL && Buffer_Temp_Size_Max<ToAdd_Size-Buffer_Offset)
+                if (Buffer_Temp!=NULL && Buffer_Temp_Size_Max<Buffer_Size-Buffer_Offset)
                 {
                     delete[] Buffer_Temp; Buffer_Temp=NULL; Buffer_Temp_Size=0; Buffer_Temp_Size_Max=0;
                 }
                 if (Buffer_Temp==NULL)
                 {
-                    size_t Buffer_Temp_Size_Max_ToAdd=ToAdd_Size-Buffer_Offset>32768?ToAdd_Size-Buffer_Offset:32768;
+                    size_t Buffer_Temp_Size_Max_ToAdd=Buffer_Size-Buffer_Offset>32768?Buffer_Size-Buffer_Offset:32768;
                     if (Buffer_Temp_Size_Max_ToAdd<Buffer_Temp_Size_Max) Buffer_Temp_Size_Max_ToAdd=Buffer_Temp_Size_Max;
                     Buffer_Temp_Size_Max=Buffer_Temp_Size_Max_ToAdd;
                     Buffer_Temp=new int8u[Buffer_Temp_Size_Max];
                 }
-                Buffer_Temp_Size=ToAdd_Size-Buffer_Offset;
-                memcpy_Unaligned_Unaligned(Buffer_Temp, ToAdd+Buffer_Offset, Buffer_Temp_Size);
+                Buffer_Temp_Size=Buffer_Size-Buffer_Offset;
+                memcpy_Unaligned_Unaligned(Buffer_Temp, Buffer+Buffer_Offset, Buffer_Temp_Size);
             }
         }
         else if (Buffer_Offset) //Already a copy, just moving it

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -518,9 +518,10 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Paramete
                             switch (Parameter)
                             {
                                 case Audio_SamplesPerFrame:
+                                case Audio_SamplingRate:
                                     if (Retrieve(Stream_Audio, StreamPos, Audio_FrameRate).empty())
                                     {
-                                        float64 SamplesPerFrame=Value.To_float64();
+                                        float64 SamplesPerFrame=Retrieve(Stream_Audio, StreamPos, Audio_SamplesPerFrame).To_float64();
                                         float64 SamplingRate=DBL_MAX;
                                         ZtringList SamplingRates;
                                         SamplingRates.Separator_Set(0, " / ");

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -5401,7 +5401,8 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxxSound()
             Fill(Stream_Audio, StreamPos_Last, Audio_Channel_s_, Channels, 10, true);
         if (SampleSize!=0 && Element_Code!=0x6D703461 && (Element_Code&0xFFFF0000)!=0x6D730000 && Retrieve(Stream_Audio, StreamPos_Last, Audio_BitDepth).empty()) //if not mp4a, and not ms*
             Fill(Stream_Audio, StreamPos_Last, Audio_BitDepth, SampleSize, 10, true);
-        Fill(Stream_Audio, StreamPos_Last, Audio_SamplingRate, SampleRate, 10, true);
+        if (SampleRate)
+            Fill(Stream_Audio, StreamPos_Last, Audio_SamplingRate, SampleRate, 10, true);
 
         //Sometimes, more Atoms in this atoms
         if (Element_Offset+8<Element_Size)

--- a/Source/MediaInfo/Multiple/File_Riff.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff.cpp
@@ -515,6 +515,21 @@ void File_Riff::Streams_Finish ()
             }
         }
 
+        if (StreamKind_Last==Stream_Audio && Retrieve(Stream_Audio, StreamPos_Last, Audio_Format)==__T("MPEG Audio"))
+        {
+            Ztring Delay = Retrieve(Stream_Audio, StreamPos_Last, Audio_Delay);
+            Ztring Delay_Original = Retrieve(Stream_Audio, StreamPos_Last, Audio_Delay_Original);
+            if (!Delay.empty() && !Delay_Original.empty())
+            {
+                Fill(Stream_Audio, StreamPos_Last, Audio_Delay, Delay.To_float64()+ Delay_Original.To_float64(), 0, true);
+                Ztring Delay_Source = Retrieve(Stream_Audio, StreamPos_Last, Audio_Delay_Source);
+                Ztring Delay_Original_Source = Retrieve(Stream_Audio, StreamPos_Last, Audio_Delay_Original_Source);
+                Fill(Stream_Audio, StreamPos_Last, Audio_Delay_Source, Delay_Source+__T(" + ")+Delay_Original_Source, true);
+                Clear(Stream_Audio, StreamPos_Last, Audio_Delay_Original);
+                Clear(Stream_Audio, StreamPos_Last, Audio_Delay_Original_Source);
+            }
+        }
+
         ++Temp;
     }
 


### PR DESCRIPTION
WAV: MP3 delay should be added to BWF time reference 
USAC: frame rate was missing in case of non standard sampling rate
Fix misbehavior of the buffering algo, leading sometimes to invalid reads