### PR TITLE
Parse of RAWcooked elements, also when in Matroska file

### DIFF
--- a/Source/MediaInfo/File__Analyze.h
+++ b/Source/MediaInfo/File__Analyze.h
@@ -608,6 +608,7 @@ public :
     void Skip_BF8 (               const char* Name);
     void Skip_BF10(               const char* Name);
     void Skip_BFP4(int8u Bits,                const char* Name);
+    void Skip_Hexa(int8u Bytes,   const char* Name);
     #define Info_B1(_INFO, _NAME)   int8u   _INFO; Get_B1  (_INFO, _NAME)
     #define Info_B2(_INFO, _NAME)   int16u  _INFO; Get_B2  (_INFO, _NAME)
     #define Info_B3(_INFO, _NAME)   int32u  _INFO; Get_B3  (_INFO, _NAME)
@@ -1335,6 +1336,7 @@ protected :
     int64u Buffer_TotalBytes_FirstSynched_Max;
     int64u Buffer_TotalBytes_Fill_Max;
     friend class File__Tags_Helper;
+    friend class File_Mk;
     friend class File_Mpeg4;
     friend class File_Mk;
 

--- a/Source/MediaInfo/File__Analyze_Buffer.cpp
+++ b/Source/MediaInfo/File__Analyze_Buffer.cpp
@@ -459,6 +459,28 @@ void File__Analyze::Skip_B16(const char* Name)
 }
 
 //---------------------------------------------------------------------------
+void File__Analyze::Skip_Hexa(int8u Bytes, const char* Name)
+{
+    INTEGRITY_SIZE_ATLEAST(Bytes);
+    if (Trace_Activated)
+    {
+        string ValueS;
+        ValueS.resize(Bytes*2);
+        const int8u* Buffer_Temp=Buffer+Buffer_Offset+(size_t)Element_Offset;
+        for (int8u i=0; i<Bytes; i++)
+        {
+            int8u Value=Buffer_Temp[i];
+            int8u Value0=Value>>4;
+            int8u Value1=Value&0xF;
+            ValueS[i*2  ]=Value0+(Value0>9?('A'-10):('0'));
+            ValueS[i*2+1]=Value1+(Value1>9?('A'-10):('0'));
+        }
+        Param(Name, ValueS);
+    }
+    Element_Offset+=Bytes;
+}
+
+//---------------------------------------------------------------------------
 void File__Analyze::Skip_BF4(const char* Name)
 {
     INTEGRITY_SIZE_ATLEAST(4);

--- a/Source/MediaInfo/File__Analyze_Element.cpp
+++ b/Source/MediaInfo/File__Analyze_Element.cpp
@@ -644,6 +644,16 @@ element_details::Element_Node::Element_Node(const Element_Node& node)
 }
 
 //---------------------------------------------------------------------------
+void element_details::Element_Node::TakeChilrenFrom(Element_Node& node)
+{
+    if (this == &node || !OwnChildren || !node.OwnChildren)
+        return;
+
+    Children.insert(Children.end(), node.Children.begin(), node.Children.end());
+    node.Children.clear();
+}
+
+//---------------------------------------------------------------------------
 element_details::Element_Node::~Element_Node()
 {
     if (!OwnChildren)

--- a/Source/MediaInfo/File__Analyze_Element.h
+++ b/Source/MediaInfo/File__Analyze_Element.h
@@ -137,6 +137,9 @@ struct element_details
         Element_Node(const Element_Node& node);
         ~Element_Node();
 
+        // Move
+        void TakeChilrenFrom(Element_Node& node);
+
         int64u                           Pos;             // Position of the element in the file
         int64u                           Size;            // Size of the element (including header and sub-elements)
     private:

--- a/Source/MediaInfo/File__Analyze_MinimizeSize.h
+++ b/Source/MediaInfo/File__Analyze_MinimizeSize.h
@@ -421,6 +421,7 @@ public :
     #define Skip_BF8(Name) Element_Offset+=8
     #define Skip_B16(Name) Element_Offset+=16
     #define Skip_BFP4(Size, Name) Element_Offset+=4
+    #define Skip_Hexa(Bytes, Name) Element_Offset+=Bytes
     #define Info_B1(_INFO, _NAME)   Element_Offset++
     #define Info_B2(_INFO, _NAME)   Element_Offset+=2
     #define Info_B3(_INFO, _NAME)   Element_Offset+=3
@@ -1260,6 +1261,7 @@ protected :
     int64u Buffer_TotalBytes_FirstSynched_Max;
     int64u Buffer_TotalBytes_Fill_Max;
     friend class File__Tags_Helper;
+    friend class File_Mk;
     friend class File_Mpeg4;
 
     //***************************************************************************

--- a/Source/MediaInfo/File__MultipleParsing.cpp
+++ b/Source/MediaInfo/File__MultipleParsing.cpp
@@ -868,6 +868,11 @@ void File__MultipleParsing::Read_Buffer_Continue()
                 //Positionning if requested
                 if (Parser[0]->File_GoTo!=(int64u)-1)
                    File_GoTo=Parser[0]->File_GoTo;
+
+                //Clean
+                #if MEDIAINFO_TRACE
+                    Details->clear();
+                #endif //MEDIAINFO_TRACE
             }
         }
     }

--- a/Source/MediaInfo/MediaInfo_Internal.h
+++ b/Source/MediaInfo/MediaInfo_Internal.h
@@ -111,6 +111,7 @@ private :
     friend class File_Bdmv;  //Theses classes need access to internal structure for optimization. There is recursivity with theses formats
     friend class File_Cdxa;  //Theses classes need access to internal structure for optimization. There is recursivity with theses formats
     friend class File_Lxf;   //Theses classes need access to internal structure for optimization. There is recursivity with theses formats
+    friend class File_Mk;  //Theses classes need access to internal structure for optimization. There is recursivity with theses formats
     friend class File_Mpeg4; //Theses classes need access to internal structure for optimization. There is recursivity with theses formats
     friend class File_MpegTs;//Theses classes need access to internal structure for optimization. There is recursivity with theses formats
     friend class File_MpegPs;//Theses classes need access to internal structure for optimization. There is recursivity with theses formats

--- a/Source/MediaInfo/Multiple/File_Mk.h
+++ b/Source/MediaInfo/Multiple/File_Mk.h
@@ -66,23 +66,31 @@ private :
     void Ebml_DocType();
     void Ebml_DocTypeVersion();
     void Ebml_DocTypeReadVersion();
+    void Rawcooked_BeforeData();
+    void Rawcooked_BeforeData(bool HasMask, bool UseMask=false);
+    void Rawcooked_AfterData();
+    void Rawcooked_AfterData(bool HasMask, bool UseMask=false);
+    void Rawcooked_FileName();
+    void Rawcooked_FileName(bool HasMask, bool UseMask=false);
     void RawcookedBlock();
-    void RawcookedBlock_BeforeData();
-    void RawcookedBlock_AfterData();
-    void RawcookedBlock_FileName();
-    void RawcookedBlock_MaskAdditionBeforeData();
-    void RawcookedBlock_MaskAdditionAfterData();
-    void RawcookedBlock_MaskAdditionFileName();
+    void RawcookedBlock_BeforeData() { Rawcooked_BeforeData(false); }
+    void RawcookedBlock_AfterData() { Rawcooked_AfterData(false); }
+    void RawcookedBlock_FileHash();
+    void RawcookedBlock_FileName() { Rawcooked_FileName(false); }
+    void RawcookedBlock_MaskAdditionBeforeData() { Rawcooked_BeforeData(true, true); }
+    void RawcookedBlock_MaskAdditionAfterData() { Rawcooked_AfterData(true, true); }
+    void RawcookedBlock_MaskAdditionFileName() { Rawcooked_FileName(true, true); }
     void RawcookedSegment();
     void RawcookedSegment_LibraryName();
     void RawcookedSegment_LibraryVersion();
-    void RawcookedTrackEntry();
-    void RawcookedTrackEntry_BeforeData();
-    void RawcookedTrackEntry_AfterData();
-    void RawcookedTrackEntry_FileName();
-    void RawcookedTrackEntry_MaskBaseBeforeData();
-    void RawcookedTrackEntry_MaskBaseAfterData();
-    void RawcookedTrackEntry_MaskBaseFileName();
+    void RawcookedTrack();
+    void RawcookedTrack_BeforeData() { RawcookedBlock_BeforeData(); }
+    void RawcookedTrack_AfterData() { RawcookedBlock_AfterData(); }
+    void RawcookedTrack_FileHash() { RawcookedBlock_FileHash(); }
+    void RawcookedTrack_FileName() { RawcookedBlock_FileName(); }
+    void RawcookedTrack_MaskBaseBeforeData() { Rawcooked_BeforeData(true, false); }
+    void RawcookedTrack_MaskBaseAfterData() { Rawcooked_AfterData(true, false); }
+    void RawcookedTrack_MaskBaseFileName() { Rawcooked_FileName(true, false); }
     void Segment();
     void Segment_SeekHead();
     void Segment_SeekHead_Seek();
@@ -276,8 +284,6 @@ private :
     void Segment_Attachments_AttachedFile_FileName();
     void Segment_Attachments_AttachedFile_FileMimeType();
     void Segment_Attachments_AttachedFile_FileData();
-    void Segment_Attachments_AttachedFile_FileData_RawcookedBlock() {RawcookedBlock();};
-    void Segment_Attachments_AttachedFile_FileData_RawcookedTrackEntry() {RawcookedTrackEntry();};
     void Segment_Attachments_AttachedFile_FileUID(){UInteger_Info();};
     void Segment_Attachments_AttachedFile_FileReferral(){Skip_XX(Element_Size, "Data");};
     void Segment_Attachments_AttachedFile_FileUsedStartTime(){UInteger_Info();};
@@ -513,14 +519,34 @@ private :
     //RAWcooked data
     struct rawcookedtrack
     {
-        string MaskAdditionFileName;
-        int64u FramePos;
+        struct mask
+        {
+            int8u*      Buffer;
+            size_t      Size;
 
-        rawcookedtrack() :
-            FramePos(0)
-        {}
+            //mask(); //Init done in rawcookedtrack() in 1 shot
+            ~mask()
+            {
+                delete[] Buffer;
+            }
+        };
+        int64u          FramePos;
+        mask            MaskBaseFileName;
+        mask            MaskBaseBeforeData;
+
+        rawcookedtrack()
+        {
+            memset(this, 0x00, sizeof(rawcookedtrack));
+        }
     };
-    rawcookedtrack RawcookedTrack;
+    rawcookedtrack RawcookedTrack_Data;
+    const int8u* Rawcooked_Compressed_Save_Buffer;
+    size_t Rawcooked_Compressed_Save_Buffer_Offset;
+    int64u Rawcooked_Compressed_Save_Element_Offset;
+    int64u Rawcooked_Compressed_Save_Element_Size;
+    bool   Trace_Activated_Save;
+    bool Rawcooked_Compressed_Start(rawcookedtrack::mask* Mask=NULL, bool UseMask=false);
+    void Rawcooked_Compressed_End(rawcookedtrack::mask* Mask=NULL, bool UseMask=false);
 
     //Hints
     size_t*                 File_Buffer_Size_Hint_Pointer;


### PR DESCRIPTION
if MediaTrace is activated, it shows the content of the RAWcooked file inside the Matroska file.
@bturkus & @digitensions, it is a huge output but you can check the content of the RAWcooked file (DPX header, file MD5 presence...) this way (look for "XPDS" for the DPX header and "FileHash" for the MD5):

```
mediainfo "--Inform=Details;1" FileName.mkv
[...]
002F Segment (60511 bytes)
002F  Header (12 bytes)
002F   Name:                                 139690087 (0x8538067)
0033   Size:                                 60499 (0x0000000000EC53)
[...]
0329  Attachments (2052 bytes)
0329   Header (12 bytes)
0329    Name:                                155296873 (0x941A469)
032D    Size:                                2040 (0x000000000007F8)
0335   CRC-32 (6 bytes)
0335    Header (2 bytes)
0335     Name:                               63 (0x3F)
0336     Size:                               4 (0x04)
0337    Value:                               913380105 (0x36711309) - OK
033B   AttachedFile (2034 bytes)
033B    Header (10 bytes)
033B     Name:                               8615 (0x21A7)
033D     Size:                               2024 (0x000000000007E8)
0345    FileName - RAWcooked reversibility data (31 bytes)
0345     Header (3 bytes)
0345      Name:                              1646 (0x066E)
0347      Size:                              28 (0x1C)
0348     Data:                               RAWcooked reversibility data
0364    FileMimeType - application/octet-stream (27 bytes)
0364     Header (3 bytes)
0364      Name:                              1632 (0x0660)
0366      Size:                              24 (0x18)
0367     Data:                               application/octet-stream
037F    FileData (1959 bytes)
037F     Header (4 bytes)
037F      Name:                              1628 (0x065C)
0381      Size:                              1955 (0x07A3)
0000     EBML (25 bytes)
0000      Header (5 bytes)
0000       Name:                             172351395 (0xA45DFA3)
0004       Size:                             20 (0x14)
0005      DocType - rawcooked (12 bytes)
0005       Header (3 bytes)
0005        Name:                            642 (0x0282)
0007        Size:                            9 (0x09)
0008       Data:                             rawcooked
0011      DocTypeVersion - 1 (0x1) (4 bytes)
0011       Header (3 bytes)
0011        Name:                            647 (0x0287)
0013        Size:                            1 (0x01)
0014       Data:                             1 (0x01)
0015      DocTypeReadVersion - 1 (0x1) (4 bytes)
0015       Header (3 bytes)
0015        Name:                            645 (0x0285)
0017        Size:                            1 (0x01)
0018       Data:                             1 (0x01)
0019     RawcookedSegment (24 bytes)
0019      Header (4 bytes)
0019       Name:                             29299 (0x007273)
001C       Size:                             20 (0x14)
001D      LibraryName (11 bytes)
001D       Header (2 bytes)
001D        Name:                            112 (0x70)
001E        Size:                            9 (0x09)
001F       LibraryName:                      RAWcooked
0028      LibraryVersion (9 bytes)
0028       Header (2 bytes)
0028        Name:                            113 (0x71)
0029        Size:                            7 (0x07)
002A       LibraryVersion:                   18.10.1
0031     RawcookedTrack (132 bytes)
0031      Header (5 bytes)
0031       Name:                             29300 (0x007274)
0034       Size:                             127 (0x007F)
0036      MaskBaseFileName (39 bytes)
0036       Header (2 bytes)
0036        Name:                            17 (0x11)
0037        Size:                            37 (0x25)
0038       Size:                             44 (0x2C)
0039       Compressed data:                  (36 bytes)
0039       Data:                             title-of-work/dpx/title-of-work_00000001.dpx
005D      MaskBaseBeforeData (88 bytes)
[...]
00B5     RawcookedBlock - 0 (63 bytes)
00B5      Header (4 bytes)
00B5       Name:                             29282 (0x007262)
00B8       Size:                             59 (0x3B)
00B9      MaskAdditionFileName (15 bytes)
00B9       Header (2 bytes)
00B9        Name:                            17 (0x11)
00BA        Size:                            13 (0x0D)
00BB       Size:                             44 (0x2C)
00BC       Compressed data:                  (12 bytes)
00BC       Data:                             title-of-work/dpx/title-of-work_00000001.dpx
00C8      MaskAdditionBeforeData (25 bytes)
00C8       Header (2 bytes)
00C8        Name:                            3 (0x03)
00C9        Size:                            23 (0x17)
00CA       Size:                             1664 (0x0680)
00CC       Compressed data:                  (21 bytes)
0000       Generic section header (1664 bytes)
0000        File information (768 bytes)
0000         Magic number:                   XPDS
0004         Offset to image data:           1664 (0x00000680)
0008         Version number of header format: V1.0
0010         Total image file size:          77696 (0x00012F80)
0014         Ditto Key:                      16777216 (0x01000000)
0018         Generic section header length:  1664 (0x00000680)
001C         Industry specific header length: 0 (0x00000000)
0020         User-defined header length:     0 (0x00000000)
0024         FileName:                       
00A0         Creator:                        Lavc58.25.100
0294         Encryption key:                 4294967295 (0xFFFFFFFF)
0298         Reserved for future use:        (104 bytes)
0300        Image information (640 bytes)
0300         Image orientation:              0 (0x0000) - Left to right, Top to bottom
0302         Number of image elements:       1 (0x0001)
0304         Pixels per line:                176 (0x000000B0)
0308         Lines per image element:        144 (0x00000090)
030C         image element (72 bytes)
030C          Data sign:                     0 (0x00000000) - unsigned
0310          Reference low data code value: 0 (0x00000000)
0314          Reference low quantity represented: 0.000
0318          Reference high data code value: 0 (0x00000000)
031C          Reference high quantity represented: 0.000
0320          Descriptor:                    50 (0x32) - R,G,B
0321          Transfer characteristic:       2 (0x02) - Linear
0322          Colorimetric specification:    2 (0x02) - 
0323          Bit depth:                     8 (0x08) - integer
0324          Packing:                       0 (0x0000) - Packed
0326          Encoding:                      0 (0x0000) - Raw
0328          Offset to data:                1664 (0x00000680)
032C          End-of-line padding:           0 (0x00000000)
0330          End-of-image padding:          0 (0x00000000)
0334          Description of image element:  
0354         Padding:                        (504 bytes)
054C         Reserved for future use:        (52 bytes)
0580        Image source information (256 bytes)
0580         X Offset:                       0 (0x00000000)
0584         Y Offset:                       0 (0x00000000)
0588         X center:                       0.000
058C         Y center:                       0.000
0590         X original size:                0 (0x00000000)
0594         Y original size:                0 (0x00000000)
0598         Source image filename:          
05FC         Source image date/time:         
0614         Input device name:              
0634         Input device serial number:     
0654         Border validity (8 bytes)
0654          XL border:                     0 (0x0000)
0656          XR border:                     0 (0x0000)
0658          YT border:                     0 (0x0000)
065A          YB border:                     0 (0x0000)
065C         Pixel ratio : horizontal:       1 (0x00000001)
0660         Pixel ratio : vertical:         1 (0x00000001)
0664         Additional source image information (28 bytes)
0664          X scanned size:                0.000
0668          Y scanned size:                0.000
066C          Reserved for future use:       (20 bytes)
00E1      FileHash (19 bytes)
00E1       Header (2 bytes)
00E1        Name:                            32 (0x20)
00E2        Size:                            17 (0x11)
00E3       Type:                             0 (0x00) - MD5
00E4       Data:                             208222C8A73D50B23216FCF594A5A7D6
```