### PR TITLE
Matroska: PCM bit rate

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.h
+++ b/Source/MediaInfo/Multiple/File_Mk.h
@@ -230,7 +230,7 @@ private :
     void Segment_Tracks_TrackEntry_Video_Projection_ProjectionPoseYaw(){Float_Info();};
     void Segment_Tracks_TrackEntry_Video_Projection_ProjectionPosePitch(){Float_Info();};
     void Segment_Tracks_TrackEntry_Video_Projection_ProjectionPoseRoll(){Float_Info();};
-    void Segment_Tracks_TrackEntry_Audio(){};
+    void Segment_Tracks_TrackEntry_Audio();
     void Segment_Tracks_TrackEntry_Audio_SamplingFrequency();
     void Segment_Tracks_TrackEntry_Audio_OutputSamplingFrequency();
     void Segment_Tracks_TrackEntry_Audio_Channels();
@@ -423,6 +423,7 @@ private :
     int8u*   CodecPrivate;
     size_t   CodecPrivate_Size;
     void     CodecPrivate_Manage();
+    void     Audio_Manage();
     Ztring   CodecID;
     infocodecid_format_t InfoCodecID_Format_Type;
     void     CodecID_Manage();

--- a/Source/MediaInfo/Video/File_Ffv1.cpp
+++ b/Source/MediaInfo/Video/File_Ffv1.cpp
@@ -477,6 +477,7 @@ File_Ffv1::File_Ffv1()
     ConfigurationRecord_IsPresent=false;
     RC=NULL;
     slices = NULL;
+    version = (int32u)-1;
     picture_structure = (int32u)-1;
     sample_aspect_ratio_num = 0;
     sample_aspect_ratio_den = 0;
@@ -516,13 +517,16 @@ void File_Ffv1::Streams_Accept()
 {
     Stream_Prepare(Stream_Video);
     Fill(Stream_Video, 0, Video_Format, "FFV1");
-    Ztring Version=__T("Version ")+Ztring::ToZtring(version);
-    if (version>=3 && version<=4)
+    if (version!=(int32u)-1)
     {
-        Version+=__T('.');
-        Version+=Ztring::ToZtring(micro_version);
+        Ztring Version=__T("Version ")+Ztring::ToZtring(version);
+        if (version>=3 && version<=4)
+        {
+            Version+=__T('.');
+            Version+=Ztring::ToZtring(micro_version);
+        }
+        Fill(Stream_Video, 0, Video_Format_Version, Version);
     }
-    Fill(Stream_Video, 0, Video_Format_Version, Version);
     Fill(Stream_Video, 0, Video_BitRate_Mode, "VBR");
 }
 


### PR DESCRIPTION
For having [DV/MKV (or other/MKV!) comparison screenshot](https://twitter.com/pjotrek_b/status/1131445067284176896/photo/1) more coherent, showing the PCM bit rate also when in Matroska.
+ some cleanup / handling of default values.
cc @pjotrek-b