### PR TITLE
MOV: Time code frame rate

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -1012,6 +1012,28 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Paramete
         }
     }
 
+    if (StreamKind==Stream_Other && Parameter==Other_FrameRate)
+    {
+        Clear(StreamKind, StreamPos, Other_FrameRate_Num);
+        Clear(StreamKind, StreamPos, Other_FrameRate_Den);
+
+        if (Value)
+        {
+            if (float32_int32s(Value) - Value*1.001000 > -0.000002
+             && float32_int32s(Value) - Value*1.001000 < +0.000002) // Detection of precise 1.001 (e.g. 24000/1001) taking into account precision of 32-bit float
+            {
+                Fill(StreamKind, StreamPos, Other_FrameRate_Num,  Value*1001, 0, Replace);
+                Fill(StreamKind, StreamPos, Other_FrameRate_Den,   1001, 10, Replace);
+            }
+            if (float32_int32s(Value) - Value*1.001001 > -0.000002
+             && float32_int32s(Value) - Value*1.001001 < +0.000002) // Detection of rounded 1.001 (e.g. 23976/1000) taking into account precision of 32-bit float
+            {
+                Fill(StreamKind, StreamPos, Other_FrameRate_Num,  Value*1000, 0, Replace);
+                Fill(StreamKind, StreamPos, Other_FrameRate_Den,   1000, 10, Replace);
+            }
+        }
+    }
+
     Fill(StreamKind, StreamPos, Parameter, Ztring::ToZtring(Value, AfterComma), Replace);
 }
 

--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -1454,6 +1454,12 @@ void File__Analyze::Streams_Finish_HumanReadable_PerStream(stream_t StreamKind, 
          && !Retrieve(StreamKind, StreamPos, Video_FrameRate_Original_Num).empty()
          && !Retrieve(StreamKind, StreamPos, Video_FrameRate_Original_Den).empty())
             Fill(Stream_Video, StreamPos, Video_FrameRate_Original_String, MediaInfoLib::Config.Language_Get(Retrieve(StreamKind, StreamPos, Video_FrameRate_Original)+__T(" (")+Retrieve(StreamKind, StreamPos, Video_FrameRate_Original_Num)+__T("/")+Retrieve(StreamKind, StreamPos, Video_FrameRate_Original_Den)+__T(")"), __T(" fps")), true);
+        if (StreamKind==Stream_Other
+         && Parameter==Other_FrameRate
+         && !Retrieve(StreamKind, StreamPos, Other_FrameRate).empty()
+         && !Retrieve(StreamKind, StreamPos, Other_FrameRate_Num).empty()
+         && !Retrieve(StreamKind, StreamPos, Other_FrameRate_Den).empty())
+            Fill(Stream_Other, StreamPos, Other_FrameRate_String, MediaInfoLib::Config.Language_Get(Retrieve(StreamKind, StreamPos, Other_FrameRate)+__T(" (")+Retrieve(StreamKind, StreamPos, Other_FrameRate_Num)+__T("/")+Retrieve(StreamKind, StreamPos, Other_FrameRate_Den)+__T(")"), __T(" fps")), true);
     }
 
     //BitRate_Mode / OverallBitRate_Mode

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -4819,6 +4819,8 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_tmcd()
             Streams[moov_trak_tkhd_TrackID].StreamKind=Stream_Other;
             Streams[moov_trak_tkhd_TrackID].StreamPos=StreamPos_Last;
         }
+        if (tc->FrameDuration)
+            Fill(Stream_Other, StreamPos_Last, Other_FrameRate, ((float64)tc->TimeScale)/tc->FrameDuration);
 
         //Filling
         Streams[moov_trak_tkhd_TrackID].TimeCode=tc;


### PR DESCRIPTION
Frame rate line also for time code, in order to differentiate e.g. 30 fps vs 60 fps time codes

```
Frame rate                               : 29.970 (29970/1000) FPS
Time code of first frame                 : 01:16:13:09
```