### PR TITLE
chore(mediainfo): Escape extended ASCII chars

### DIFF
--- a/Source/MediaInfo/File__Analyze_Element.cpp
+++ b/Source/MediaInfo/File__Analyze_Element.cpp
@@ -364,6 +364,8 @@ static size_t Xml_Content_Escape_MustEscape(const char* Content, size_t Size)
             default:
                 if (C<0x20)
                     return Pos;
+                if (C>0x7F)
+                    return Pos;
         }
     }
 


### PR DESCRIPTION
Fix Mediaconch error: [220](https://github.com/MediaArea/MediaConch/issues/220) and [220](https://github.com/MediaArea/MediaConch/issues/220) and Mediaconch_sourceCode [658](https://github.com/MediaArea/MediaConch_SourceCode/issues/658)