### PR TITLE
HEVC: better support of MP4 files with Stream format inside a block

### DIFF
--- a/Source/MediaInfo/File__Analyze.h
+++ b/Source/MediaInfo/File__Analyze.h
@@ -1344,6 +1344,7 @@ protected :
     friend class File__Tags_Helper;
     friend class File_Mk;
     friend class File_Mpeg4;
+    friend class File_Hevc;
 
     //***************************************************************************
     // Helpers

--- a/Source/MediaInfo/File__Analyze_MinimizeSize.h
+++ b/Source/MediaInfo/File__Analyze_MinimizeSize.h
@@ -1270,6 +1270,7 @@ protected :
     friend class File__Tags_Helper;
     friend class File_Mk;
     friend class File_Mpeg4;
+    friend class File_Hevc;
 
     //***************************************************************************
     // Helpers

--- a/Source/MediaInfo/Video/File_Hevc.h
+++ b/Source/MediaInfo/Video/File_Hevc.h
@@ -30,6 +30,7 @@ public :
     bool   MustParse_VPS_SPS_PPS_FromMatroska;
     bool   MustParse_VPS_SPS_PPS_FromFlv;
     bool   SizedBlocks;
+    size_t SizedBlocks_FileThenStream;
 
     //Constructor/Destructor
     File_Hevc();


### PR DESCRIPTION
Found a file with 0x000001 sync inside a "File format" content (in a block in a MP4 sample), even if it is expected to have only one NAL per block.

Note: it is supported in several other players, so I guess that it is relatively common.