### PR TITLE
MPEG-4: support of colr/nclx box

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -199,7 +199,7 @@ private :
     void moov_trak_mdia_minf_stbl_stsd_xxxx_clap();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_clli();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_colr();
-    void moov_trak_mdia_minf_stbl_stsd_xxxx_colr_nclc(bool LittleEndian=false);
+    void moov_trak_mdia_minf_stbl_stsd_xxxx_colr_nclc(bool LittleEndian=false, bool HasFlags=false);
     void moov_trak_mdia_minf_stbl_stsd_xxxx_colr_prof();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_d263();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_dac3();


### PR DESCRIPTION
Usually it is `nclc `but in MP4 spec it is `nclx `(it adds colour range, limited or full).