### PR TITLE
CMake: Copy source files into binary dir

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -93,8 +93,13 @@ elseif(MSVC)
 else()
   set(MediaInfoLib_CONFIG_INSTALL_DIR "${LIB_INSTALL_DIR}/cmake/mediainfolib")
 endif()
-
-set(MediaInfoLib_SOURCES_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../Source)
+if(MINGW)
+  # Work around for cmake generating extra long paths
+  file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../Source DESTINATION .)
+  set(MediaInfoLib_SOURCES_PATH ${CMAKE_CURRENT_BINARY_DIR}/Source)
+else()
+  set(MediaInfoLib_SOURCES_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../Source)
+endif()
 
 # use bundled tinyxml only if no system
 find_package(TinyXML)
@@ -392,6 +397,10 @@ set(MediaInfoLib_SRCS
 if(NOT TinyXML_FOUND)
   include_directories(${MediaInfoLib_SOURCES_PATH}/ThirdParty/tinyxml2/)
   list(APPEND MediaInfoLib_SRCS ${MediaInfoLib_SOURCES_PATH}/ThirdParty/tinyxml2/tinyxml2.cpp)
+endif()
+
+if(MINGW)
+  set_source_files_properties(${MediaInfoLib_SRCS} PROPERTIES GENERATED true)
 endif()
 
 add_library(mediainfo ${MediaInfoLib_SRCS})


### PR DESCRIPTION
Same as https://github.com/MediaArea/ZenLib/pull/105

A work around for certain compilers not working on windows due to extra long paths (Something like `CMakeFiles/mediainfo.dir/D_/actions/_work/media-autobuild_suite/media-autobuild_suite/build/libmediainfo-git/Source/ThirdParty/aes-gladman/aes_modes.c.o` under `D:/actions/_work/media-autobuild_suite/media-autobuild_suite/build/libmediainfo-git/build`)

Since it the source files aren't subdirectories, cmake uses absolute paths to the files when deciding the output name.