### PR TITLE
AVC slice header - chroma weight table fix

### DIFF
--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -2597,6 +2597,8 @@ void File_Avc::pred_weight_table(int32u num_ref_idx_l0_active_minus1, int32u num
 			TEST_SB_SKIP(                                       "chroma_weight_l0_flag");
 				Skip_SE(                                        "chroma_weight_l0");
 				Skip_SE(                                        "chroma_offset_l0");
+				Skip_SE(                                        "chroma_weight_l0");
+				Skip_SE(                                        "chroma_offset_l0");
 			TEST_SB_END();
 		}
     }

--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -2592,13 +2592,13 @@ void File_Avc::pred_weight_table(int32u num_ref_idx_l0_active_minus1, int32u num
             Skip_SE(                                            "luma_weight_l0");
             Skip_SE(                                            "luma_offset_l0");
         TEST_SB_END();
-    }
-    if (ChromaArrayType)
-    {
-        TEST_SB_SKIP(                                           "chroma_weight_l0_flag");
-            Skip_SE(                                            "chroma_weight_l0");
-            Skip_SE(                                            "chroma_offset_l0");
-        TEST_SB_END();
+		if (ChromaArrayType)
+		{
+			TEST_SB_SKIP(                                       "chroma_weight_l0_flag");
+				Skip_SE(                                        "chroma_weight_l0");
+				Skip_SE(                                        "chroma_offset_l0");
+			TEST_SB_END();
+		}
     }
 }
 


### PR DESCRIPTION
File_Avc.cpp::pred_weight_table
Currently there is only one set of chroma weight/offset
values read per list(l0, l1), after all the luma coefficient sets.
But I believe there should be two sets for each set of luma
coefficients.

Noticed when mediatrace returned a value of -355 for
slice_beta_offset_div2, which has range (-6,+6), and 21 for
disable_deblocking_filter_idc in range (0,+2). 😄 