### PR TITLE
DV analysis: update of the invalid data detection algorithm

### DIFF
--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -269,7 +269,6 @@ File_DvDif::File_DvDif()
     Speed_FrameCount_Stts_Fluctuation=0;
     SMP=(int8u)-1;
     QU=(int8u)-1;
-    CH_IsPresent.resize(8);
     Speed_TimeCode_IsValid=false;
     Speed_Arb_IsValid=false;
     Mpeg4_stts=NULL;

--- a/Source/MediaInfo/Multiple/File_DvDif.h
+++ b/Source/MediaInfo/Multiple/File_DvDif.h
@@ -175,7 +175,6 @@ protected :
     bool   REC_ST;
     bool   REC_END;
     bool   REC_IsValid;
-    std::bitset<8> audio_source_IsPresentInFrame;
     struct dvdate
     {
         int8u  Days;
@@ -243,12 +242,12 @@ protected :
     std::vector<size_t> Video_STA_Errors; //Per STA type
     std::vector<size_t> Video_STA_Errors_ByDseq; //Per Dseq & STA type
     std::vector<size_t> Video_STA_Errors_Total; //Per STA type
-    std::vector<size_t> Audio_Errors; //Per Dseq
-    std::vector<bool> audio_source_IsPresent;
-    std::vector<bool>   CH_IsPresent;
-    std::vector<std::vector<size_t> > Audio_Errors_Total; //Per Channel and Dseq
-    std::vector<std::vector<size_t> > Audio_Invalids; //Per Channel and Dseq
-    std::vector<std::vector<size_t> > Audio_Invalids_Total; //Per Channel and Dseq
+    static const size_t ChannelGroup_Count=2;
+    static const size_t Dseq_Count=16;
+    std::vector<std::vector<int8u> > audio_source_mode; //Per ChannelGroup and Dseq, -1 means not present
+    bitset<ChannelGroup_Count*2> ChannelInfo;
+    std::vector<std::vector<size_t> > Audio_Errors; //Per ChannelGroup and Dseq
+    std::vector<std::vector<size_t> > Audio_Errors_TotalPerChannel; //Per Channel and Dseq
     struct recZ_Single
     {
         int64u FramePos;


### PR DESCRIPTION
Audio is split in "channel groups" (1 group for DV25, 2 groups for DV50, 4 groups for DV100)
Each "channel group" has 2 "channels", first channel in Dseq 0-4 and second channel in Dseq 5-9 (note: if 2-bit 32 kHz, each "channel" contains actually 2 real channels)
 
For each channel:
- We consider all audio blocks of a Dseq as invalid if audio mode of this Dseq of this channel group is 0xF (15)
- We consider all audio blocks as invalid if the frame (all channels) has no audio_source but had audio_source for this channel in the latest frame having at least 1 audio_source.
- We consider a block as invalid if full of 0x8000 (16-bit and 12-bit) or 0x800 (12-bit)

A channel group (its both channels) is considered as active if:
- at least 1 audio_source is found for this channel group
- no audio_source is found in the whole frame and there was at least 1 audio_source found in the latest frame having at least 1 audio_source.

This remove the detection of mono streams (it is 0, 2, 4, 8 channels) as well as 12-bit 32 kHz stereo with the 2nd "channel" (in that case a channel pair) empty (it is 0 or 4 channels) 

There is no difference visible between:
- a Dseq having audio mode 0xF (15),
- a Dseq without audio_source but latest frame having at least 1 audio_source had it,
- a Dseq having all 9 blocks with invalid content

Maybe out of spec but seen:
- a 12-bit content full of 0x8000 (it should be 0x800 for signaling invalid data), so we detect it tooo

(PR description may be updated during tests and changes in the algorithm)

It should fix https://github.com/mipops/dvrescue/issues/44 and https://github.com/mipops/dvrescue/issues/43.