### PR TITLE
Dolby Vision: support of Dolby Vision 2

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -813,13 +813,6 @@ void File__Analyze::Streams_Finish_StreamOnly_Video(size_t Pos)
     }
     else if (!Retrieve_Const(Stream_Video, Pos, Video_HDR_Format_Compatibility).empty())
     {
-        ZtringList HDR_Format_Compatibility;
-        HDR_Format_Compatibility.Separator_Set(0, __T(" / "));
-        HDR_Format_Compatibility.Write(Retrieve(Stream_Video, Pos, Video_HDR_Format_Compatibility));
-        for (size_t j=0; j<HDR_Format_Compatibility.size(); j++)
-            if (HDR_Format_Compatibility[j].find(__T("HDR10"))==0)
-                HDR_Format_Compatibility[j].clear();
-        Fill(Stream_Video, Pos, Video_HDR_Format_Compatibility, HDR_Format_Compatibility.Read(), true);
     }
     if (Retrieve(Stream_Video, Pos, Video_HDR_Format_String).empty())
     {
@@ -833,9 +826,6 @@ void File__Analyze::Streams_Finish_StreamOnly_Video(size_t Pos)
             HDR_Format_Compatibility.Separator_Set(0, __T(" / "));
             HDR_Format_Compatibility.Write(Retrieve(Stream_Video, Pos, Video_HDR_Format_Compatibility));
             HDR_Format_Compatibility.resize(Summary.size());
-            for (size_t j=0; j<Summary.size(); j++)
-                if (HDR_Format_Compatibility[j].empty())
-                    HDR_Format_Compatibility[j]=Summary[j];
             ZtringList ToAdd;
             ToAdd.Separator_Set(0, __T(" / "));
             for (size_t i=Video_HDR_Format_String+1; i<=Video_HDR_Format_Settings; i++)
@@ -857,7 +847,7 @@ void File__Analyze::Streams_Finish_StreamOnly_Video(size_t Pos)
                 }
             }
             for (size_t j=0; j<Summary.size(); j++)
-                if (HDR_Format_Compatibility[j].find(__T("HDR10"))==0) // We add for info the HDR10/HDR10+ compatibility in the displayable part
+                if (!HDR_Format_Compatibility[j].empty())
                 {
                     Summary[j]+=__T(", ")+HDR_Format_Compatibility[j]+__T(" compatible");
                     Commercial[j]=HDR_Format_Compatibility[j].substr(0, HDR_Format_Compatibility[j].find(__T(' ')));

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -6803,6 +6803,18 @@ extern const char* DolbyVision_Profiles [DolbyVision_Profiles_Size] = // dv[BL_c
     "dvav",
 };
 
+extern const size_t DolbyVision_Compatibility_Size=7;
+extern const char* DolbyVision_Compatibility[DolbyVision_Compatibility_Size]=
+{
+    "",
+    "HDR10",
+    "SDR",
+    NULL,
+    "HLG",
+    NULL,
+    "Blu-ray",
+};
+
 //---------------------------------------------------------------------------
 void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxx_dvcC()
 {
@@ -6810,28 +6822,41 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxx_dvcC()
     AddCodecConfigurationBoxInfo();
 
     //Parsing
-    int8u  dv_version_major, dv_version_minor, dv_profile, dv_level;
+    int8u  dv_version_major, dv_version_minor, dv_profile, dv_level, dv_bl_signal_compatibility_id;
     bool rpu_present_flag, el_present_flag, bl_present_flag;
     Get_B1 (dv_version_major,                                   "dv_version_major");
-    Get_B1 (dv_version_minor,                                   "dv_version_minor");
-    if (dv_version_major==1) //Spec says nothing, we hope that a minor version change means that the stream is backward compatible
+    if (dv_version_major && dv_version_major<=2) //Spec says nothing, we hope that a minor version change means that the stream is backward compatible
     {
+        Get_B1 (dv_version_minor,                               "dv_version_minor");
         BS_Begin();
+        size_t End=Data_BS_Remain();
+        if (End>=176)
+            End-=176;
+        else
+            End=0; // Not enough place for reserved bits, but we currently ignore such case, just considered as unknown
         Get_S1 (7, dv_profile,                                  "dv_profile");
         Get_S1 (6, dv_level,                                    "dv_level");
         Get_SB (   rpu_present_flag,                            "rpu_present_flag");
         Get_SB (   el_present_flag,                             "el_present_flag");
         Get_SB (   bl_present_flag,                             "bl_present_flag");
+        if (Data_BS_Remain())
+        {
+            Get_S1 (4, dv_bl_signal_compatibility_id,           "dv_bl_signal_compatibility_id"); // in dv_version_major 2 only if based on specs but it was confirmed to be seen in dv_version_major 1 too and it does not hurt (value 0 means no new display)
+            if (End<Data_BS_Remain())
+                Skip_BS(Data_BS_Remain()-End,                   "reserved");
+        }
+        else
+            dv_bl_signal_compatibility_id=0;
         BS_End();
     }
-    else
-        Skip_XX(Element_Size-Element_Offset,                    "Unknown");
+    Skip_XX(Element_Size-Element_Offset,                        "Unknown");
 
     FILLING_BEGIN();
-        Ztring Summary=Ztring::ToZtring(dv_version_major)+__T('.')+Ztring::ToZtring(dv_version_minor);
-        Fill(Stream_Video, StreamPos_Last, "HDR_Format_Version", Summary);
-        if (dv_version_major==1)
+        Fill(Stream_Video, StreamPos_Last, "HDR_Format", "Dolby Vision");
+        if (dv_version_major && dv_version_major<=2)
         {
+            Ztring Summary=Ztring::ToZtring(dv_version_major)+__T('.')+Ztring::ToZtring(dv_version_minor);
+            Fill(Stream_Video, StreamPos_Last, "HDR_Format_Version", Summary);
             string Profile, Level;
             if (dv_profile<DolbyVision_Profiles_Size)
                 Profile+=DolbyVision_Profiles[dv_profile];
@@ -6840,7 +6865,6 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxx_dvcC()
             Profile+=__T('.');
             Profile+=Ztring().From_CC1(dv_profile).To_UTF8();
             Level+=Ztring().From_CC1(dv_level).To_UTF8();
-            Fill(Stream_Video, StreamPos_Last, "HDR_Format", "Dolby Vision");
             Fill(Stream_Video, StreamPos_Last, "HDR_Format_Profile", Profile);
             Fill(Stream_Video, StreamPos_Last, "HDR_Format_Level", Level);
             Summary+=__T(',');
@@ -6864,7 +6888,18 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxx_dvcC()
                 Summary+=Ztring().From_UTF8(Layers);
             }
             Fill(Stream_Video, StreamPos_Last, "HDR_Format_Settings", Layers);
+            if (dv_bl_signal_compatibility_id)
+            {
+                string Compatibility;
+                if (dv_bl_signal_compatibility_id<DolbyVision_Compatibility_Size && DolbyVision_Compatibility[dv_bl_signal_compatibility_id])
+                    Compatibility=DolbyVision_Compatibility[dv_bl_signal_compatibility_id];
+                else
+                    Compatibility=Ztring().From_Number(dv_bl_signal_compatibility_id).To_UTF8();
+                Fill(Stream_Video, StreamPos_Last, Video_HDR_Format_Compatibility, Compatibility);
+            }
         }
+        else
+            Fill(Stream_Video, StreamPos_Last, "HDR_Format_Version", dv_version_major);
     FILLING_END();
 }
 

--- a/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
@@ -1189,6 +1189,10 @@ static bool Mpeg_Descriptors_CA_system_ID_MustSkipSlices(int16u CA_system_ID)
     }
 }
 
+//---------------------------------------------------------------------------
+extern const size_t DolbyVision_Compatibility_Size;
+extern const char* DolbyVision_Compatibility[];
+
 //***************************************************************************
 // Constructor/Destructor
 //***************************************************************************
@@ -3214,28 +3218,41 @@ extern const char* DolbyVision_Profiles[];
 void File_Mpeg_Descriptors::Descriptor_B0()
 {
     //Parsing
-    int8u  dv_version_major, dv_version_minor, dv_profile, dv_level;
+    int8u  dv_version_major, dv_version_minor, dv_profile, dv_level, dv_bl_signal_compatibility_id;
     bool rpu_present_flag, el_present_flag, bl_present_flag;
     Get_B1 (dv_version_major,                                   "dv_version_major");
-    Get_B1 (dv_version_minor,                                   "dv_version_minor");
-    if (dv_version_major==1) //Spec says nothing, we hope that a minor version change means that the stream is backward compatible
+    if (dv_version_major && dv_version_major<=2) //Spec says nothing, we hope that a minor version change means that the stream is backward compatible
     {
+        Get_B1 (dv_version_minor,                               "dv_version_minor");
         BS_Begin();
+        size_t End=Data_BS_Remain();
+        if (End>=176)
+            End-=176;
+        else
+            End=0; // Not enough place for reserved bits, but we currently ignore such case, just considered as unknown
         Get_S1 (7, dv_profile,                                  "dv_profile");
         Get_S1 (6, dv_level,                                    "dv_level");
         Get_SB (   rpu_present_flag,                            "rpu_present_flag");
         Get_SB (   el_present_flag,                             "el_present_flag");
         Get_SB (   bl_present_flag,                             "bl_present_flag");
+        if (Data_BS_Remain())
+        {
+            Get_S1 (4, dv_bl_signal_compatibility_id,           "dv_bl_signal_compatibility_id"); // in dv_version_major 2 only if based on specs but it was confirmed to be seen in dv_version_major 1 too and it does not hurt (value 0 means no new display)
+            if (End<Data_BS_Remain())
+                Skip_BS(Data_BS_Remain()-End,                   "reserved");
+        }
+        else
+            dv_bl_signal_compatibility_id=0;
         BS_End();
     }
-    else
-        Skip_XX(Element_Size-Element_Offset,                    "Unknown");
+    Skip_XX(Element_Size-Element_Offset,                        "Unknown");
 
     FILLING_BEGIN();
-        Ztring Summary=Ztring::ToZtring(dv_version_major)+__T('.')+Ztring::ToZtring(dv_version_minor);
-        Complete_Stream->Streams[elementary_PID]->Infos["HDR_Format_Version"]=Summary;
-        if (dv_version_major==1)
+        Complete_Stream->Streams[elementary_PID]->Infos["HDR_Format"].From_UTF8("Dolby Vision");
+        if (dv_version_major && dv_version_major<=2)
         {
+            Ztring Summary=Ztring::ToZtring(dv_version_major)+__T('.')+Ztring::ToZtring(dv_version_minor);
+            Complete_Stream->Streams[elementary_PID]->Infos["HDR_Format_Version"]=Summary;
             string Profile, Level;
             if (dv_profile<DolbyVision_Profiles_Size)
                 Profile+=DolbyVision_Profiles[dv_profile];
@@ -3244,7 +3261,6 @@ void File_Mpeg_Descriptors::Descriptor_B0()
             Profile+=__T('.');
             Profile+=Ztring().From_CC1(dv_profile).To_UTF8();
             Level+=Ztring().From_CC1(dv_level).To_UTF8();
-            Complete_Stream->Streams[elementary_PID]->Infos["HDR_Format"].From_UTF8("Dolby Vision");
             Complete_Stream->Streams[elementary_PID]->Infos["HDR_Format_Profile"].From_UTF8(Profile);
             Complete_Stream->Streams[elementary_PID]->Infos["HDR_Format_Level"].From_UTF8(Level);
             Summary+=__T(',');
@@ -3268,8 +3284,18 @@ void File_Mpeg_Descriptors::Descriptor_B0()
                 Summary+=Ztring().From_UTF8(Layers);
             }
             Complete_Stream->Streams[elementary_PID]->Infos["HDR_Format_Settings"].From_UTF8(Layers);
-            Complete_Stream->Streams[elementary_PID]->Infos["HDR_Format_Compatibility"]=Ztring();
+            if (dv_bl_signal_compatibility_id)
+            {
+                string Compatibility;
+                if (dv_bl_signal_compatibility_id<DolbyVision_Compatibility_Size && DolbyVision_Compatibility[dv_bl_signal_compatibility_id])
+                    Compatibility=DolbyVision_Compatibility[dv_bl_signal_compatibility_id];
+                else
+                    Compatibility=Ztring().From_Number(dv_bl_signal_compatibility_id).To_UTF8();
+                Complete_Stream->Streams[elementary_PID]->Infos["HDR_Format_Compatibility"].From_UTF8(Compatibility);
+            }
         }
+        else
+            Complete_Stream->Streams[elementary_PID]->Infos["HDR_Format_Version"]=Ztring::ToZtring(dv_version_major);
     FILLING_END();
 }
 


### PR DESCRIPTION
Add support of [Dolby Vision 2 metadata](https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-bitstreams-within-the-iso-base-media-file-format-v2.1.2.pdf).