### PR TITLE
Support of nested elements

### DIFF
--- a/Source/MediaInfo/File__Analyze.h
+++ b/Source/MediaInfo/File__Analyze.h
@@ -1135,6 +1135,11 @@ public :
     inline void Fill (stream_t StreamKind, size_t StreamPos, size_t Parameter, size_t         Value, int8u Radix=10, bool Replace=false) {Fill(StreamKind, StreamPos, Parameter, Ztring::ToZtring(Value, Radix).MakeUpperCase(), Replace);}
     #endif //SIZE_T_IS_LONG
     //Fill with datas
+    void Fill_Dup (stream_t StreamKind, size_t StreamPos, const char* Parameter, const Ztring  &Value, bool Replace=false);
+    void Fill_Measure (stream_t StreamKind, size_t StreamPos, const char* Parameter, const Ztring  &Value, const Ztring& Measure, bool Replace=false);
+    inline void Fill_Measure(stream_t StreamKind, size_t StreamPos, const char* Parameter, const string&  Value, const Ztring& Measure, bool Utf8=true, bool Replace=false) {Fill_Measure(StreamKind, StreamPos, Parameter, Ztring().From_UTF8(Value.c_str(), Value.size()), Measure, Replace);}
+    inline void Fill_Measure(stream_t StreamKind, size_t StreamPos, const char* Parameter, int            Value, const Ztring& Measure, int8u Radix=10, bool Replace=false) {Fill_Measure(StreamKind, StreamPos, Parameter, Ztring::ToZtring(Value, Radix).MakeUpperCase(), Measure, Replace);}
+    inline void Fill_Measure(stream_t StreamKind, size_t StreamPos, const char* Parameter, float64        Value, const Ztring& Measure, int8u AfterComma=3, bool Replace=false) {Fill_Measure(StreamKind, StreamPos, Parameter, Ztring::ToZtring(Value, AfterComma), Measure, Replace);}
     void Fill (stream_t StreamKind, size_t StreamPos, const char* Parameter, const Ztring  &Value, bool Replace=false);
     void Fill (stream_t StreamKind, size_t StreamPos, const char* Parameter, ZtringList &Value, ZtringList& Id, bool Replace=false);
     inline void Fill (stream_t StreamKind, size_t StreamPos, const char* Parameter, const std::string &Value, bool Utf8=true, bool Replace=false) {if (Utf8) Fill(StreamKind, StreamPos, Parameter, Ztring().From_UTF8(Value.c_str(), Value.size())); else Fill(StreamKind, StreamPos, Parameter, Ztring().From_Local(Value.c_str(), Value.size()), Replace);}

--- a/Source/MediaInfo/File__Analyze_MinimizeSize.h
+++ b/Source/MediaInfo/File__Analyze_MinimizeSize.h
@@ -1058,6 +1058,11 @@ public :
     inline void Fill (stream_t StreamKind, size_t StreamPos, size_t Parameter, size_t         Value, int8u Radix=10, bool Replace=false) {Fill(StreamKind, StreamPos, Parameter, Ztring::ToZtring(Value, Radix).MakeUpperCase(), Replace);}
     #endif //SIZE_T_IS_LONG
     //Fill with datas
+    void Fill_Dup (stream_t StreamKind, size_t StreamPos, const char* Parameter, const Ztring  &Value, bool Replace=false);
+    void Fill_Measure (stream_t StreamKind, size_t StreamPos, const char* Parameter, const Ztring  &Value, const Ztring& Measure, bool Replace=false);
+    inline void Fill_Measure(stream_t StreamKind, size_t StreamPos, const char* Parameter, const string&  Value, const Ztring& Measure, bool Utf8=true, bool Replace=false) {Fill_Measure(StreamKind, StreamPos, Parameter, Ztring().From_UTF8(Value.c_str(), Value.size()), Measure, Replace);}
+    inline void Fill_Measure(stream_t StreamKind, size_t StreamPos, const char* Parameter, int            Value, const Ztring& Measure, int8u Radix=10, bool Replace=false) {Fill_Measure(StreamKind, StreamPos, Parameter, Ztring::ToZtring(Value, Radix).MakeUpperCase(), Measure, Replace);}
+    inline void Fill_Measure(stream_t StreamKind, size_t StreamPos, const char* Parameter, float64        Value, const Ztring& Measure, int8u AfterComma=3, bool Replace=false) {Fill_Measure(StreamKind, StreamPos, Parameter, Ztring::ToZtring(Value, AfterComma), Measure, Replace);}
     void Fill (stream_t StreamKind, size_t StreamPos, const char* Parameter, const Ztring  &Value, bool Replace=false);
     void Fill (stream_t StreamKind, size_t StreamPos, const char* Parameter, ZtringList &Value, ZtringList& Id, bool Replace=false);
     inline void Fill (stream_t StreamKind, size_t StreamPos, const char* Parameter, const std::string &Value, bool Utf8=true, bool Replace=false) {if (Utf8) Fill(StreamKind, StreamPos, Parameter, Ztring().From_UTF8(Value.c_str(), Value.size())); else Fill(StreamKind, StreamPos, Parameter, Ztring().From_Local(Value.c_str(), Value.size()), Replace);}

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -1046,6 +1046,25 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Paramete
 }
 
 //---------------------------------------------------------------------------
+void File__Analyze::Fill_Dup(stream_t StreamKind, size_t StreamPos, const char* Parameter, const Ztring& Value, bool Replace)
+{
+    const Ztring& OldValue=Retrieve_Const(StreamKind, StreamPos, Parameter);
+    if (Value!=OldValue)
+        Fill(StreamKind, StreamPos, Parameter, Value, Replace);
+}
+
+//---------------------------------------------------------------------------
+void File__Analyze::Fill_Measure(stream_t StreamKind, size_t StreamPos, const char* Parameter, const Ztring& Value, const Ztring& Measure, bool Replace)
+{
+    string Parameter_String(Parameter);
+    Parameter_String+="/String";
+    Fill(Stream_Audio, 0, Parameter, Value, Replace);
+    Fill_SetOptions(Stream_Audio, 0, Parameter, "N NFY");
+    Fill(Stream_Audio, 0, Parameter_String.c_str(), MediaInfoLib::Config.Language_Get(Value, Measure), Replace);
+    Fill_SetOptions(Stream_Audio, 0, Parameter_String.c_str(), "Y NFN");
+}
+
+//---------------------------------------------------------------------------
 void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, const char* Parameter, const Ztring &Value, bool Replace)
 {
     //Integrity
@@ -1131,6 +1150,24 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, const char* Par
     }
     else
     {
+        size_t Space=Parameter_ISO.find(__T(' '));
+        size_t LastFound=(size_t)-1;
+        if (Space!=string::npos)
+        {
+            Ztring ToSearch=Parameter_ISO.substr(0, Space);
+            for (size_t i=0; i<Stream_More_Item.size(); i++)
+            {
+                if (Stream_More_Item(i, Info_Name).rfind(ToSearch, ToSearch.size())==0 && (Stream_More_Item(i, Info_Name).size()==ToSearch.size() || Stream_More_Item(i, Info_Name)[ToSearch.size()]==__T(' ')))
+                    LastFound=i;
+            }
+            if (LastFound!=(size_t)-1)
+            {
+                ZtringList ToInsert;
+                ToInsert(Info_Name)=Parameter_ISO;
+                Stream_More_Item.insert(Stream_More_Item.begin()+LastFound+1, ToInsert);
+            }
+        }
+
         Ztring &Target= Stream_More_Item(Parameter_ISO, Info_Text);
         if (Target.empty() || Replace)
         {
@@ -1206,7 +1243,18 @@ const Ztring &File__Analyze::Retrieve_Const (stream_t StreamKind, size_t StreamP
     if (StreamKind>=Stream_Max
      || StreamPos>=(*Stream)[StreamKind].size()
      || Parameter>=MediaInfoLib::Config.Info_Get(StreamKind).size()+(*Stream_More)[StreamKind][StreamPos].size())
+    {
+        if (StreamKind<sizeof(Fill_Temp)/sizeof(vector<fill_temp_item>))
+        {
+            Ztring Parameter_Local;
+            Parameter_Local.From_Number(Parameter);
+            for (size_t Pos=0; Pos<Fill_Temp[StreamKind].size(); Pos++)
+                if (Fill_Temp[StreamKind][Pos].Parameter==Parameter_Local)
+                    return Fill_Temp[StreamKind][Pos].Value;
+        }
+
         return MediaInfoLib::Config.EmptyString_Get();
+    }
 
     if (Parameter>=MediaInfoLib::Config.Info_Get(StreamKind).size())
     {
@@ -1219,7 +1267,7 @@ const Ztring &File__Analyze::Retrieve_Const (stream_t StreamKind, size_t StreamP
     if (KindOfInfo!=Info_Text)
         return MediaInfoLib::Config.Info_Get(StreamKind, Parameter, KindOfInfo);
 
-    if (Parameter>=(*Stream)[StreamKind][StreamPos].size())
+    if (StreamKind>=(*Stream).size() || StreamPos>=(*Stream)[StreamKind].size() || Parameter>=(*Stream)[StreamKind][StreamPos].size())
         return MediaInfoLib::Config.EmptyString_Get();
     return (*Stream)[StreamKind][StreamPos](Parameter);
 }
@@ -1244,7 +1292,7 @@ Ztring File__Analyze::Retrieve (stream_t StreamKind, size_t StreamPos, size_t Pa
     if (KindOfInfo!=Info_Text)
         return MediaInfoLib::Config.Info_Get(StreamKind, Parameter, KindOfInfo);
 
-    if (Parameter>=(*Stream)[StreamKind][StreamPos].size())
+    if (StreamKind>=(*Stream).size() || StreamPos>=(*Stream)[StreamKind].size() || Parameter>=(*Stream)[StreamKind][StreamPos].size())
         return MediaInfoLib::Config.EmptyString_Get();
     return (*Stream)[StreamKind][StreamPos](Parameter);
 }
@@ -1254,7 +1302,6 @@ const Ztring &File__Analyze::Retrieve_Const (stream_t StreamKind, size_t StreamP
 {
     //Integrity
     if (StreamKind>=Stream_Max
-     || StreamPos>=(*Stream)[StreamKind].size()
      || Parameter==NULL
      || Parameter[0]=='\0')
         return MediaInfoLib::Config.EmptyString_Get();
@@ -1265,11 +1312,21 @@ const Ztring &File__Analyze::Retrieve_Const (stream_t StreamKind, size_t StreamP
     size_t Parameter_Pos=MediaInfoLib::Config.Info_Get(StreamKind).Find(Parameter_Local);
     if (Parameter_Pos==Error)
     {
+        if (StreamPos==(*Stream)[StreamKind].size())
+        {
+            for (size_t Pos=0; Pos<Fill_Temp[StreamKind].size(); Pos++)
+                if (Fill_Temp[StreamKind][Pos].Parameter==Parameter_Local)
+                    return Fill_Temp[StreamKind][Pos].Value;
+        }
+        if (StreamPos>=(*Stream)[StreamKind].size())
+            return MediaInfoLib::Config.EmptyString_Get();
         Parameter_Pos=(*Stream_More)[StreamKind][StreamPos].Find(Parameter_Local);
         if (Parameter_Pos==Error)
             return MediaInfoLib::Config.EmptyString_Get();
         return (*Stream_More)[StreamKind][StreamPos](Parameter_Pos, 1);
     }
+    if (StreamKind>=(*Stream).size() || StreamPos>=(*Stream)[StreamKind].size() || Parameter_Pos>=(*Stream)[StreamKind][StreamPos].size())
+        return MediaInfoLib::Config.EmptyString_Get();
     return (*Stream)[StreamKind][StreamPos](Parameter_Pos);
 }
 
@@ -1294,6 +1351,8 @@ Ztring File__Analyze::Retrieve (stream_t StreamKind, size_t StreamPos, const cha
             return MediaInfoLib::Config.EmptyString_Get();
         return (*Stream_More)[StreamKind][StreamPos](Parameter_Pos, 1);
     }
+    if (StreamKind>=(*Stream).size() || StreamPos>=(*Stream)[StreamKind].size() || Parameter_Pos>=(*Stream)[StreamKind][StreamPos].size())
+        return MediaInfoLib::Config.EmptyString_Get();
     return (*Stream)[StreamKind][StreamPos](Parameter_Pos);
 }
 

--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -713,7 +713,7 @@ void File__Analyze::Streams_Finish_StreamOnly_Video(size_t Pos)
         if (Duration==0)
         {
             Duration=Retrieve(Stream_General, 0, General_Duration).To_int64s();
-            DurationFromGeneral=true;
+            DurationFromGeneral=Retrieve(Stream_General, 0, General_Format)!=Retrieve(Stream_Video, Pos, Audio_Format);
         }
         else
             DurationFromGeneral=false;
@@ -1009,7 +1009,7 @@ void File__Analyze::Streams_Finish_StreamOnly_Audio(size_t Pos)
         if (Duration==0)
         {
             Duration=Retrieve(Stream_General, 0, General_Duration).To_int64s();
-            DurationFromGeneral=true;
+            DurationFromGeneral=Retrieve(Stream_General, 0, General_Format)!=Retrieve(Stream_Audio, Pos, Audio_Format);
         }
         else
             DurationFromGeneral=false;

--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -209,6 +209,8 @@ void File__Analyze::Streams_Finish_Global()
     Streams_Finish_InterStreams();
     Streams_Finish_StreamOnly();
 
+    Config->File_ExpandSubs_Update((void**)(&Stream_More));
+
     if (!IsSub && !Config->File_IsReferenced_Get() && MediaInfoLib::Config.ReadByHuman_Get())
         Streams_Finish_HumanReadable();
 }

--- a/Source/MediaInfo/MediaInfoList_Internal.cpp
+++ b/Source/MediaInfo/MediaInfoList_Internal.cpp
@@ -506,6 +506,8 @@ String MediaInfoList_Internal::Option (const String &Option, const String &Value
     }
     else if (OptionLower.find(__T("file_"))==0)
     {
+        for (size_t i=0; i<Info.size(); i++) //Applies to both past and future items
+            Info[i]->Option(Option, Value);
         Config_MediaInfo_Items[Option]=Value;
         return __T("");
     }

--- a/Source/MediaInfo/MediaInfo_Config.cpp
+++ b/Source/MediaInfo/MediaInfo_Config.cpp
@@ -2150,7 +2150,7 @@ void MediaInfo_Config::Language_Set (const ZtringListList &NewValue)
         for (size_t Pos=0; Pos<NewValue.size(); Pos++)
             if (NewValue[Pos].size()>=2)
                 Language.Write(NewValue[Pos][0], NewValue[Pos][1]);
-            else if (NewValue[Pos].size()==1)
+            else if (NewValue[Pos].size()==1 && NewValue[0]==__T("  Config_Text_ThousandsSeparator")) // Only the thousands separator is authorized to be empty, else empty content means keeping default value
                 Language.Write(NewValue[Pos][0], Ztring());
     }
 
@@ -2245,13 +2245,9 @@ Ztring MediaInfo_Config::Language_Get (const Ztring &Count, const Ztring &Value,
         return Count;
 
     //Different Plurals are available or not?
-    if (Language_Get(Value+__T("1")).empty())
-    {
-        //if (Count==__T("0") || Count==__T("1"))
-            return Count+Language_Get(Value);
-        //else
-            //return Count+Language_Get(Value+__T("s"));
-    }
+    Ztring Value1=Value+__T('1');
+    if (!ValueIsAlwaysSame && Language_Get(Value1)==Value1)
+        ValueIsAlwaysSame=true;
 
     //Detecting plural form for multiple plurals
     int8u  Form=(int8u)-1;
@@ -2321,6 +2317,8 @@ Ztring MediaInfo_Config::Language_Get (const Ztring &Count, const Ztring &Value,
         ToReturn.FindAndReplace(DecimalPoint, Language_Get(__T("  Config_Text_FloatSeparator")), DotPos);
     else
         DotPos=ToReturn.size();
+    if (DotPos>3 && ToReturn[0]==__T('-'))
+        DotPos--;
     if (DotPos>3)
         ToReturn.insert(DotPos-3, Language_Get(__T("  Config_Text_ThousandsSeparator")));
 

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -150,6 +150,8 @@ MediaInfo_Config_MediaInfo::MediaInfo_Config_MediaInfo()
     Audio_MergeMonoStreams=false;
     File_Demux_Interleave=false;
     File_ID_OnlyRoot=false;
+    File_ExpandSubs_Backup=NULL;
+    File_ExpandSubs_Source=NULL;
     #if MEDIAINFO_ADVANCED
         File_IgnoreSequenceFileSize=false;
         File_IgnoreSequenceFilesCount=false;
@@ -299,6 +301,7 @@ MediaInfo_Config_MediaInfo::MediaInfo_Config_MediaInfo()
 MediaInfo_Config_MediaInfo::~MediaInfo_Config_MediaInfo()
 {
     delete[] File_Buffer; //File_Buffer=NULL;
+    delete (std::vector<std::vector<ZtringListList> >*)File_ExpandSubs_Backup; //File_ExpandSubs_Backup=NULL
 
     #if MEDIAINFO_EVENTS
         for (events_delayed::iterator Event=Events_Delayed.begin(); Event!=Events_Delayed.end(); ++Event)
@@ -439,6 +442,11 @@ Ztring MediaInfo_Config_MediaInfo::Option (const String &Option, const String &V
     else if (Option_Lower==__T("file_id_onlyroot"))
     {
         File_ID_OnlyRoot_Set(!(Value==__T("0") || Value.empty()));
+        return __T("");
+    }
+    else if (Option_Lower==__T("file_expandsubs"))
+    {
+        File_ExpandSubs_Set(!(Value==__T("0") || Value.empty()));
         return __T("");
     }
     else if (Option_Lower==__T("file_id_onlyroot_get"))
@@ -1452,6 +1460,191 @@ bool MediaInfo_Config_MediaInfo::File_ID_OnlyRoot_Get ()
 {
     CriticalSectionLocker CSL(CS);
     return File_ID_OnlyRoot;
+}
+
+//---------------------------------------------------------------------------
+void MediaInfo_Config_MediaInfo::File_ExpandSubs_Set (bool NewValue)
+{
+    { //for CSL
+        CriticalSectionLocker CSL(CS);
+        if ((File_ExpandSubs_Backup && NewValue) || (!File_ExpandSubs_Backup && !NewValue))
+            return; //No change
+        if (File_ExpandSubs_Backup)
+        {
+            //We want the default
+            if (File_ExpandSubs_Source)
+            {
+                //Config has the backup, Source has the expanded one
+                std::vector<std::vector<ZtringListList> >* Stream_More=(std::vector<std::vector<ZtringListList> >*)File_ExpandSubs_Source;
+                std::vector<std::vector<ZtringListList> >* Backup=(std::vector<std::vector<ZtringListList> >*)File_ExpandSubs_Backup;
+                *Stream_More=*Backup;
+                Backup->clear();
+            }
+            delete (std::vector<std::vector<ZtringListList> > *)File_ExpandSubs_Backup;
+            File_ExpandSubs_Backup=NULL;
+        }
+        else
+        {
+            //We want the expanded subs
+            File_ExpandSubs_Backup=new std::vector<std::vector<ZtringListList> >;
+        }
+    }
+
+    File_ExpandSubs_Update(NULL);
+}
+
+bool MediaInfo_Config_MediaInfo::File_ExpandSubs_Get ()
+{
+    CriticalSectionLocker CSL(CS);
+    return File_ExpandSubs_Backup?true:false;
+}
+
+void MediaInfo_Config_MediaInfo::File_ExpandSubs_Update(void** Source)
+{
+    CriticalSectionLocker CSL(CS);
+    if (Source)
+        File_ExpandSubs_Source=*Source;
+    if (!File_ExpandSubs_Source)
+        return;
+    std::vector<std::vector<ZtringListList> >* Stream_More=(std::vector<std::vector<ZtringListList> >*)File_ExpandSubs_Source;
+    std::vector<std::vector<ZtringListList> >* Backup=(std::vector<std::vector<ZtringListList> >*)File_ExpandSubs_Backup;
+
+    //Reset if needed
+    if (File_ExpandSubs_Backup && !Backup->empty())
+    {
+        *Stream_More=*Backup;
+        Backup->clear();
+    }
+    
+    if (File_ExpandSubs_Backup)
+    {
+        //Backup
+        *Backup=*Stream_More;
+
+        //Sub-elements
+        const Char* UpSuffix=__T("_Pos");
+        const Char* HideSuffix=__T("_Pos/String");
+        //for (set<string>::iterator File_ExpandSubs_Item=File_ExpandSubs_Items.begin(); File_ExpandSubs_Item!=File_ExpandSubs_Items.end(); ++File_ExpandSubs_Item)
+        for (size_t i=0; i<3; i++)
+        {
+            //const Ztring Sub=Ztring().From_UTF8(*File_ExpandSubs_Item);
+            for (size_t StreamKind=Stream_General; StreamKind<Stream_Max; StreamKind++)
+                for (size_t StreamPos=0; StreamPos<(*Stream_More)[StreamKind].size(); StreamPos++)
+                {
+                    ZtringListList Temp;
+                    size_t Pos_Max=(*Stream_More)[StreamKind][StreamPos].size();
+                    for (size_t Pos=0; Pos<Pos_Max; Pos++)
+                        if ((*Stream_More)[StreamKind][StreamPos][Pos].size()>Info_Name_Text)
+                        {
+                            Ztring& Name=(*Stream_More)[StreamKind][StreamPos][Pos][Info_Name];
+
+                            // Tree
+                            size_t Up_Pos=Name.find(__T(" LinkedTo_"));
+                            size_t Up_Pos_End;
+                            if (Up_Pos!=string::npos)
+                                Up_Pos_End=Name.find(__T("_Pos"), Up_Pos);
+                            if (Up_Pos!=string::npos && Up_Pos_End==Name.size()-4)
+                            {
+                                Ztring Up=Name.substr(Up_Pos);
+
+                                //Hide
+                                Ztring ToHide=Name+__T("/String");
+                                for (size_t j=Pos+1; j<(*Stream_More)[StreamKind][StreamPos].size(); j++)
+                                {
+                                    if ((*Stream_More)[StreamKind][StreamPos][j][Info_Name]==ToHide)
+                                    {
+                                        ZtringList& ToHideList=(*Stream_More)[StreamKind][StreamPos][j];
+                                        ToHideList[Info_Options]=__T("N NT");
+                                        break;
+                                    }
+                                }
+
+                                //Expand
+                                size_t SpacesCount=1;
+                                size_t SpacesTestPos=Name.size()-Up.size();
+                                while (SpacesTestPos && (SpacesTestPos=Name.rfind(__T(' '), SpacesTestPos-1))!=string::npos)
+                                    SpacesCount++;
+                                ZtringList L;
+                                L.Separator_Set(0, __T(" + "));
+                                L.Write((*Stream_More)[StreamKind][StreamPos][Pos][Info_Text]);
+                                for (size_t i=0; i<L.size(); i++)
+                                {
+                                    Ztring ToSearch=Up.substr(10, Up.find('_', 10)-10)+L[i];
+                                    for (size_t j=Pos+1; j<(*Stream_More)[StreamKind][StreamPos].size(); j++)
+                                    {
+                                        if ((*Stream_More)[StreamKind][StreamPos][j][Info_Name]==ToSearch)
+                                        {
+                                            while (j<(*Stream_More)[StreamKind][StreamPos].size() && (*Stream_More)[StreamKind][StreamPos][j][Info_Name].rfind(ToSearch, ToSearch.size())==0)
+                                            {
+                                                Temp.push_back((*Stream_More)[StreamKind][StreamPos][j]);
+                                                Temp.back()[Info_Name].insert(0, SpacesCount, __T(' '));
+                                                j++;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            else
+                                Temp.push_back((*Stream_More)[StreamKind][StreamPos][Pos]);
+
+                        }
+                    (*Stream_More)[StreamKind][StreamPos]=Temp;
+                }
+        }
+    }
+
+    //Sub-elements
+    for (size_t StreamKind=Stream_General; StreamKind<Stream_Max; StreamKind++)
+        for (size_t StreamPos=0; StreamPos<(*Stream_More)[StreamKind].size(); StreamPos++)
+        {
+            const ZtringListList& Track=(*Stream_More)[StreamKind][StreamPos];
+            for (size_t Pos=0; Pos<Track.size(); Pos++)
+            {
+                const ZtringList& Field=Track[Pos];
+                if (Field.size()>Info_Name_Text)
+                {
+                    // Text
+                    Ztring Name=Field[Info_Name];
+                    size_t Spaces=0;
+                    size_t i=0;
+                    for (;;)
+                    {
+                        size_t j=Name.find(__T(' '), i);
+                        if (j==(size_t)-1)
+                            break;
+                        i=j+1;
+                        Spaces++;
+                    }
+                    //if (Spaces)
+                    {
+                        Name.erase(0, i);
+                        size_t Number=0;
+                        if (!Name.empty() && Pos+1<Track.size())
+                        {
+                            const ZtringList& Field1=Track[Pos+1];
+                            const Ztring& Name1=Field1[Info_Name];
+                            size_t Name1_SpacePos=i+Name.size();
+                            if (Name1_SpacePos<Name1.size() && Name1[Name1_SpacePos]==__T(' ') && Name==Name1.substr(i, Name.size()))
+                            {
+                                size_t Text_End=Name.find_last_not_of(__T("0123456789"))+1;
+                                if (Text_End!=Name.size())
+                                {
+                                    Number=Ztring(Name.substr(Text_End)).To_int64u()+1;
+                                    Name.resize(Text_End);
+                                }
+                            }
+                        }
+                        Ztring TranslatedName=MediaInfoLib::Config.Language_Get(Name);
+                        if (!TranslatedName.empty())
+                            Name=TranslatedName;
+                        Name.insert(0, Spaces, __T(' '));
+                        if (Number)
+                            Name+= MediaInfoLib::Config.Language_Get(__T("  Config_Text_NumberTag"))+Ztring::ToZtring(Number);
+                        (*Stream_More)[StreamKind][StreamPos][Pos][Info_Name_Text]=Name;
+                    }
+                }
+            }
+        }
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
@@ -120,6 +120,10 @@ public :
     void          File_ID_OnlyRoot_Set (bool NewValue);
     bool          File_ID_OnlyRoot_Get ();
 
+    void          File_ExpandSubs_Set(bool NewValue);
+    bool          File_ExpandSubs_Get();
+    void          File_ExpandSubs_Update(void** Source);
+
     #if MEDIAINFO_ADVANCED
         void          File_IgnoreSequenceFileSize_Set (bool NewValue);
         bool          File_IgnoreSequenceFileSize_Get ();
@@ -437,6 +441,8 @@ private :
     bool                    Audio_MergeMonoStreams;
     bool                    File_Demux_Interleave;
     bool                    File_ID_OnlyRoot;
+    void*                   File_ExpandSubs_Backup;
+    void*                   File_ExpandSubs_Source;
     #if MEDIAINFO_ADVANCED
         bool                File_IgnoreSequenceFileSize;
         bool                File_IgnoreSequenceFilesCount;

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -720,7 +720,8 @@ void File_Mpeg4::Streams_Finish()
         //Fragments
         if (IsFragmented)
         {
-            Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Duration), Temp->second.stts_Duration/((float)Temp->second.mdhd_TimeScale)*1000, 0, true);
+            if (Temp->second.mdhd_TimeScale)
+                Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Duration), Temp->second.stts_Duration/((float)Temp->second.mdhd_TimeScale)*1000, 0, true);
             Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_FrameCount), Temp->second.stts_FrameCount, 10, true);
         }
 

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -1311,7 +1311,7 @@ void File_Mpeg4::Streams_Finish()
                 CodecConfigurationBoxInfo+=__T('+');
             CodecConfigurationBoxInfo+=Ztring().From_CC4(Temp->second.CodecConfigurationBoxInfo[i]);
         }
-        Fill(StreamKind_Last, StreamPos_Last, "Codec configuration box", CodecConfigurationBoxInfo);
+        Fill(StreamKind_Last, StreamPos_Last, "CodecConfigurationBox", CodecConfigurationBoxInfo);
 
         //ES_ID
         for (File_Mpeg4_Descriptors::es_id_infos::iterator ES_ID_Info=ES_ID_Infos.begin(); ES_ID_Info!=ES_ID_Infos.end(); ES_ID_Info++)

--- a/Source/MediaInfo/OutputHelpers.cpp
+++ b/Source/MediaInfo/OutputHelpers.cpp
@@ -258,15 +258,24 @@ string To_JSON_Elements(Node& Cur_Node, const int& Level, bool Indent)
             if (!Cur_Node.Childs[Pos2])
                 continue;
 
-            Result+=(Indent?string(Level+1, '\t'):string())+"{";
-            Result+=To_JSON_Attributes(*Cur_Node.Childs[Pos2], Level+2, Indent);
-            Result+=To_JSON_Elements(*Cur_Node.Childs[Pos2], Level+2, Indent);
-            Result+="\n";
+            if (Cur_Node.Childs[Pos2]->Attrs.empty() && Cur_Node.Childs[Pos2]->Childs.empty() && !Cur_Node.Childs[Pos2]->Multiple)
+            {
+                if (Cur_Node.Childs[Pos2]->Value.empty())
+                    Result+="null";
+                else
+                    Result+="\""+JSON_Encode(Cur_Node.Childs[Pos2]->Value)+"\"";
+            }
+            else
+            {
+                Result+=(Indent?string(Level+1, '\t'):string())+"{";
+                Result+=To_JSON_Attributes(*Cur_Node.Childs[Pos2], Level+2, Indent);
+                Result+=To_JSON_Elements(*Cur_Node.Childs[Pos2], Level+2, Indent);
+                Result+="\n";
 
-            if(!Cur_Node.Childs[Pos2]->Value.empty())
-                Result+=(Indent?string(Level+2, '\t'):string())+"\"#value\": \""+JSON_Encode(Cur_Node.Childs[Pos2]->Value)+"\"\n";
-            Result+=(Indent?string(Level+1, '\t'):string())+"}";
-
+                if(!Cur_Node.Childs[Pos2]->Value.empty())
+                    Result+=(Indent?string(Level+2, '\t'):string())+"\"#value\": \""+JSON_Encode(Cur_Node.Childs[Pos2]->Value)+"\"\n";
+                Result+=(Indent?string(Level+1, '\t'):string())+"}";
+            }
             if (Pos2<Cur_Node.Childs.size()-1 && Cur_Node.Childs[Pos2]->Name==Cur_Node.Childs[Pos2+1]->Name)
                 Result+=",";
 


### PR DESCRIPTION
Tree and text views can have something like (with presentation 1 merging signal groups 1 & 2, presentation 2 merging signal groups 1 & 3):
```
+ Presentation 1
  +- Loudness
  +- DRC
  + Signal group 1
    +- Type: Bed channels
    +- Channel mode: 7.1.4
  + Signal group 2
    +- Type: Dialog
    +- Language: English
    +- Channel mode: 1.0
+ Presentation 2
  +- Loudness
  +- DRC
  + Signal group 1
    +- Type: Bed channels
    +- Channel mode: 7.1.4
  + Signal group 3
    +- Type: Dialog
    +- Language: German
    +- Channel mode: 1.0
```

It will be useful for incoming support of multi-substreams audio streams.

Includes a couple of tiny fixes.