### PR TITLE
Fix #1242 for when Encoded_Date has more than one date, leave only th…

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -793,6 +793,7 @@ void File_Mk::Streams_Finish()
                     {
                         Ztring Hutc = Retrieve(Stream_General, 0, "Encoded_Date");
                         Hutc.FindAndReplace(__T("UTC "), Ztring());
+                        Hutc = Hutc.substr(0, Hutc.find(__T(" / "), 0)); // leave only the first date in a "UTC date1 / UTC date2" field
                         Ztring App, Utc;
                         Item2=Item->second.find(__T("_STATISTICS_WRITING_APP"));
                         if (Item2!=Item->second.end())


### PR DESCRIPTION
…e first one before the ' / ' separator

It seems like Mkvmerge is prepending dates to the **Encoded_Date** field, preserving the original encoding date, which turns the field into a "UTC date1 / UTC date2" string.
As a result, MediaInfo fails to properly compare this date to the single `Utc` date and fails to read statistical tags even when they are up-to-date.
This commit leaves only the first date from the  **Encoded_Date** field by removing everthing after the ' / ' separator, e.g.
`date1 / UTC date2` (UTC from date1 is stripped by a preceding `FindAndReplace` command) is turned into
`date1`
which can then be properly compared to `_STATISTICS_WRITING_DATE_UTC`