### PR TITLE
DV: ignore rec_date/rec_time full of 0xFF or incoherent

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac_Main.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_Main.cpp
@@ -392,7 +392,10 @@ extern string Aac_ChannelLayout_GetString(const Aac_OutputChannel* const OutputC
     string Value;
     for (int i=0; i< OutputChannels_Size; i++)
     {
-        Value+=Aac_OutputChannelPosition[OutputChannels[i]];
+        if (OutputChannels[i]<Aac_OutputChannelPosition_Size)
+            Value+=Aac_OutputChannelPosition[OutputChannels[i]];
+        else
+            Value+=Ztring::ToZtring(OutputChannels[i]).To_UTF8();
         Value+=' ';
     }
     Value.resize(Value.size()-1);

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -2791,7 +2791,7 @@ void MediaInfo_Config_MediaInfo::Event_Send (File__Analyze* Source, const int8u*
     {
         MediaInfo_Event_Generic* Event=(MediaInfo_Event_Generic*)Data_Content;
 
-        if (Event->StreamIDs_Size>=2 && Event->ParserIDs[0]==MediaInfo_Parser_MpegTs && Event->ParserIDs[1]==MediaInfo_Parser_MpegPs)
+        if (Event->StreamIDs_Size>=2 && Event->EventCode!=(MediaInfo_Parser_DvDif<<24 | MediaInfo_Event_DvDif_Analysis_Frame<<8) &&  Event->ParserIDs[0]==MediaInfo_Parser_MpegTs && Event->ParserIDs[1]==MediaInfo_Parser_MpegPs)
         {
             //Catching reference stream
             if (Event->StreamIDs[1]==0xE0 && Events_TimestampShift_Reference_ID==(int64u)-1)

--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -1758,6 +1758,15 @@ void File_DvDif::consumer_camera_2()
 //---------------------------------------------------------------------------
 void File_DvDif::recdate(bool FromVideo)
 {
+    // Coherency test
+    int32u Test;
+    Peek_B4(Test);
+    if (Test==(int32u)-1)
+    {
+        Skip_B4(                                                "Junk");
+        return;
+    }
+
     BS_Begin();
 
     int8u Temp;
@@ -1786,7 +1795,7 @@ void File_DvDif::recdate(bool FromVideo)
 
     BS_End();
 
-    if (FromVideo && Frame_Count==1 && Month<=12 && Day<=31 && Recorded_Date_Date.empty())
+    if (FromVideo && Frame_Count==1 && Year!=2065 && Month && Month<=12 && Day && Day<=31 && Recorded_Date_Date.empty())
     {
         Ztring MonthString;
         if (Month<10)
@@ -1803,6 +1812,15 @@ void File_DvDif::recdate(bool FromVideo)
 //---------------------------------------------------------------------------
 void File_DvDif::rectime(bool FromVideo)
 {
+    // Coherency test
+    int32u Test;
+    Peek_B4(Test);
+    if (Test==(int32u)-1)
+    {
+        Skip_B4(                                            "Junk");
+        return;
+    }
+
     if (!DSF_IsValid)
     {
         Trusted_IsNot("Not in right order");

--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -149,8 +149,9 @@ void File_DvDif::Read_Buffer_Continue()
                                                            + ((Buffer[Buffer_Offset+3+Pos+3]&0x0F)   )   ;
                             int8u Years                     =((Buffer[Buffer_Offset+3+Pos+4]&0xF0)>>4)*10
                                                            + ((Buffer[Buffer_Offset+3+Pos+4]&0x0F)   )   ;
-                            if (Months<=12
-                             && Days  <=31)
+                            if (Years!=165
+                             && Months && Months<=12
+                             && Days && Days<=31)
                             {
                                 if (Speed_RecDate_Current.IsValid
                                  && Speed_RecDate_Current.Days      !=Days


### PR DESCRIPTION
@kieranjol @dericed I was disturbed 😋 by "2037-02-00" date in your files.
I ignore rec_date full of 0xFF or even when only year is 0xFF or when day is 0x00 etc.