### PR TITLE
DV Analysis: keep former source/source_control for video & audio

### DIFF
--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -1468,8 +1468,6 @@ void File_DvDif::Errors_Stats_Update()
 
     FSC_WasSet=false;
     FSP_WasNotSet=false;
-    video_source_stype=(int8u)-1;
-    aspect=(int8u)-1;
     ssyb_AP3=(int8u)-1;
     Speed_TimeCode_Last=Speed_TimeCode_Current;
     Speed_TimeCode_Current.Clear();


### PR DESCRIPTION
when source/source_control is missing

Fix https://github.com/mipops/dvrescue/issues/63.