### PR TITLE
MKV/WebM: Report Delay and Duration correctly for VP9 MKV/WebM files.

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -1148,49 +1148,49 @@ void File_Mk::Streams_Finish()
             }
         }
 
-        if (Temp->second.Parser)
+        //Delay
+        if (Temp->second.TimeCode_Start!=(int64u)-1 && TimecodeScale)
         {
-            //Delay
-            if (Temp->second.TimeCode_Start!=(int64u)-1 && TimecodeScale)
+            //From TimeCode
+            float64 Delay=Temp->second.TimeCode_Start*int64u_float64(TimecodeScale)/1000000.0;
+
+            //From stream format
+            if (Temp->second.Parser && StreamKind_Last==Stream_Audio && Count_Get(Stream_Video)==1 && Temp->second.Parser->Count_Get(Stream_General)>0)
             {
-                //From TimeCode
-                float64 Delay=Temp->second.TimeCode_Start*int64u_float64(TimecodeScale)/1000000.0;
-
-                //From stream format
-                if (StreamKind_Last==Stream_Audio && Count_Get(Stream_Video)==1 && Temp->second.Parser->Count_Get(Stream_General)>0)
+                     if (Temp->second.Parser->Buffer_TotalBytes_FirstSynched==0)
+                    ;
+                else if (Temp->second.AvgBytesPerSec!=0)
+                    Delay+=((float64)Temp->second.Parser->Buffer_TotalBytes_FirstSynched)*1000/Temp->second.AvgBytesPerSec;
+                else
                 {
-                         if (Temp->second.Parser->Buffer_TotalBytes_FirstSynched==0)
-                        ;
-                    else if (Temp->second.AvgBytesPerSec!=0)
-                        Delay+=((float64)Temp->second.Parser->Buffer_TotalBytes_FirstSynched)*1000/Temp->second.AvgBytesPerSec;
-                    else
-                    {
-                        int64u BitRate = Temp->second.Parser->Retrieve(Stream_Audio, 0, Audio_BitRate).To_int64u();
-                        if (BitRate == 0)
-                            BitRate = Temp->second.Parser->Retrieve(Stream_Audio, 0, Audio_BitRate_Nominal).To_int64u();
-                        if (BitRate)
-                            Delay += ((float64)Temp->second.Parser->Buffer_TotalBytes_FirstSynched) * 1000 / BitRate;
-                    }
-                }
-
-                //Filling
-                Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Delay), Delay, 0, true);
-                Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Delay_Source), "Container");
-
-                const Ztring &DurationS=Retrieve(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Duration));
-                float64 Duration=DurationS.To_float64();
-                if (!HasStats && Duration && Duration>=Delay) //Not sure about when tats are present, so for the moment we remove delay from duration only if there is no stats, Duration looks like more lie timestamp of the end of the last frame with the example we got
-                {
-                    Duration-=Delay;
-                    size_t DotPos=DurationS.find(__T('.'));
-                    if (DotPos == (size_t)-1)
-                        DotPos = DurationS.size();
-                    else
-                        DotPos++;
-                    Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Duration), Duration, DurationS.size()-DotPos, true);
+                    int64u BitRate = Temp->second.Parser->Retrieve(Stream_Audio, 0, Audio_BitRate).To_int64u();
+                    if (BitRate == 0)
+                        BitRate = Temp->second.Parser->Retrieve(Stream_Audio, 0, Audio_BitRate_Nominal).To_int64u();
+                    if (BitRate)
+                        Delay += ((float64)Temp->second.Parser->Buffer_TotalBytes_FirstSynched) * 1000 / BitRate;
                 }
             }
 
+            //Filling
+            Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Delay), Delay, 0, true);
+            Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Delay_Source), "Container");
+
+            const Ztring &DurationS=Retrieve(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Duration));
+            float64 Duration=DurationS.To_float64();
+            if (!HasStats && Duration && Duration>=Delay) //Not sure about when tats are present, so for the moment we remove delay from duration only if there is no stats, Duration looks like more lie timestamp of the end of the last frame with the example we got
+            {
+                Duration-=Delay;
+                size_t DotPos=DurationS.find(__T('.'));
+                if (DotPos == (size_t)-1)
+                    DotPos = DurationS.size();
+                else
+                    DotPos++;
+                Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Duration), Duration, DurationS.size()-DotPos, true);
+            }
+        }
+
+        if (Temp->second.Parser)
+        {
             Ztring Codec_Temp=Retrieve(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Codec)); //We want to keep the 4CC;
             //if (Duration_Temp.empty()) Duration_Temp=Retrieve(StreamKind_Last, Temp->second.StreamPos, Fill_Parameter(StreamKind_Last, Generic_Duration)); //Duration from stream is sometimes false
             //else Duration_Temp.clear();


### PR DESCRIPTION
No parser had been implemented for the VP9 codec, and the MKV analyzer was
not reporting Delay for any codec without a parser.

Since the parser is not actually necessary to extract the accurate Delay for
MKV video files, I did not fix this by implementing a VP9 parser; rather I
allowed the MKV analyzer to report a Delay if no parser is present.

With the Delay value detected correctly, the Duration can now be calculated
correctly as well.

This test video is an excerpt from [Big Buck Bunny](https://peach.blender.org/about/) which is copyright 2008, [Blender Foundation](https://www.blender.org/foundation/) and licensed under [CC BY 3.0](http://creativecommons.org/licenses/by/3.0/).
[test_video_000000002.zip](https://github.com/MediaArea/MediaInfoLib/files/4732455/test_video_000000002.zip)

Because the test video has a nonzero initial timestamp, its duration will not be reported correctly unless the Delay is detected. This patch fixes the duration in the Video section of the mediainfo report.