### PR TITLE
Don't seek to the end (false positive range related error with HTTP)

### DIFF
--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -3245,8 +3245,9 @@ void File__Analyze::GoTo (int64u GoTo, const char* ParserName)
     if (GoTo==File_Size)
     {
         BookMark_Get();
-        if (File_GoTo!=(int64u)-1)
-            return;
+        if (File_GoTo==(int64u)-1)
+            Finish();
+        return;
     }
 
     if (ShouldContinueParsing)


### PR DESCRIPTION
Fix https://github.com/MediaArea/MediaInfo/issues/454 "HTTP server doesn't seem to support byte ranges. Cannot resume." with HTTP links and MP4 files with header at the end.
