### PR TITLE
DV analysis : fix non-continuous recording date/time false detection

### DIFF
--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -1442,7 +1442,7 @@ void File_DvDif::Errors_Stats_Update()
         {
             Speed_RecTime_Current_Theory.Time.Seconds=0;
             Speed_RecTime_Current_Theory.Time.Minutes++;
-            if (Speed_RecTime_Current_Theory.Time.Seconds>=60)
+            if (Speed_RecTime_Current_Theory.Time.Minutes>=60)
             {
                 Speed_RecTime_Current_Theory.Time.Minutes=0;
                 Speed_RecTime_Current_Theory.Time.Hours++;


### PR DESCRIPTION
Fix https://github.com/mipops/dvrescue/issues/113
(stupid bad typo...)