### PR TITLE
DPX: don't load the whole file in RAM

### DIFF
--- a/Source/MediaInfo/Image/File_Dpx.cpp
+++ b/Source/MediaInfo/Image/File_Dpx.cpp
@@ -489,6 +489,9 @@ void File_Dpx::Header_Parse()
     }
     else
         Header_Fill_Size(Sizes[Sizes_Pos]);
+
+    if (Sizes_Pos==Pos_ImageData)
+        DataMustAlwaysBeComplete=false; //We actually don't need to load the whole ImageData, as we don't parse it
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
We actually don't need to load the whole ImageData, as we don't have to parse it
Fix https://github.com/MediaArea/MediaInfoLib/issues/1273.