### PR TITLE
Remove UTF-8 BOM from metadata if present

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -360,6 +360,28 @@ bool ShowSource_IsInList(video Value)
 //---------------------------------------------------------------------------
 void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Parameter, const Ztring &Value, bool Replace)
 {
+    // Sanitize
+    if (!Value.empty())
+    {
+        size_t Value_NotBOM_Pos;
+        if (sizeof(Char)==1)
+        {
+            Value_NotBOM_Pos=0;
+            while (Value.size()-Value_NotBOM_Pos>=3 // Avoid deep recursivity
+             && Value[Value_NotBOM_Pos  ]==0xEF 
+             && Value[Value_NotBOM_Pos+1]==0xBB
+             && Value[Value_NotBOM_Pos+2]==0xBF
+                )
+                Value_NotBOM_Pos+=3;
+        }
+        else
+        {
+            Value_NotBOM_Pos=Value.find_first_not_of(__T('\xFEFF')); // Avoid deep recursivity
+        }
+        if (Value_NotBOM_Pos)
+            return Fill(StreamKind, StreamPos, Parameter, Value.substr(Value_NotBOM_Pos), Replace);
+    }
+
     //MergedStreams
     if (FillAllMergedStreams)
     {

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -376,6 +376,25 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Paramete
         }
         else
         {
+            //Check inverted bytes from UTF BOM
+            Value_NotBOM_Pos=Value.find_first_not_of(__T('\xFFFE')); // Avoid deep recursivity
+            if (Value_NotBOM_Pos)
+            {
+                Ztring Value2;
+                Value2.reserve(Value.size()-1);
+                for (size_t i=0; i<Value.size(); i++)
+                {
+                    //Swap
+                    Char ValueChar=Value[i];
+                    ValueChar=((ValueChar<<8 & 0xFFFF) | ((ValueChar>>8) & 0xFF)); // Swap
+                    Value2.append(1, ValueChar);
+                }
+                Value_NotBOM_Pos=Value2.find_first_not_of(__T('\xFEFF')); // Avoid deep recursivity
+                if (Value_NotBOM_Pos)
+                    Value2=Value2.substr(Value_NotBOM_Pos);
+                return Fill(StreamKind, StreamPos, Parameter, Value2, Replace);
+            }
+
             Value_NotBOM_Pos=Value.find_first_not_of(__T('\xFEFF')); // Avoid deep recursivity
         }
         if (Value_NotBOM_Pos)

--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -743,7 +743,7 @@ void File__Analyze::Streams_Finish_StreamOnly_Video(size_t Pos)
             if (!Source.empty())
             {
                 Fill(Stream_Video, Pos, "Duration_Source", Source);
-                //Fill_SetOptions(Stream_Video, Pos, "Duration_Source", "N NTN");
+                Fill_SetOptions(Stream_Video, Pos, "Duration_Source", "N NTN");
             }
         }
     }
@@ -1087,7 +1087,7 @@ void File__Analyze::Streams_Finish_StreamOnly_Audio(size_t Pos)
             if (!Source.empty())
             {
                 Fill(Stream_Audio, Pos, "Duration_Source", Source);
-                //Fill_SetOptions(Stream_Audio, Pos, "Duration_Source", "N NTN");
+                Fill_SetOptions(Stream_Audio, Pos, "Duration_Source", "N NTN");
             }
         }
     }


### PR DESCRIPTION
Useless and potential XML output validation issue.
Also reformat if BOM indicates a wrong order of bytes.
Referenced in https://github.com/sbraz/pymediainfo/issues/90#issuecomment-646915113.