### PR TITLE
VorbisTag: DISCID is legitimate

### DIFF
--- a/Source/MediaInfo/Tag/File_VorbisCom.cpp
+++ b/Source/MediaInfo/Tag/File_VorbisCom.cpp
@@ -230,7 +230,6 @@ void File_VorbisCom::Data_Parse()
         else if (Key==__T("DATE"))                   Fill(StreamKind_Common,   0, "Recorded_Date", Value, true);
         else if (Key==__T("DESCRIPTION"))            Fill(StreamKind_Common,   0, "Description", Value);
         else if (Key==__T("DISC"))                   Fill(StreamKind_Common,   0, "Part", Value, true);
-        else if (Key==__T("DISCID"))                 {}
         else if (Key==__T("DISCNUMBER"))             Fill(StreamKind_Common,   0, "Part", Value, true);
         else if (Key==__T("DISCTOTAL"))              {if (Value!=Retrieve(StreamKind_Common, 0, "Part/Position_Total")) Fill(StreamKind_Common,   0, "Part/Position_Total", Value);}
         else if (Key==__T("ENCODEDBY"))              Fill(StreamKind_Common,   0, "EncodedBy", Value);


### PR DESCRIPTION
DISCID field seems legitimate for most files, so we don't ignore it anymore.