### PR TITLE
Detection of Dolby E hidden in tracks having more than 2 channels

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -169,6 +169,7 @@ set(MediaInfoLib_SRCS
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Audio/File_Caf.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Audio/File_Celt.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Audio/File_ChannelGrouping.cpp
+  ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Audio/File_ChannelSplitting.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Audio/File_Dsdiff.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Audio/File_Dsf.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Audio/File_Dts.cpp

--- a/Project/GNU/Library/Makefile.am
+++ b/Project/GNU/Library/Makefile.am
@@ -54,6 +54,7 @@ lib@MediaInfoLib_LibName@_la_SOURCES = \
                        ../../../Source/MediaInfo/Audio/File_Caf.cpp \
                        ../../../Source/MediaInfo/Audio/File_Celt.cpp \
                        ../../../Source/MediaInfo/Audio/File_ChannelGrouping.cpp \
+                       ../../../Source/MediaInfo/Audio/File_ChannelSplitting.cpp \
                        ../../../Source/MediaInfo/Audio/File_Dsdiff.cpp \
                        ../../../Source/MediaInfo/Audio/File_Dsf.cpp \
                        ../../../Source/MediaInfo/Audio/File_Dts.cpp \

--- a/Project/MSVC2013/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2013/Library/MediaInfoLib.vcxproj
@@ -128,6 +128,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Caf.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Celt.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.cpp" />
@@ -417,6 +418,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Caf.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Celt.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.h" />

--- a/Project/MSVC2013/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2013/Library/MediaInfoLib.vcxproj.filters
@@ -797,6 +797,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Video\File_DolbyVisionMetadata.cpp">
       <Filter>Source Files\Video</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.cpp">
+      <Filter>Source Files\Audio</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyse_Automatic.h">
@@ -1490,6 +1493,9 @@
       <Filter>Header Files\Video</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Usac.h">
+      <Filter>Header Files\Audio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.h">
       <Filter>Header Files\Audio</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Project/MSVC2015/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2015/Library/MediaInfoLib.vcxproj
@@ -128,6 +128,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Caf.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Celt.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.cpp" />
@@ -417,6 +418,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Caf.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Celt.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.h" />

--- a/Project/MSVC2015/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2015/Library/MediaInfoLib.vcxproj.filters
@@ -797,6 +797,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Video\File_DolbyVisionMetadata.cpp">
       <Filter>Source Files\Video</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.cpp">
+      <Filter>Source Files\Audio</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyse_Automatic.h">
@@ -1490,6 +1493,9 @@
       <Filter>Header Files\Video</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Usac.h">
+      <Filter>Header Files\Audio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.h">
       <Filter>Header Files\Audio</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Project/MSVC2017/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2017/Library/MediaInfoLib.vcxproj
@@ -128,6 +128,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Caf.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Celt.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.cpp" />
@@ -417,6 +418,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Caf.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Celt.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.h" />

--- a/Project/MSVC2017/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2017/Library/MediaInfoLib.vcxproj.filters
@@ -797,6 +797,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Video\File_DolbyVisionMetadata.cpp">
       <Filter>Source Files\Video</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.cpp">
+      <Filter>Source Files\Audio</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyse_Automatic.h">
@@ -1490,6 +1493,9 @@
       <Filter>Header Files\Video</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Usac.h">
+      <Filter>Header Files\Audio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.h">
       <Filter>Header Files\Audio</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Project/MSVC2017/Library/MediaInfoLib_UWP.vcxproj
+++ b/Project/MSVC2017/Library/MediaInfoLib_UWP.vcxproj
@@ -191,6 +191,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Caf.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Celt.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.cpp" />
@@ -480,6 +481,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Caf.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Celt.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.h" />

--- a/Project/MSVC2019/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2019/Library/MediaInfoLib.vcxproj
@@ -129,6 +129,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Caf.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Celt.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.cpp" />
@@ -418,6 +419,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Caf.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Celt.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.h" />

--- a/Project/MSVC2019/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2019/Library/MediaInfoLib.vcxproj.filters
@@ -797,6 +797,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Mpegh3da.cpp">
       <Filter>Source Files\Audio</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.cpp">
+      <Filter>Source Files\Audio</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyse_Automatic.h">
@@ -1490,6 +1493,9 @@
       <Filter>Header Files\Audio</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Usac.h">
+      <Filter>Header Files\Audio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.h">
       <Filter>Header Files\Audio</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Project/MSVC2019/Library/MediaInfoLib_UWP.vcxproj
+++ b/Project/MSVC2019/Library/MediaInfoLib_UWP.vcxproj
@@ -191,6 +191,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Caf.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Celt.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.cpp" />
@@ -479,6 +480,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Caf.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Celt.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelGrouping.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_ChannelSplitting.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_DolbyE.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsdiff.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Dsf.h" />

--- a/Source/MediaInfo/Audio/File_ChannelSplitting.cpp
+++ b/Source/MediaInfo/Audio/File_ChannelSplitting.cpp
@@ -1,0 +1,369 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//---------------------------------------------------------------------------
+// Pre-compilation
+#include "MediaInfo/PreComp.h"
+#ifdef __BORLANDC__
+    #pragma hdrstop
+#endif
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/Setup.h"
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#if defined(MEDIAINFO_SMPTEST0337_YES)
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/Audio/File_ChannelSplitting.h"
+#if defined(MEDIAINFO_SMPTEST0337_YES)
+    #include "MediaInfo/Audio/File_SmpteSt0337.h"
+#endif
+#if defined(MEDIAINFO_PCM_YES)
+    #include "MediaInfo/Audio/File_Pcm.h"
+#endif
+#if MEDIAINFO_EVENTS
+    #include "MediaInfo/MediaInfo_Events.h"
+#endif //MEDIAINFO_EVENTS
+#include "MediaInfo/MediaInfo_Config_MediaInfo.h"
+//---------------------------------------------------------------------------
+
+namespace MediaInfoLib
+{
+
+//***************************************************************************
+// Constructor/Destructor
+//***************************************************************************
+
+File_ChannelSplitting::File_ChannelSplitting()
+{
+    //Configuration
+    #if MEDIAINFO_EVENTS
+        ParserIDs[0]=0; // MediaInfo_Parser_ChannelSplitting;
+        StreamIDs_Width[0]=1;
+    #endif //MEDIAINFO_EVENTS
+    #if MEDIAINFO_DEMUX
+        Demux_Level=2; //Container
+    #endif //MEDIAINFO_DEMUX
+    #if MEDIAINFO_TRACE
+        Trace_Layers_Update(0); //Container1
+    #endif //MEDIAINFO_TRACE
+    StreamSource=IsStream;
+
+    //In
+    BitDepth=0;
+    SamplingRate=0;
+    Endianness=0;
+    Aligned=false;
+    Common=NULL;
+    Channel_Total=1;
+}
+
+File_ChannelSplitting::~File_ChannelSplitting()
+{
+    delete Common; //Common=NULL;
+}
+
+//***************************************************************************
+// Streams management
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+void File_ChannelSplitting::Streams_Fill()
+{
+    Fill(Stream_General, 0, General_Format, "ChannelSplitting");
+
+    for (size_t i=0; i<Common->SplittedChannels.size(); i++)
+    {
+        std::vector<File__Analyze*>& Parsers=Common->SplittedChannels[i]->Parsers;
+
+        if (Parsers.size()!=1)
+            continue;
+        
+        if (!Parsers[0]->Status[IsAccepted])
+        {
+            for (int j=0; j<2; j++)
+            {
+                File_Pcm Parser;
+                Parser.BitDepth=BitDepth;
+                Parser.Channels=1;
+                Parser.SamplingRate=SamplingRate;
+                Parser.Endianness=Endianness;
+                Open_Buffer_Init(&Parser);
+                Parser.Accept();
+                Fill(&Parser);
+                size_t Pos=Count_Get(Stream_Audio);
+                Merge(Parser);
+                Fill(Stream_Audio, Pos, Audio_ID, i*2+1+j, true);
+                Fill(Stream_Audio, Pos, Audio_MuxingMode, "Multiple");
+            }
+            continue;
+        }
+
+        Fill(Parsers[0]);
+        size_t Pos=Count_Get(Stream_Audio);
+        Merge(*Parsers[0]);
+        for (size_t j=0; j<Parsers[0]->Count_Get(Stream_Audio); j++)
+        {
+            Ztring ID=Ztring().From_Number(i*2+1)+__T(" / ") + Ztring().From_Number(i*2+2);
+            const Ztring& ID_Parser=Parsers[0]->Retrieve_Const(Stream_Audio, j, Audio_ID);
+            if (!ID_Parser.empty())
+            {
+                ID+=__T('-');
+                ID+=ID_Parser;
+            }
+            Fill(Stream_Audio, Pos+j, Audio_ID, ID, true);
+            Ztring MuxingMode=__T("Multiple");
+            const Ztring& MuxingMode_Parser=Parsers[0]->Retrieve(Stream_Audio, j, Audio_MuxingMode);
+            if (!MuxingMode_Parser.empty())
+            {
+                MuxingMode+=__T(" / ");
+                MuxingMode+=MuxingMode_Parser;
+            }
+            Fill(Stream_Audio, Pos+j, Audio_MuxingMode, MuxingMode, true);
+        }
+    }
+}
+
+//---------------------------------------------------------------------------
+void File_ChannelSplitting::Streams_Finish()
+{
+    for (size_t i = 0; i<Common->SplittedChannels.size(); i++)
+    {
+        std::vector<File__Analyze*>& Parsers=Common->SplittedChannels[i]->Parsers;
+        
+        if (Parsers.size()!=1)
+            continue;
+
+        Finish(Parsers[0]);
+    }
+}
+
+//***************************************************************************
+// Buffer - Global
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+void File_ChannelSplitting::Read_Buffer_Init()
+{
+    if (Common==NULL)
+    {
+        if (Channel_Total%2)
+        {
+            Reject();
+            return; //Currently supporting only pairs
+        }
+            
+        //Common
+        Common=new common;
+        Common->SplittedChannels.resize(Channel_Total/2);
+
+        for (size_t i=0; i<Common->SplittedChannels.size(); i++)
+        {
+            Common->SplittedChannels[i]=new common::channel;
+            std::vector<File__Analyze*>& Parsers=Common->SplittedChannels[i]->Parsers;
+
+            //SMPTE ST 337
+            {
+                File_SmpteSt0337* Parser=new File_SmpteSt0337;
+                Parser->Container_Bits=BitDepth;
+                Parser->Endianness=Endianness;
+                Parser->Aligned=Aligned;
+                Parsers.push_back(Parser);
+            }
+
+            // PCM // TODO (currently no demux)
+
+            //for all parsers
+            for (size_t Pos=0; Pos<Parsers.size(); Pos++)
+            {
+                #if MEDIAINFO_DEMUX
+                    if (Config->Demux_Unpacketize_Get())
+                    {
+                        Parsers[Pos]->Demux_UnpacketizeContainer=true;
+                        Parsers[Pos]->Demux_Level=2; //Container
+                        Demux_Level=4; //Intermediate
+                    }
+                #endif //MEDIAINFO_DEMUX
+                Element_Code=i+1;
+                Open_Buffer_Init(Parsers[Pos]);
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------------------------
+void File_ChannelSplitting::Read_Buffer_Continue()
+{
+    //Handling of multiple frames in one block
+    if (Buffer_Size==0)
+    {
+        Read_Buffer_Continue_Parse();
+        return;
+    }
+
+    //Demux
+    #if MEDIAINFO_DEMUX
+        Demux(Buffer+Buffer_Offset, Buffer_Size-Buffer_Offset, ContentType_MainStream);
+    #endif //MEDIAINFO_EVENTS
+
+    //Size of buffer
+    for (size_t i=0; i<Common->SplittedChannels.size(); i++)
+    {
+        common::channel* SplittedChannel=Common->SplittedChannels[i];
+
+        if (Buffer_Size/Common->SplittedChannels.size()>SplittedChannel->Buffer_Size_Max)
+            SplittedChannel->resize(Buffer_Size/Common->SplittedChannels.size());
+        SplittedChannel->Buffer_Size=0;
+    }
+
+    //Copying to splitted channels
+    Buffer_Offset=0;
+    while (Channel_Total*BitDepth<=(Buffer_Size-Buffer_Offset)*8)
+    {
+        for (size_t i=0; i<Common->SplittedChannels.size(); i++)
+        {
+            common::channel* SplittedChannel=Common->SplittedChannels[i];
+
+            switch (BitDepth)
+            {
+                case 24:
+                    // Copy 6 bytes
+                    SplittedChannel->Buffer[SplittedChannel->Buffer_Size++]=Buffer[Buffer_Offset++];
+                case 20:
+                    // Copy 5 bytes
+                    SplittedChannel->Buffer[SplittedChannel->Buffer_Size++]=Buffer[Buffer_Offset++];
+                case 16:
+                    // Copy 4 bytes
+                    SplittedChannel->Buffer[SplittedChannel->Buffer_Size++]=Buffer[Buffer_Offset++];
+                    SplittedChannel->Buffer[SplittedChannel->Buffer_Size++]=Buffer[Buffer_Offset++];
+                    SplittedChannel->Buffer[SplittedChannel->Buffer_Size++]=Buffer[Buffer_Offset++];
+                    SplittedChannel->Buffer[SplittedChannel->Buffer_Size++]=Buffer[Buffer_Offset++];
+                    break;
+                default: ;
+                    // Not supported
+                    Reject();
+                    return;
+            }
+        }
+    }
+
+    for (size_t i=0; i<Common->SplittedChannels.size(); i++)
+    {
+        common::channel* SplittedChannel=Common->SplittedChannels[i];
+
+        for (size_t Pos=0; Pos<SplittedChannel->Parsers.size(); Pos++)
+        {
+            if (FrameInfo_Next.DTS!=(int64u)-1)
+                SplittedChannel->Parsers[Pos]->FrameInfo = FrameInfo_Next; //AES3 parse has its own buffer management
+            else if (FrameInfo.DTS!=(int64u)-1)
+                SplittedChannel->Parsers[Pos]->FrameInfo = FrameInfo;
+        }
+    }
+    FrameInfo=frame_info();
+    AllFilled=true;
+    AllFinished=true;
+    SplittedChannels_i=0;
+    size_t ContentSize=Buffer_Offset;
+    Buffer_Offset=0;
+    Skip_XX(ContentSize,                                        "Channel grouping data");
+    Element_Offset=0;
+    Read_Buffer_Continue_Parse();
+    Buffer_Offset=ContentSize;
+    Element_WaitForMoreData();
+}
+
+void File_ChannelSplitting::Read_Buffer_Continue_Parse()
+{
+    for (; SplittedChannels_i<Common->SplittedChannels.size(); SplittedChannels_i++)
+    {
+        common::channel* SplittedChannel=Common->SplittedChannels[SplittedChannels_i];
+
+        for (size_t Pos=0; Pos<SplittedChannel->Parsers.size(); Pos++)
+        {
+            Element_Code=SplittedChannels_i*2+1;
+            Open_Buffer_Continue(SplittedChannel->Parsers[Pos], SplittedChannel->Buffer, SplittedChannel->Buffer_Size, false);
+
+            //Multiple parsers
+            if (SplittedChannel->Parsers.size()>1)
+            {
+                //Test if valid
+                if (!Status[IsAccepted] && SplittedChannel->Parsers[SplittedChannel->Parsers.size()-1]->Frame_Count+1 >= ((File_Pcm*)SplittedChannel->Parsers[SplittedChannel->Parsers.size()-1])->Frame_Count_Valid)
+                {
+                    //Rejecting here, else the parser may emit a frame before we detect that we want to reject the stream because there are no PCM stream (not handled here)
+                    Reject();
+                    return;
+                }
+                if (!SplittedChannel->Parsers[Pos]->Status[IsAccepted] && SplittedChannel->Parsers[Pos]->Status[IsFinished])
+                {
+                    delete *(SplittedChannel->Parsers.begin()+Pos);
+                    SplittedChannel->Parsers.erase(SplittedChannel->Parsers.begin()+Pos);
+                    Pos--;
+                }
+                else if (SplittedChannel->Parsers.size()>1 && SplittedChannel->Parsers[Pos]->Status[IsAccepted])
+                {
+                    if (Pos==SplittedChannel->Parsers.size()-1)
+                        SplittedChannel->IsPcm=true; //Last parser is PCM
+                        
+                    File__Analyze* Parser=SplittedChannel->Parsers[Pos];
+                    for (size_t Pos2=0; Pos2<SplittedChannel->Parsers.size(); Pos2++)
+                    {
+                        if (Pos2!=Pos)
+                            delete *(SplittedChannel->Parsers.begin()+Pos2);
+                    }
+                    SplittedChannel->Parsers.clear();
+                    SplittedChannel->Parsers.push_back(Parser);
+                }
+            }
+        }
+        if (!Status[IsAccepted] && !SplittedChannel->IsPcm && SplittedChannel->Parsers.size()==1 && SplittedChannel->Parsers[0]->Status[IsAccepted])
+            Accept();
+        if (SplittedChannel->IsPcm || SplittedChannel->Parsers.size()!=1 || (!SplittedChannel->Parsers[0]->Status[IsFinished] && !SplittedChannel->Parsers[0]->Status[IsFilled]))
+            AllFilled=false;
+        if (SplittedChannel->IsPcm || SplittedChannel->Parsers.size()!=1 || !SplittedChannel->Parsers[0]->Status[IsFinished])
+            AllFinished=false;
+
+        #if MEDIAINFO_DEMUX
+            if (Config->Demux_EventWasSent)
+            {
+                SplittedChannels_i++;
+                return;
+            }
+        #endif //MEDIAINFO_DEMUX
+    }
+    Frame_Count++;
+    if (!Status[IsFilled] && AllFilled)
+        Fill();
+    if (!Status[IsFinished] && AllFinished)
+        Finish();
+}
+
+//---------------------------------------------------------------------------
+void File_ChannelSplitting::Read_Buffer_Unsynched()
+{
+    if (!Common)
+        return;
+
+    for (size_t i=0; i<Common->SplittedChannels.size(); i++)
+    {
+        common::channel* SplittedChannel=Common->SplittedChannels[i];
+
+        for (size_t Pos=0; Pos<Common->SplittedChannels[i]->Parsers.size(); Pos++)
+            if (SplittedChannel->Parsers[Pos])
+                SplittedChannel->Parsers[Pos]->Open_Buffer_Unsynch();
+    }
+}
+
+//***************************************************************************
+// C++
+//***************************************************************************
+
+} //NameSpace
+
+#endif //MEDIAINFO_SMPTEST0337_YES

--- a/Source/MediaInfo/Audio/File_ChannelSplitting.h
+++ b/Source/MediaInfo/Audio/File_ChannelSplitting.h
@@ -1,0 +1,114 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+//
+// Some containers use 4-channel stream for 2 AES3 (Stereo) transport
+// We need to split the 4-channel streams in two before sending
+// data to AES parser
+//
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+//---------------------------------------------------------------------------
+#ifndef MediaInfo_File_ChannelSplittingH
+#define MediaInfo_File_ChannelSplittingH
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/File__Analyze.h"
+#include <cstring>
+//---------------------------------------------------------------------------
+
+namespace MediaInfoLib
+{
+
+//***************************************************************************
+// Class File_ChannelSplitting
+//***************************************************************************
+#ifdef MEDIAINFO_SMPTEST0337_YES
+class File_ChannelSplitting : public File__Analyze
+{
+public :
+    //In
+    int8u   BitDepth;
+    int16u  SamplingRate;
+    int8u   Endianness;
+    bool    Aligned;
+
+    struct common
+    {
+        struct channel
+        {
+            int8u*          Buffer;
+            size_t          Buffer_Size;
+            size_t          Buffer_Size_Max;
+            std::vector<File__Analyze*> Parsers;
+            bool            IsPcm;
+
+            channel()
+            {
+                Buffer=NULL;
+                Buffer_Size=0;
+                Buffer_Size_Max=0;
+                IsPcm=false;
+            }
+
+            ~channel()
+            {
+                delete[] Buffer; //Buffer=NULL;
+                for (size_t Pos=0; Pos<Parsers.size(); Pos++)
+                    delete Parsers[Pos];
+            }
+
+            void resize(size_t NewSize)
+            {
+                delete[] Buffer;
+                Buffer_Size_Max=NewSize;
+                Buffer=new int8u[Buffer_Size_Max];
+            }
+        };
+        vector<channel*>    SplittedChannels;
+
+        common()
+        {
+        }
+
+        ~common()
+        {
+            for (size_t Pos=0; Pos<SplittedChannels.size(); Pos++)
+                delete SplittedChannels[Pos]; //Channels[Pos]=NULL;
+        }
+    };
+    int64u  StreamID;
+    common* Common;
+    int8u   Channel_Total;
+
+    //Constructor/Destructor
+    File_ChannelSplitting();
+    ~File_ChannelSplitting();
+
+private :
+    //Streams management
+    void Streams_Fill();
+    void Streams_Finish();
+
+    //Buffer - Global
+    void Read_Buffer_Init ();
+    void Read_Buffer_Continue ();
+    void Read_Buffer_Continue_Parse ();
+    void Read_Buffer_Unsynched();
+
+    //Temp
+    bool AllFilled;
+    bool AllFinished;
+    size_t SplittedChannels_i;
+};
+
+#endif // MEDIAINFO_SMPTEST0337_YES
+} //NameSpace
+
+#endif
+

--- a/Source/MediaInfo/Audio/File_Pcm.cpp
+++ b/Source/MediaInfo/Audio/File_Pcm.cpp
@@ -80,7 +80,7 @@ File_Pcm::File_Pcm()
     PTS_DTS_Needed=true;
 
     //In
-    Frame_Count_Valid=4;
+    Frame_Count_Valid=16;
     BitDepth=0;
     BitDepth_Significant=0;
     Channels=0;

--- a/Source/MediaInfo/Audio/File_SmpteSt0337.cpp
+++ b/Source/MediaInfo/Audio/File_SmpteSt0337.cpp
@@ -1391,6 +1391,7 @@ void File_SmpteSt0337::Data_Parse()
         Buffer_Offset=Save_Buffer_Offset;
         Buffer_Size=Save_Buffer_Size;
         File_Offset-=Buffer_Offset;
+        Element_Size=Save_Element_Size;
     }
 
     // Guard band

--- a/Source/MediaInfo/Audio/File_SmpteSt0337.cpp
+++ b/Source/MediaInfo/Audio/File_SmpteSt0337.cpp
@@ -374,7 +374,7 @@ bool File_SmpteSt0337::Synchronize()
     // Synchronizing
     while (Buffer_Offset+16<=Buffer_Size)
     {
-        if (!Status[IsAccepted] && !IsSub && File_Offset_FirstSynched==(int64u)-1 && Buffer_TotalBytes+Buffer_Offset>=Buffer_TotalBytes_FirstSynched_Max)
+        if (!Status[IsAccepted] && File_Offset_FirstSynched==(int64u)-1 && Buffer_TotalBytes+Buffer_Offset>=Buffer_TotalBytes_FirstSynched_Max)
         {
             Reject();
             return false;

--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -1105,7 +1105,7 @@ void File__Analyze::Streams_Finish_StreamOnly_Audio(size_t Pos)
         if (Duration && BitRate)
             Fill(Stream_Audio, Pos, Audio_StreamSize, Duration*BitRate/8/1000);
         if (Duration && BitRate_Encoded)
-            Fill(Stream_Audio, Pos, Audio_StreamSize_Encoded, Duration*BitRate_Encoded/8/1000);
+            Fill(Stream_Audio, Pos, Audio_StreamSize_Encoded, Duration*BitRate_Encoded/8/1000, 10, true);
     }
 
     //CBR/VBR

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -17266,6 +17266,8 @@ void File_Mxf::ChooseParser_Pcm(const essences::iterator &Essence, const descrip
             }
         #endif //MEDIAINFO_DEMUX
 
+        if (Essence->second.Parsers.empty())
+            Parser->Frame_Count_Valid=1;
         Essence->second.Parsers.push_back(Parser);
     #endif
 }

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -3031,12 +3031,26 @@ void File_Mxf::Streams_Finish_Essence(int32u EssenceUID, int128u TrackUID)
             }
 
             //Removing the 2 corresponding streams
-            NewPos1=(Essence->second.StreamPos_Initial/2)*2+StreamPos_Difference;
-            size_t NewPos2=NewPos1+1;
+            NewPos1=Essence->second.StreamPos_Initial-1+StreamPos_Difference;
             ID=Ztring::ToZtring(Essence1->second.TrackID)+__T(" / ")+Ztring::ToZtring(Essence->second.TrackID);
 
-            Stream_Erase(NewKind, NewPos2);
+            Stream_Erase(NewKind, NewPos1+1);
             Stream_Erase(NewKind, NewPos1);
+
+            essences::iterator NextStream=Essence1;
+            ++NextStream;
+            size_t NewAudio_Count=Essence->second.Parsers[0]->Count_Get(Stream_Audio);
+            while (NextStream!=Essences.end())
+            {
+                if (NextStream->second.StreamKind==Stream_Audio)
+                {
+                    NextStream->second.StreamPos-=2;
+                    NextStream->second.StreamPos+=NewAudio_Count;
+                    NextStream->second.StreamPos_Initial-=2;
+                    NextStream->second.StreamPos_Initial+=NewAudio_Count;
+                }
+                ++NextStream;
+            }
         }
         else
         {
@@ -3079,14 +3093,6 @@ void File_Mxf::Streams_Finish_Essence(int32u EssenceUID, int128u TrackUID)
                 }
             }
         }
-
-        //Positioning other streams
-        for (essences::iterator Essence_Temp=Essence; Essence_Temp!=Essences.end(); ++Essence_Temp)
-            if (!Essence_Temp->second.Parsers.empty() && Essence_Temp->second.Parsers[0]->Count_Get(Stream_Audio))
-            {
-                Essence_Temp->second.StreamPos-=2; //ChannelGrouping
-                Essence_Temp->second.StreamPos+=(*(Essence_Temp->second.Parsers.begin()))->Count_Get(Stream_Audio);
-            }
     }
     else //Normal
     {

--- a/Source/MediaInfo/Multiple/File_Mxf.h
+++ b/Source/MediaInfo/Multiple/File_Mxf.h
@@ -1158,6 +1158,7 @@ protected :
     void           ChooseParser_Ac3(const essences::iterator &Essence, const descriptors::iterator &Descriptor);
     void           ChooseParser_Alaw(const essences::iterator &Essence, const descriptors::iterator &Descriptor);
     void           ChooseParser_ChannelGrouping(const essences::iterator &Essence, const descriptors::iterator &Descriptor);
+    void           ChooseParser_ChannelSplitting(const essences::iterator& Essence, const descriptors::iterator& Descriptor);
     void           ChooseParser_Mpega(const essences::iterator &Essence, const descriptors::iterator &Descriptor);
     void           ChooseParser_Pcm(const essences::iterator &Essence, const descriptors::iterator &Descriptor);
     void           ChooseParser_SmpteSt0331(const essences::iterator &Essence, const descriptors::iterator &Descriptor);

--- a/Source/MediaInfo/Multiple/File_Riff.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff.cpp
@@ -773,7 +773,15 @@ bool File_Riff::Header_Begin()
             default        : AVI__movi_xxxx();
         }
 
+        bool ShouldStop=false;
         if (Config->ParseSpeed<1.0 && File_Offset+Buffer_Offset+Element_Offset-Buffer_DataToParse_Begin>=256*1024)
+        {
+            ShouldStop=true;
+            for (std::map<int32u, stream>::iterator StreamItem=Stream.begin(); StreamItem!=Stream.end(); ++StreamItem)
+                if (StreamItem->second.Parsers.size()>1 || (!StreamItem->second.Parsers.empty() && !StreamItem->second.Parsers[0]->Status[IsFilled]))
+                    ShouldStop=false;
+        }
+        if (ShouldStop)
         {
             File_GoTo=Buffer_DataToParse_End;
             Buffer_Offset=Buffer_Size;

--- a/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
+++ b/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
@@ -1420,7 +1420,7 @@ void File__ReferenceFilesHelper::ParseReference_Finalize_PerStream ()
         CodecID+=MI->Retrieve(StreamKind_Last, StreamPos_To, MI->Fill_Parameter(StreamKind_Last, Generic_CodecID));
         MI->Fill(StreamKind_Last, StreamPos_To, MI->Fill_Parameter(StreamKind_Last, Generic_CodecID), CodecID, true);
     }
-    if (!Sequences[Sequences_Current]->IsMain && Sequences[Sequences_Current]->MI->Count_Get(Stream_Video)+Sequences[Sequences_Current]->MI->Count_Get(Stream_Audio)>1 && Sequences[Sequences_Current]->MI->Get(Stream_Video, 0, Video_Format)!=__T("DV"))
+    if (!Sequences[Sequences_Current]->IsMain && Sequences[Sequences_Current]->MI->Count_Get(Stream_Video)+Sequences[Sequences_Current]->MI->Count_Get(Stream_Audio)>1 && Sequences[Sequences_Current]->MI->Get(Stream_Video, 0, Video_Format)!=__T("DV") && Sequences[Sequences_Current]->MI->Get(Stream_Audio, 0, Audio_Format)!=__T("Dolby E"))
     {
         if (StreamKind_Last==Stream_Menu)
         {


### PR DESCRIPTION
e.g. a WAV file may have a 8-ch tracks actually containing 4 Dolby E tracks, each track containing 2 programs.
Supported in WAV/MXF/MP4.

& several Dolby E related minor fixes found during the development.