### PR TITLE
PNG: compression is Deflate (LZ77+Huffman), not LZ77

### DIFF
--- a/Source/MediaInfo/Image/File_Png.cpp
+++ b/Source/MediaInfo/Image/File_Png.cpp
@@ -284,7 +284,7 @@ void File_Png::IHDR()
             switch (Compression_method)
             {
                 case 0 :
-                    Fill(StreamKind_Last, 0, "Format_Compression", "LZ77");
+                    Fill(StreamKind_Last, 0, "Format_Compression", "Deflate");
                     break;
                 default: ;
             }


### PR DESCRIPTION
Fix [this Google play comment](https://play.google.com/store/apps/details?id=net.mediaarea.mediainfo&hl=ru&reviewId=gp%3AAOqpTOHvoqrzB3zulPR0UVFnjLeZqBZqPV36JZY4rmtrvWXePKEDd5fc_eoVKWFfWaNU0yulRvGuwXCKwJtw4EQ).