### PR TITLE
Add dependency_pid in DOVI descriptor

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
@@ -3454,7 +3454,12 @@ void File_Mpeg_Descriptors::Descriptor_B0()
         Get_SB (   rpu_present_flag,                            "rpu_present_flag");
         Get_SB (   el_present_flag,                             "el_present_flag");
         Get_SB (   bl_present_flag,                             "bl_present_flag");
-        if (Data_BS_Remain())
+        if (!bl_present_flag && Data_BS_Remain()>=20)
+        {
+            Skip_S2(13,                                         "dependency_pid");
+            Skip_S1( 3,                                         "reserved");
+        }
+        else if (Data_BS_Remain())
         {
             Get_S1 (4, dv_bl_signal_compatibility_id,           "dv_bl_signal_compatibility_id"); // in dv_version_major 2 only if based on specs but it was confirmed to be seen in dv_version_major 1 too and it does not hurt (value 0 means no new display)
             if (End<Data_BS_Remain())

--- a/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
@@ -3459,7 +3459,7 @@ void File_Mpeg_Descriptors::Descriptor_B0()
             Skip_S2(13,                                         "dependency_pid");
             Skip_S1( 3,                                         "reserved");
         }
-        else if (Data_BS_Remain())
+        if (Data_BS_Remain())
         {
             Get_S1 (4, dv_bl_signal_compatibility_id,           "dv_bl_signal_compatibility_id"); // in dv_version_major 2 only if based on specs but it was confirmed to be seen in dv_version_major 1 too and it does not hurt (value 0 means no new display)
             if (End<Data_BS_Remain())


### PR DESCRIPTION
With dual PID profile 7 streams, the DOVI descriptor can include the dependency_pid field. 

Cf. dolby-vision-bitstreams-in-mpeg-2-transport-stream-multiplex-v1.2.pdf:

<img width="232" alt="Dovi" src="https://user-images.githubusercontent.com/56721609/94348499-0877b500-003d-11eb-844c-647f23126a6f.png">
