### PR TITLE
Alpha channel

### DIFF
--- a/Source/MediaInfo/Image/File_Png.cpp
+++ b/Source/MediaInfo/Image/File_Png.cpp
@@ -80,6 +80,9 @@ File_Png::File_Png()
     #endif //MEDIAINFO_TRACE
     StreamSource=IsStream;
 
+    //In
+    StreamKind=Stream_Max;
+
     //Temp
     Signature_Parsed=false;
 }
@@ -102,7 +105,7 @@ void File_Png::Streams_Accept()
             Fill(Stream_Video, StreamPos_Last, Video_FrameCount, Config->File_Names.size());
     }
     else
-        Stream_Prepare(StreamKind_Last);
+        Stream_Prepare(StreamKind==Stream_Max?StreamKind_Last:StreamKind);
 }
 
 //***************************************************************************
@@ -269,18 +272,11 @@ void File_Png::IHDR()
         {
             Fill(StreamKind_Last, 0, "Width", Width);
             Fill(StreamKind_Last, 0, "Height", Height);
-            int8u Resolution;
-            switch (Colour_type)
-            {
-                case 0 : Resolution=Bit_depth; break;
-                case 2 : Resolution=Bit_depth*3; break;
-                case 3 : Resolution=Bit_depth; break;
-                case 4 : Resolution=Bit_depth*2; break;
-                case 6 : Resolution=Bit_depth*4; break;
-                default: Resolution=0;
-            }
-            if (Resolution)
-                Fill(StreamKind_Last, 0, "BitDepth", Resolution);
+            string ColorSpace=(Colour_type&(1<<1))?"RGB":"Y";
+            if (Colour_type&(1<<2))
+                ColorSpace+='A';
+            Fill(StreamKind_Last, 0, "ColorSpace", ColorSpace);
+            Fill(StreamKind_Last, 0, "BitDepth", Bit_depth);
             switch (Compression_method)
             {
                 case 0 :

--- a/Source/MediaInfo/Image/File_Png.h
+++ b/Source/MediaInfo/Image/File_Png.h
@@ -32,6 +32,9 @@ public :
     //Constructor/Destructor
     File_Png();
 
+    //In
+    stream_t                    StreamKind;
+
 private :
     //Streams management
     void Streams_Accept();

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -58,6 +58,9 @@
 #if defined(MEDIAINFO_MPEGV_YES)
     #include "MediaInfo/Video/File_Mpegv.h"
 #endif
+#if defined(MEDIAINFO_PNG_YES)
+    #include "MediaInfo/Image/File_Png.h"
+#endif
 #if defined(MEDIAINFO_PRORES_YES)
     #include "MediaInfo/Video/File_ProRes.h"
 #endif
@@ -5890,6 +5893,14 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxxVideo()
                     #if MEDIAINFO_DEMUX
                         Streams[moov_trak_tkhd_TrackID].Demux_Level=4; //Intermediate
                     #endif //MEDIAINFO_DEMUX
+                }
+            #endif
+            #if defined(MEDIAINFO_PNG_YES)
+                if (MediaInfoLib::Config.CodecID_Get(Stream_Video, InfoCodecID_Format_Mpeg4, Codec, InfoCodecID_Format)==__T("PNG"))
+                {
+                    File_Png* Parser=new File_Png;
+                    Parser->StreamKind=Stream_Video;
+                    Streams[moov_trak_tkhd_TrackID].Parsers.push_back(Parser);
                 }
             #endif
             #if defined(MEDIAINFO_CINEFORM_YES)

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -3905,7 +3905,12 @@ void File_Mxf::Streams_Finish_Descriptor(const int128u DescriptorUID, const int1
                     }
                     
                     for (std::map<std::string, Ztring>::iterator Info=SubDescriptor->second.Infos.begin(); Info!=SubDescriptor->second.Infos.end(); ++Info)
-                        if (Retrieve(StreamKind_Last, StreamPos_Last, Info->first.c_str()).empty())
+                        if (Info->first=="ComponentCount")
+                        {
+                            if (Info->second==__T("4") && !Retrieve(StreamKind_Last, StreamPos_Last, "ColorSpace").empty())
+                                Fill(StreamKind_Last, StreamPos_Last, "ColorSpace", Retrieve(StreamKind_Last, StreamPos_Last, "ColorSpace")+__T('A'), true); // Descriptor name is "RGBA"...
+                        }
+                        else if (Retrieve(StreamKind_Last, StreamPos_Last, Info->first.c_str()).empty())
                             Fill(StreamKind_Last, StreamPos_Last, Info->first.c_str(), Info->second);
                         else if (Retrieve(StreamKind_Last, StreamPos_Last, Info->first.c_str()) != Info->second)
                         {
@@ -10430,7 +10435,13 @@ void File_Mxf::JPEG2000PictureSubDescriptor_YTOsiz()
 void File_Mxf::JPEG2000PictureSubDescriptor_Csiz()
 {
     //Parsing
-    Info_B2(Data,                                                "Data"); Element_Info1(Data);
+    int16u Data;
+    Get_B2 (Data,                                                "Data"); Element_Info1(Data);
+
+    FILLING_BEGIN()
+        Descriptor_Fill("ComponentCount", Ztring::ToZtring(Data));
+    FILLING_END()
+
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -1881,10 +1881,17 @@ void File_Riff::AVI__hdlr_strl_strf_vids()
         if (Resolution==32)
         {
             Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Format), "RGBA", Unlimited, true, true);
+            if (StreamKind_Last==Stream_Video)
+                Fill(Stream_Video, StreamPos_Last, Video_ColorSpace, "RGBA", Unlimited, true, true);
             Fill(StreamKind_Last, StreamPos_Last, "BitDepth", Resolution/4); //With Alpha
         }
         else
+        {
+            Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Format), "RGB", Unlimited, true, true);
+            if (StreamKind_Last==Stream_Video)
+                Fill(Stream_Video, StreamPos_Last, Video_ColorSpace, "RGB", Unlimited, true, true);
             Fill(StreamKind_Last, StreamPos_Last, "BitDepth", Resolution<=16?8:(Resolution/3)); //indexed or normal
+        }
     }
     else if (Compression==0x56503632 //VP62
             || MediaInfoLib::Config.CodecID_Get(StreamKind_Last, InfoCodecID_Format_Riff, Ztring().From_CC4(Compression), InfoCodecID_Format)==__T("H.263") //H.263


### PR DESCRIPTION
Better support of alpha channel detection in several containers: PNG (alone or in MOV/MP4), AVI, MXF.