### PR TITLE
Recommended setting of CMAKE_MODULE_PATH

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.11)
 
 project(MediaInfoLib)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
 set(MediaInfoLib_MAJOR_VERSION 20)
 set(MediaInfoLib_MINOR_VERSION 08)


### PR DESCRIPTION
A more flexible, more generic and recommended setting of CMAKE_MODULE_PATH. See examples here:
https://cgold.readthedocs.io/en/latest/tutorials/cmake-sources/includes.html#modify-correct
https://cgold.readthedocs.io/en/latest/tutorials/cmake-sources/includes.html#modify-incorrect
With this change, parent projects are able to propagate custom modules to MediaInfoLib, like a custom FindZenLib.cmake file.