### PR TITLE
Fix undeclared INT8_MIN/INT8_MAX with c++03 compilers

### DIFF
--- a/Source/MediaInfo/Audio/File_DolbyE.cpp
+++ b/Source/MediaInfo/Audio/File_DolbyE.cpp
@@ -28,6 +28,14 @@
 #include "MediaInfo/Audio/File_DolbyE.h"
 #include "MediaInfo/Audio/File_Aac.h"
 #include <cmath>
+
+#if !defined(INT8_MAX)
+#define INT8_MAX (127)
+#endif //!defined(INT8_MAX)
+#if !defined(INT8_MIN)
+#define INT8_MIN (-128)
+#endif //!defined(INT8_MIN)
+
 using namespace std;
 //---------------------------------------------------------------------------
 


### PR DESCRIPTION
Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>