### PR TITLE
Dolby ED2: don't convert object Cartesian positions to a channel layout

### DIFF
--- a/Source/MediaInfo/Audio/File_DolbyE.cpp
+++ b/Source/MediaInfo/Audio/File_DolbyE.cpp
@@ -1274,10 +1274,12 @@ void File_DolbyE::Streams_Fill_ED2()
         string Summary;
         if (Summary.empty())
             Summary=sound_category_Values[DynObject.sound_category];
+        /*
         if (Summary.empty())
             Summary=ChannelLayout;
         if (Summary.empty())
             Summary=Position_Polar;
+        */
         if (Summary.empty())
             Summary="Yes";
 
@@ -1294,11 +1296,13 @@ void File_DolbyE::Streams_Fill_ED2()
         {
             string A=P;
             const dyn_object::dyn_object_alt& DynObject_Current=ObjectElements[Bed_Object_Count+p].Alts[0];
+            /*
             if (!ChannelLayout.empty())
             {
                 Fill(Stream_Audio, 0, (A+" ChannelLayout").c_str(), ChannelLayout);
                 Fill_SetOptions(Stream_Audio, 0, (A+" ChannelLayout").c_str(), "Y NTY");
             }
+            */
             if (!Position_Polar.empty())
             {
                 Fill(Stream_Audio, 0, (A+" Position_Polar").c_str(), Position_Polar);
@@ -1339,20 +1343,24 @@ void File_DolbyE::Streams_Fill_ED2()
             string Summary2;
             if (Summary2.empty())
                 Summary2=sound_category_Values[DynObject.sound_category];
+            /*
             if (Summary2.empty())
                 Summary2=ChannelLayout;
             if (Summary2.empty())
                 Summary2=Position_Polar;
+            */
             if (Summary2.empty())
                 Summary2="Yes";
 
             string A=P+Ztring(__T(" Alt")+Ztring::ToZtring(a)).To_UTF8();
             Fill(Stream_Audio, 0, A.c_str(), Summary2);
+            /*
             if (!ChannelLayout.empty())
             {
                 Fill(Stream_Audio, 0, (A+" ChannelLayout").c_str(), ChannelLayout);
                 Fill_SetOptions(Stream_Audio, 0, (A+" ChannelLayout").c_str(), "Y NTY");
             }
+            */
             if (!Position_Polar.empty())
             {
                 Fill(Stream_Audio, 0, (A+" Position_Polar").c_str(), Position_Polar);

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -1649,7 +1649,8 @@ void MediaInfo_Config_MediaInfo::File_ExpandSubs_Update(void** Source)
                                                             if ((*Stream_More)[StreamKind][StreamPos][k][Info_Name]==ToSearch3)
                                                             {
                                                                 Found=(*Stream_More)[StreamKind][StreamPos][k][Info_Text];
-                                                                if (k
+                                                                if (k && !Temp.empty()
+                                                                 && Temp[Temp.size()-1][Info_Name].rfind(__T(" ChannelLayout" ))+14==Temp[Temp.size()-1][Info_Name].size()
                                                                  && (*Stream_More)[StreamKind][StreamPos][k  ][Info_Name].rfind(__T(" Position_Polar"))+15==(*Stream_More)[StreamKind][StreamPos][k  ][Info_Name].size()
                                                                  && (*Stream_More)[StreamKind][StreamPos][k-1][Info_Name].rfind(__T(" ChannelLayout" ))+14!=(*Stream_More)[StreamKind][StreamPos][k-1][Info_Name].size())
                                                                 {


### PR DESCRIPTION
and don't show the position in the object summary