### PR TITLE
DVRescue: ignore 0xFFFF blocks, ignore duplicated content

### DIFF
--- a/Source/MediaInfo/Multiple/File_DvDif.h
+++ b/Source/MediaInfo/Multiple/File_DvDif.h
@@ -243,6 +243,11 @@ protected :
     std::vector<size_t> Video_STA_Errors_Total; //Per STA type
     static const size_t ChannelGroup_Count=2;
     static const size_t Dseq_Count=16;
+    enum caption
+    {
+        Caption_Present,
+        Caption_ParityIssueAny,
+    };
     bitset<32> Captions_Flags;
     enum coherency
     {


### PR DESCRIPTION
Consider a 0xFFFF byte pair as "valid" (no parity check on it).
Ignore the captions not in the first part of a DV50/DV100 frame (they are expected to be duplicated content: TODO: check that it is duplicated content).