### PR TITLE
Add support for TIFF compression codes 7 and 8

### DIFF
--- a/Source/MediaInfo/Image/File_Tiff.cpp
+++ b/Source/MediaInfo/Image/File_Tiff.cpp
@@ -10,6 +10,7 @@
 //
 // From
 // http://partners.adobe.com/public/developer/en/tiff/TIFF6.pdf
+// http://partners.adobe.com/public/developer/en/tiff/TIFFphotoshop.pdf
 // http://www.fileformat.info/format/tiff/
 // http://en.wikipedia.org/wiki/Tagged_Image_File_Format
 //
@@ -143,7 +144,9 @@ static const char* Tiff_Compression(int32u Compression)
         case     2 : return "CCITT Group 3";
         case     3 : return "CCITT T.4";
         case     5 : return "LZW";
-        case     6 : return "JPEG";
+        case     6 : return "JPEG (TIFF v6)";
+        case     7 : return "JPEG (ISO)";
+        case     8 : return "Deflate";
         case 32773 : return "PackBits";
         default    : return ""; //Unknown
     }
@@ -158,6 +161,7 @@ static const char* Tiff_Compression_Mode(int32u Compression)
         case     2 :
         case     3 :
         case     5 :
+        case     8 :
         case 32773 : return "Lossless";
         default    : return ""; //Unknown or depends of the compresser (e.g. JPEG can be lossless or lossy)
     }


### PR DESCRIPTION
These were defined in the [Adobe Photoshop Technical Notes from 2002](https://www.adobe.io/content/dam/udp/en/open/standards/tiff/TIFFphotoshop.pdf), a link to which has also been included. The document outlines Deflate compression as well as a better method for using JPEG compression in TIFFs than was previously defined in the TIFF v6 specification (which was released prior to JPEG's ISO standardization).

Also, keep up the great work. It's much appreciated.