### PR TITLE
RF64: fix the WAV malformed chunk size test

### DIFF
--- a/Source/MediaInfo/Multiple/File_Riff.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff.cpp
@@ -951,9 +951,9 @@ void File_Riff::Header_Parse()
     }
 
     //Testing malformed (not word aligned)
-    if (!IsNotWordAligned_Tested && !IsBigEndian && Size%2)
+    if (!IsNotWordAligned_Tested && !IsBigEndian && Size_Complete %2)
     {
-        if (File_Offset+Buffer_Offset+8+Size==File_Size)
+        if (File_Offset+Buffer_Offset+8+Size_Complete==File_Size)
             IsNotWordAligned=true;
         #if defined(MEDIAINFO_FILE_YES) //TODO: seek if file API is not available
         else if (!File_Name.empty())

--- a/Source/MediaInfo/Multiple/File_Riff.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff.cpp
@@ -925,30 +925,7 @@ void File_Riff::Header_Parse()
     if (IsBigEndian)
         Get_B4 (Size,                                           "Size");
     else
-    {
         Get_L4 (Size,                                           "Size");
-
-        //Testing malformed (not word aligned)
-        if (!IsNotWordAligned_Tested && Size%2)
-        {
-            if (File_Offset+Buffer_Offset+8+Size==File_Size)
-                IsNotWordAligned=true;
-            #if defined(MEDIAINFO_FILE_YES) //TODO: seek if file API is not available
-            else if (!File_Name.empty())
-            {
-                File F(File_Name);
-                F.GoTo(File_Offset+Buffer_Offset+8+Size);
-                int8u Temp;
-                if (F.Read(&Temp, 1))
-                {
-                    if (!((Temp<'A' || Temp>'z') && Temp!=' '))
-                        IsNotWordAligned=true;
-                }
-            }
-            #endif //defined(MEDIAINFO_FILE_YES)
-            IsNotWordAligned_Tested=true;
-        }
-    }
 
     //RF64
     int64u Size_Complete=Size;
@@ -971,6 +948,27 @@ void File_Riff::Header_Parse()
             Size_Complete=WAVE_data_Size;
             Param_Info1(Size_Complete);
         }
+    }
+
+    //Testing malformed (not word aligned)
+    if (!IsNotWordAligned_Tested && !IsBigEndian && Size%2)
+    {
+        if (File_Offset+Buffer_Offset+8+Size==File_Size)
+            IsNotWordAligned=true;
+        #if defined(MEDIAINFO_FILE_YES) //TODO: seek if file API is not available
+        else if (!File_Name.empty())
+        {
+            File F(File_Name);
+            F.GoTo(File_Offset+Buffer_Offset+8+Size);
+            int8u Temp;
+            if (F.Read(&Temp, 1))
+            {
+                if (!((Temp<'A' || Temp>'z') && Temp!=' '))
+                    IsNotWordAligned=true;
+            }
+        }
+        #endif //defined(MEDIAINFO_FILE_YES)
+        IsNotWordAligned_Tested=true;
     }
 
     //Coherency


### PR DESCRIPTION
A WAV malformed chunk size test is applied to a RF64 file but without using the RF64 data chunk size, so the check was done inside the data chunk instead of at the end.