### PR TITLE
MPEG-4: Fix of random bad parsing when atoms have both own content and nested atoms

### DIFF
--- a/Source/MediaInfo/File__Analyze.h
+++ b/Source/MediaInfo/File__Analyze.h
@@ -1669,12 +1669,44 @@ public :
                 _ATOM(); \
             } \
 
+#define LIST_COMPLETE(_ATOM) \
+    case Elements::_ATOM : \
+            if (Level==Element_Level) \
+            { \
+                if (Element_IsComplete_Get()) \
+                { \
+                    Element_ThisIsAList(); \
+                    _ATOM(); \
+                } \
+                else \
+                { \
+                    Element_WaitForMoreData(); \
+                    return; \
+                } \
+            } \
+
 #define LIST_DEFAULT(_ATOM) \
             default : \
             if (Level==Element_Level) \
             { \
                 Element_ThisIsAList(); \
                 _ATOM(); \
+            } \
+
+#define LIST_DEFAULT_COMPLETE(_ATOM) \
+            default : \
+            if (Level==Element_Level) \
+            { \
+                if (Element_IsComplete_Get()) \
+                { \
+                    Element_ThisIsAList(); \
+                    _ATOM(); \
+                } \
+                else \
+                { \
+                    Element_WaitForMoreData(); \
+                    return; \
+                } \
             } \
 
 #define ATOM_END_DEFAULT \

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -128,6 +128,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cfloat>
+
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
@@ -1132,20 +1133,20 @@ void File_Mpeg4::Data_Parse()
                         ATOM(moov_trak_mdia_minf_stbl_stsc)
                         LIST(moov_trak_mdia_minf_stbl_stsd)
                             ATOM_BEGIN
-                            LIST(moov_trak_mdia_minf_stbl_stsd_stpp)
+                            LIST_COMPLETE(moov_trak_mdia_minf_stbl_stsd_stpp)
                                 ATOM_BEGIN
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_stpp_btrt)
                                 ATOM_END
                             ATOM(moov_trak_mdia_minf_stbl_stsd_text)
-                            LIST(moov_trak_mdia_minf_stbl_stsd_tmcd)
+                            LIST_COMPLETE(moov_trak_mdia_minf_stbl_stsd_tmcd)
                                 ATOM_BEGIN
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_tmcd_name)
                                 ATOM_END
-                            LIST(moov_trak_mdia_minf_stbl_stsd_tx3g)
+                            LIST_COMPLETE(moov_trak_mdia_minf_stbl_stsd_tx3g)
                                 ATOM_BEGIN
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_tx3g_ftab)
                                 ATOM_END
-                            LIST_DEFAULT(moov_trak_mdia_minf_stbl_stsd_xxxx)
+                            LIST_DEFAULT_COMPLETE(moov_trak_mdia_minf_stbl_stsd_xxxx)
                                 ATOM_BEGIN
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_xxxx_alac)
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_xxxx_AALP)


### PR DESCRIPTION
Randomness is due to the size of the input blocks if a block from disk or an URL ends inside after the content part + few bytes, the nested elements are not detected so discarded.