### PR TITLE
DVRescue: read from stdin

### DIFF
--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -1090,16 +1090,25 @@ bool File__Analyze::Open_Buffer_Continue_Loop ()
     Element[Element_Level].WaitForMoreData=false;
     Read_Buffer_Continue();
     if (Element_IsWaitingForMoreData())
+    {
+        Buffer_TotalBytes+=Buffer_Offset;
         return false; //Wait for more data
+    }
     if (sizeof(size_t)<sizeof(int64u) && Buffer_Offset+Element_Offset>=(int64u)(size_t)-1)
         GoTo(File_Offset+Buffer_Offset+Element_Offset);
     else
         Buffer_Offset+=(size_t)Element_Offset;
     if ((Status[IsFinished] && !ShouldContinueParsing) || Buffer_Offset>Buffer_Size || File_GoTo!=(int64u)-1)
+    {
+        Buffer_TotalBytes+=Buffer_Offset;
         return false; //Finish
+    }
     #if MEDIAINFO_DEMUX
         if (Config->Demux_EventWasSent)
+        {
+            Buffer_TotalBytes+=Buffer_Offset;
             return false;
+        }
     #endif //MEDIAINFO_DEMUX
 
     //Parsing;

--- a/Source/MediaInfo/MediaInfoList_Internal.cpp
+++ b/Source/MediaInfo/MediaInfoList_Internal.cpp
@@ -98,6 +98,8 @@ size_t MediaInfoList_Internal::Open(const String &File_Name, const fileoptions_t
     {
         List=Dir::GetAllFileNames(File_Name, (Options&FileOption_NoRecursive)?Dir::Include_Files:((Dir::dirlist_t)(Dir::Include_Files|Dir::Parse_SubDirs)));
         sort(List.begin(), List.end());
+        if (List.empty())
+            List.push_back(File_Name); // Try directly the file name e.g. "-" for pipe
 
         #if MEDIAINFO_ADVANCED
             if (MediaInfoLib::Config.ParseOnlyKnownExtensions_IsSet())

--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -230,7 +230,7 @@ File_DvDif::File_DvDif()
         StreamIDs_Width[0]=4;
     #endif //MEDIAINFO_EVENTS
     #if MEDIAINFO_DEMUX
-        Demux_Level=2; //Container
+        Demux_Level=1; //Container
     #endif //MEDIAINFO_DEMUX
     MustSynchronize=true;
     Buffer_TotalBytes_FirstSynched_Max=64*1024;
@@ -634,7 +634,14 @@ bool File_DvDif::Synchronize()
         return false;
 
     if (!Status[IsAccepted])
+    {
         Accept();
+
+        #if MEDIAINFO_DEMUX
+            if (Config->Demux_Unpacketize_Get())
+                Demux_UnpacketizeContainer=true;
+        #endif //MEDIAINFO_DEMUX
+    }
 
     return true;
 }
@@ -822,6 +829,7 @@ bool File_DvDif::Demux_UnpacketizeContainer_Test()
         if (Demux_Offset+8*80>Buffer_Size && File_Offset+Buffer_Size==File_Size)
             Demux_Offset=(size_t)(File_Size-File_Offset); //Using the complete buffer (no next sync)
 
+        Element_Code=-1;
         Demux_UnpacketizeContainer_Demux();
     }
 

--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -44,9 +44,23 @@ void File_DvDif::Read_Buffer_Continue()
             return;
     }
 
+    if (!Synchro_Manage())
+    {
+        Element_WaitForMoreData();
+        return; //Wait for more data
+    }
+
     //Errors stats
     while (Buffer_Offset+80<=Buffer_Size)
     {
+        #if MEDIAINFO_DEMUX
+            if (Demux_TotalBytes && File_Offset+Buffer_Offset+80>Demux_TotalBytes)
+            {
+                Element_WaitForMoreData();
+                return; //Wait for more data
+            }
+        #endif // MEDIAINFO_DEMUX
+
         //Quick search depends of SCT
         switch(Buffer[Buffer_Offset]&0xE0)
         {
@@ -553,6 +567,11 @@ void File_DvDif::Read_Buffer_Continue()
     if (!Status[IsAccepted])
         File__Analyze::Buffer_Offset=0;
     Config->State_Set(((float)File_Offset)/File_Size);
+
+    {
+        Element_WaitForMoreData();
+        return; //Wait for more data
+    }
 }
 
 void File_DvDif::Errors_Stats_Update()


### PR DESCRIPTION
Accept stdin as file input (`mediainfo -`).
Can demux DV (split per frame).
Part of https://github.com/mipops/dvrescue/issues/86.