### PR TITLE
Add support for passing vectors of paths into MediaInfoList

### DIFF
--- a/Source/MediaInfo/MediaInfoList.cpp
+++ b/Source/MediaInfo/MediaInfoList.cpp
@@ -119,6 +119,12 @@ size_t MediaInfoList::Open(const String &File, const fileoptions_t Options)
 }
 
 //---------------------------------------------------------------------------
+size_t MediaInfoList::Open (const std::vector<String> &Files, const fileoptions_t Options)
+{
+    return Internal->Open(Files, Options);
+}
+
+//---------------------------------------------------------------------------
 size_t MediaInfoList::Open_Buffer_Init (int64u File_Size_, int64u File_Offset_)
 {
     return Internal->Open_Buffer_Init(File_Size_, File_Offset_);

--- a/Source/MediaInfo/MediaInfoList.h
+++ b/Source/MediaInfo/MediaInfoList.h
@@ -17,6 +17,7 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/MediaInfo.h"
+#include <vector>
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -68,6 +69,14 @@ public :
         ///                  FileOption_Close = Close all already opened files before
         /// @return Number of files successfuly added
     size_t Open (const String &File, const fileoptions_t Options=FileOption_Nothing);
+        /// Open one or more files and collect information about them (technical information and tags)
+        /// @brief Open files
+        /// @param File Full name of file(s) to open \n
+        ///             or Full name of folder(s) to open \n
+        /// @param Options: FileOption_Recursive = Recursive mode for folders \n
+        ///                  FileOption_Close = Close all already opened files before
+        /// @return Number of files successfuly added
+    size_t Open (const std::vector<String> &Files, const fileoptions_t Options=FileOption_Nothing);
         /// Open a stream and collect information about it (technical information and tags)
         /// @brief Open a stream (Init)
         /// @param File_Size Estimated file size

--- a/Source/MediaInfo/MediaInfoList_Internal.h
+++ b/Source/MediaInfo/MediaInfoList_Internal.h
@@ -33,6 +33,7 @@ public :
 
     //Files
     size_t Open (const String &File, const fileoptions_t Options=FileOption_Nothing);
+    size_t Open (const std::vector<String> &Files, const fileoptions_t Options=FileOption_Nothing);
     size_t Open_Buffer_Init (ZenLib::int64u File_Size=(ZenLib::int64u)-1, ZenLib::int64u File_Offset=0);
     size_t Open_Buffer_Continue (size_t FilePos, const ZenLib::int8u* Buffer, size_t Buffer_Size);
     ZenLib::int64u Open_Buffer_Continue_GoTo_Get (size_t FilePos);


### PR DESCRIPTION
This adds an `Open` call for a vector of file paths.