### PR TITLE
HDR mastering max. luminance precision was wrong

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -148,7 +148,7 @@ void File__Analyze::Get_MasteringDisplayColorVolume(Ztring &MasteringDisplay_Col
 
     if (Meta.Luminance[0]!=(int32u)-1 && Meta.Luminance[1]!=(int32u)-1)
         MasteringDisplay_Luminance=        __T("min: ")+Ztring::ToZtring(((float64)Meta.Luminance[0])/10000, 4)
-                                  +__T(" cd/m2, max: ")+Ztring::ToZtring(((float64)Meta.Luminance[1])/10000, (Meta.Luminance[1]-((int)Meta.Luminance[1])==0)?0:4)
+                                  +__T(" cd/m2, max: ")+Ztring::ToZtring(((float64)Meta.Luminance[1])/10000, ((float64)Meta.Luminance[1]/10000-Meta.Luminance[1]/10000==0)?0:4)
                                   +__T(" cd/m2");
 }
 #endif


### PR DESCRIPTION
This it due to the fact Meta.Luminance not being float, fixes #1116. That was an always true expression, so in all cases Meta.Luminance[1] (that element in array is mastering max. luminance) was truncated to integer values (Ztring::ToZtring precision set to 0), which is very problematic.

The other idea is to set precision to 4 always.