### PR TITLE
Fix parsing of WM/EncodingTime

### DIFF
--- a/Source/MediaInfo/Multiple/File_Wm_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Wm_Elements.cpp
@@ -265,7 +265,10 @@ void File_Wm::Header_FileProperties()
     //Filling
     if (MaximumBitRate)
         Fill(Stream_General, 0, General_OverallBitRate_Maximum, MaximumBitRate);
-    Fill(Stream_General, 0, General_Encoded_Date, Ztring().Date_From_Milliseconds_1601(CreationDate/10000));
+    Ztring Encoded_Date_New=Ztring().Date_From_Seconds_1601(CreationDate/10000000);
+    const Ztring& Encoded_Date_Old=Retrieve_Const(Stream_General, 0, General_Encoded_Date);
+    if (Encoded_Date_Old.empty() || Encoded_Date_New!=Encoded_Date_Old)
+        Fill(Stream_General, 0, General_Encoded_Date, Encoded_Date_New);
     if (PlayDuration/1000>Preroll)
         Fill(Stream_General, 0, General_Duration, PlayDuration/10000-Preroll);
     FileProperties_Preroll=(int32u)(Preroll);
@@ -1162,7 +1165,12 @@ void File_Wm::Header_ExtendedContentDescription()
             else if (Name==__T("WM/EncoderSettings"))
                 Fill(Stream_General, 0, General_Encoded_Library_Settings, Value);
             else if (Name==__T("WM/EncodingTime"))
-                Fill(Stream_General, 0, General_Encoded_Date, Ztring().Date_From_Seconds_1601(Value_Int64));
+            {
+                 Ztring Encoded_Date_New=Ztring().Date_From_Seconds_1601(Value_Int64/10000000);
+                 const Ztring& Encoded_Date_Old=Retrieve_Const(Stream_General, 0, General_Encoded_Date);
+                 if (Encoded_Date_Old.empty() || Encoded_Date_New!=Encoded_Date_Old)
+                    Fill(Stream_General, 0, General_Encoded_Date, Encoded_Date_New);
+            }
             else if (Name==__T("WM/Genre"))
                 Fill(Stream_General, 0, General_Genre, Value, true); //Clear last value
             else if (Name==__T("WM/GenreID"))


### PR DESCRIPTION
The Windows Media parsing code tried to handle "WM/EncodingTime" but was failing because the value is a FILETIME, which uses units of 100 nanoseconds from 1601, but it was passing the value as-is to something that expects seconds from 1601. Just needs a division by 10000000 to fix.

I found a side-effect of fixing this which could be a breaking change for dependencies:

- File_Wm::Header_FileProperties sets Stream_General / General_Encoded_Date to the CreationDate from the header.

- With this fix in place, File_Wm::Header_ExtendedContentDescription also sets Stream_General / General_Encoded_Date to the "WM/EncodingTime" date-time (if the file has the tag).

- This results in MI.Get("Encoded_Date") returning a string with two date-times. For example:
   "UTC 2005-11-03 16:04:06.505 / UTC 2021-01-01 14:20:24"
   The first is the time from the header, and the second is WM/EncodingTime.

That's fine for me, as I just made my code parse the last date-time in that case. But maybe it will break code that doesn't expect anything extra after the seconds or optional milliseconds of the first date-time.

If you want to test this, you can set WM/EncodingTime on a test WMV file via Windows 10's Properties dialog. The field is, confusingly, called "Media Created", at least in English.

I can make and share a small test file if it would be useful and save you time.
