### PR TITLE
DvDif: remove check of zeroed bytes in timecode, considered again as valid timecode

### DIFF
--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -1357,16 +1357,6 @@ void File_DvDif::timecode()
 {
     Element_Name("timecode");
 
-    if (Buffer[Buffer_Offset+(size_t)Element_Offset  ]==0x00
-     && Buffer[Buffer_Offset+(size_t)Element_Offset+1]==0x00
-     && Buffer[Buffer_Offset+(size_t)Element_Offset+2]==0x00
-     && Buffer[Buffer_Offset+(size_t)Element_Offset+3]==0x00
-    )
-    {
-        Skip_XX(4,                                              "All zero");
-        return;
-    }
-
     //Parsing
     int8u Frames_Units, Frames_Tens, Seconds_Units, Seconds_Tens, Minutes_Units, Minutes_Tens, Hours_Units, Hours_Tens;
     int64u MilliSeconds=0;

--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -153,21 +153,6 @@ void File_DvDif::Read_Buffer_Continue()
                             int8u Hours                     =((Buffer[Buffer_Offset+3+Pos+3+4]&0x30)>>4)*10
                                                            + ((Buffer[Buffer_Offset+3+Pos+3+4]&0x0F)   )   ;
 
-                            if (Frames ==0x00
-                             && Seconds==0x00
-                             && Minutes==0x00
-                             && Hours  ==0x00
-                             && Buffer[Buffer_Offset+3+Pos+3+1]==0x00
-                             && Buffer[Buffer_Offset+3+Pos+3+2]==0x00
-                             && Buffer[Buffer_Offset+3+Pos+3+3]==0x00
-                             && Buffer[Buffer_Offset+3+Pos+3+4]==0x00
-                             )
-                            {
-                                Frames =45;
-                                Seconds=85;
-                                Minutes=85;
-                                Hours  =45;
-                            }
                             if (Frames !=45
                              && Seconds!=85
                              && Minutes!=85


### PR DESCRIPTION
Fix https://github.com/mipops/dvrescue/issues/214.

```
<?xml version="1.0" encoding="UTF-8"?>
<dvrescue xmlns="https://mediaarea.net/dvrescue" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://mediaarea.net/dvrescue https://mediaarea.net/dvrescue/dvrescue.xsd" version="1.1">
        <creator>
                <program>dvrescue</program>
                <version>0.20.11.20210227dev</version>
        </creator>
        <media ref="BCD00216_take2_1st_120000000_2400000.dv" format="DV" size="120000">
                <frames count="1" pts="00:00:00.000000" end_pts="00:00:00.033367" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" audio_rate="48000" channels="2">
                        <frame n="0" pos="0" pts="00:00:00.000000" abst="3842" tc="00:00:00:00" rec_start="1" seqn="F">
                                <dseq n="0">
                                        <aud n="9"/>
                                </dseq>
                                <dseq n="2">
                                        <sta t="10" n="28"/>
                                        <aud n="9"/>
                                </dseq>
                                <dseq n="4">
                                        <sta t="10" n="30"/>
                                </dseq>
                                <dseq n="6">
                                        <sta t="10" n="27"/>
                                </dseq>
                                <dseq n="8">
                                        <sta t="10" n="48"/>
                                </dseq>
                                <sta t="10" n="133" n_even="133"/>
                                <aud n="18" n_even="18"/>
                        </frame>
                </frames>
        </media>
</dvrescue>
```