### PR TITLE
MOV/MP4: avoid stop of parsing when huge atoms are present, fix

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -8076,7 +8076,6 @@ void File_Mpeg4::moov_trak_udta_xxxx()
 void File_Mpeg4::moov_udta()
 {
     Element_Name("User Data");
-    Skip_XX(Element_TotalSize_Get(), "XXX");
 
     moov_trak_tkhd_TrackID=(int32u)-1;
 }


### PR DESCRIPTION
Remove code from https://github.com/MediaArea/MediaInfoLib/pull/1338 which should never have been there.
Fix https://github.com/MediaArea/MediaInfoLib/issues/1371.