### PR TITLE
Use File__Analyze HDR metadata formatting in File__Mxf

### DIFF
--- a/Source/MediaInfo/File__Analyze.h
+++ b/Source/MediaInfo/File__Analyze.h
@@ -885,7 +885,7 @@ public :
     #if defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES)
     void Get_MasteringDisplayColorVolume(Ztring &MasteringDisplay_ColorPrimaries, Ztring &MasteringDisplay_Luminance);
     #endif
-    #if defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MATROSKA_YES)
+    #if defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MATROSKA_YES) || defined(MEDIAINFO_MXF_YES)
     struct mastering_metadata_2086
     {
         int16u Primaries[8];

--- a/Source/MediaInfo/File__Analyze_MinimizeSize.h
+++ b/Source/MediaInfo/File__Analyze_MinimizeSize.h
@@ -774,7 +774,7 @@ public :
     #if defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES)
     void Get_MasteringDisplayColorVolume(Ztring &MasteringDisplay_ColorPrimaries, Ztring &MasteringDisplay_Luminance);
     #endif
-    #if defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MATROSKA_YES)
+    #if defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MATROSKA_YES) || defined(MEDIAINFO_MXF_YES)
     struct mastering_metadata_2086
     {
         int16u Primaries[8];


### PR DESCRIPTION
This change unifies the HDR10 metadata handling in Mxf to use the same code as used already by other formats (MP4, Mk etc). Having them separate could introduce differences between the string representations (e.g. "DCI P3" primaries were not recognised in MXF but were in MP4 before this change.
