### PR TITLE
AC-3/AC-4: top layer channels after Lw/Rw

### DIFF
--- a/Source/MediaInfo/Audio/File_Ac3.cpp
+++ b/Source/MediaInfo/Audio/File_Ac3.cpp
@@ -356,15 +356,36 @@ static const char* AC3_nonstd_bed_channel_assignment_mask_ChannelLayout_List[17]
     "Rw",
     "LFE2",
 };
+static int8s AC3_nonstd_bed_channel_assignment_mask_ChannelLayout_Reordering[17] =
+{
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    6, // Wide channels before top layer
+    6, // Wide channels before top layer
+    -2,
+    -2,
+    -2,
+    -2,
+    -2,
+    -2,
+    0,
+};
 Ztring AC3_nonstd_bed_channel_assignment_mask_ChannelLayout(int32u nonstd_bed_channel_assignment_mask)
 {
     Ztring ToReturn;
 
     for (int8u i=0; i<17; i++)
     {
-        if (nonstd_bed_channel_assignment_mask&(1<<i))
+        int8u i2=i+AC3_nonstd_bed_channel_assignment_mask_ChannelLayout_Reordering[i];
+        if (nonstd_bed_channel_assignment_mask&(1<<i2))
         {
-            ToReturn+=Ztring().From_UTF8(AC3_nonstd_bed_channel_assignment_mask_ChannelLayout_List[i]);
+            ToReturn+=Ztring().From_UTF8(AC3_nonstd_bed_channel_assignment_mask_ChannelLayout_List[i2]);
             ToReturn+=__T(' ');
         }
     }

--- a/Source/MediaInfo/Audio/File_Ac4.cpp
+++ b/Source/MediaInfo/Audio/File_Ac4.cpp
@@ -614,6 +614,37 @@ static const char* AC4_nonstd_bed_channel_assignment_mask_ChannelLayout_List[17+
     "Tfc",
     "Tbc",
 };
+static int8s AC4_nonstd_bed_channel_assignment_mask_ChannelLayout_Reordering[17+11] =
+{
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    6, // Wide channels before top layer
+    6, // Wide channels before top layer
+    -2,
+    -2,
+    -2,
+    -2,
+    -2,
+    -2,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+};
 static Ztring AC4_nonstd_bed_channel_assignment_mask_ChannelLayout(int32u nonstd_bed_channel_assignment_mask)
 {
     if (!nonstd_bed_channel_assignment_mask)
@@ -623,9 +654,10 @@ static Ztring AC4_nonstd_bed_channel_assignment_mask_ChannelLayout(int32u nonstd
 
     for (int8u i=0; i<17+11; i++)
     {
-        if (nonstd_bed_channel_assignment_mask&(1<<i))
+        int8u i2=i+AC4_nonstd_bed_channel_assignment_mask_ChannelLayout_Reordering[i];
+        if (nonstd_bed_channel_assignment_mask&(1<<i2))
         {
-            ToReturn+=Ztring().From_UTF8(AC4_nonstd_bed_channel_assignment_mask_ChannelLayout_List[i]);
+            ToReturn+=Ztring().From_UTF8(AC4_nonstd_bed_channel_assignment_mask_ChannelLayout_List[i2]);
             ToReturn+=__T(' ');
         }
     }


### PR DESCRIPTION
as it becomes the defacto standard layout (reference decoders do the reordering too).