### PR TITLE
DV: fix PTS/DUR info

### DIFF
--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -273,6 +273,8 @@ File_DvDif::File_DvDif()
     Speed_Contains_NULL=0;
     Speed_FrameCount_Arb_Incoherency=0;
     Speed_FrameCount_Stts_Fluctuation=0;
+    Speed_FrameCount_system[0]=0;
+    Speed_FrameCount_system[1]=0;
     AbstBf_Current=(0x7FFFFF)<<1;
     AbstBf_Previous=(0x7FFFFF)<<1;
     AbstBf_Previous_MaxAbst=0xFFFFFF;
@@ -833,6 +835,11 @@ bool File_DvDif::Demux_UnpacketizeContainer_Test()
             Demux_Offset=(size_t)(File_Size-File_Offset); //Using the complete buffer (no next sync)
 
         Element_Code=-1;
+        FrameInfo.DTS=FrameInfo.PTS=Speed_FrameCount_system[0]*100100000/3+Speed_FrameCount_system[1]*40000000;
+        Speed_FrameCount_system[system]++;
+        int64u NextPTS=Speed_FrameCount_system[0]*100100000/3+Speed_FrameCount_system[1]*40000000;
+        Speed_FrameCount_system[system]--;
+        FrameInfo.DUR=(int64u)-1; // Unknown, system flag is not yet checked
         Demux_UnpacketizeContainer_Demux();
     }
 

--- a/Source/MediaInfo/Multiple/File_DvDif.h
+++ b/Source/MediaInfo/Multiple/File_DvDif.h
@@ -167,6 +167,7 @@ protected :
     int64u Speed_Contains_NULL;                         //Per Frame - Error 4
     int64u Speed_FrameCount_Arb_Incoherency;            //Global    - Error 5
     int64u Speed_FrameCount_Stts_Fluctuation;           //Global    - Error 6
+    int64u Speed_FrameCount_system[2];                  //Global    - Total per system (NTSC or PAL)
     struct abst_bf
     {
         struct value_trust

--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -678,6 +678,12 @@ void File_DvDif::Errors_Stats_Update()
             return;
     }
 
+    FrameInfo.DTS=FrameInfo.PTS=Speed_FrameCount_system[0]*100100000/3+Speed_FrameCount_system[1]*40000000;
+    Speed_FrameCount_system[system]++;
+    int64u NextPTS=Speed_FrameCount_system[0]*100100000/3+Speed_FrameCount_system[1]*40000000;
+    Speed_FrameCount_system[system]--;
+    FrameInfo.DUR=NextPTS-FrameInfo.PTS; // PTS + DUR = PTS of next frame, DUR rounding is adapted in order to have the exact PTS of next frame
+
     Ztring Errors_Stats_Line;
     {
         bool Errors_AreDetected=false;
@@ -725,6 +731,7 @@ void File_DvDif::Errors_Stats_Update()
 
         EVENT_BEGIN(DvDif, Change, 0)
             Event.StreamOffset=Speed_FrameCount_StartOffset;
+            Event.FrameNumber=Speed_FrameCount;
             switch (video_source_stype)
             {
                 case 0x00 :
@@ -1652,6 +1659,7 @@ void File_DvDif::Errors_Stats_Update()
             struct MediaInfo_Event_DvDif_Analysis_Frame_1 Event1;
             Event_Prepare((struct MediaInfo_Event_Generic*)&Event1, MediaInfo_EventCode_Create(MediaInfo_Parser_DvDif, MediaInfo_Event_DvDif_Analysis_Frame, 1), sizeof(MediaInfo_Event_DvDif_Analysis_Frame_1));
             Event1.StreamOffset=Speed_FrameCount_StartOffset;
+            Event1.FrameNumber=Speed_FrameCount;
             Event1.TimeCode=Event.TimeCode;
             Event1.RecordedDateTime1=Event.RecordedDateTime1;
             Event1.RecordedDateTime2Buggy=Event.RecordedDateTime2;
@@ -1792,6 +1800,7 @@ void File_DvDif::Errors_Stats_Update()
     Speed_Arb_Last=Speed_Arb_Current;
     Speed_Arb_Current.Clear();
     Speed_FrameCount++;
+    Speed_FrameCount_system[system]++;
     REC_IsValid=false;
     audio_source_mode.clear();
     Speed_Contains_NULL=0;


### PR DESCRIPTION
Note: PTS is related to the DV stream only, container PTS offset e.g. QuickTime edit list is not (yet) handled.

Part of handling of https://github.com/mipops/dvrescue/issues/284.