### PR TITLE
MP4/QuickTime: Android slow motion real frame rate

### DIFF
--- a/Source/MediaInfo/File__Analyse_Automatic.h
+++ b/Source/MediaInfo/File__Analyse_Automatic.h
@@ -688,6 +688,8 @@ enum video
     Video_FrameRate_Original_String,
     Video_FrameRate_Original_Num,
     Video_FrameRate_Original_Den,
+    Video_FrameRate_Real,
+    Video_FrameRate_Real_String,
     Video_FrameCount,
     Video_Source_FrameCount,
     Video_Standard,

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -4729,6 +4729,8 @@ void MediaInfo_Config_Video (ZtringListList &Info)
     "FrameRate_Original/String;;;Y NT;;;Original (in the raw stream) frames per second (with measurement)\n"
     "FrameRate_Original_Num;;;N NFN;;;Frames per second, numerator\n"
     "FrameRate_Original_Den;;;N NFN;;;Frames per second, denominator\n"
+    "FrameRate_Real;; fps;N YFY;;;Real (capture) frames per second\n"
+    "FrameRate_Real/String;;;Y NT;;;Real (capture) frames per second (with measurement)\n"
     "FrameCount;;;N NIY;;;Number of frames\n"
     "Source_FrameCount;;;N NI;;;Source Number of frames\n"
     "Standard;;;Y NTY;;;NTSC or PAL\n"

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -474,6 +474,10 @@ void File_Mpeg4::Streams_Finish()
         {
             Fill(Stream_Video, StreamPos_Last, Video_DisplayAspectRatio, DisplayAspectRatio);
         }
+        if (StreamKind_Last==Stream_Video && !FrameRate_Real.empty() && Retrieve_Const(Stream_Video, StreamPos_Last, Video_FrameRate_Real).empty())
+        {
+            Fill(Stream_Video, StreamPos_Last, Video_FrameRate_Real, FrameRate_Real);
+        }
 
         //if (Temp->second.stsz_StreamSize)
         //    Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_StreamSize), Temp->second.stsz_StreamSize);

--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -382,6 +382,7 @@ private :
     int32u                                  Vendor;
     Ztring                                  Vendor_Version;
     Ztring                                  DisplayAspectRatio;
+    Ztring                                  FrameRate_Real;
     int64u                                  FirstMdatPos;
     int64u                                  LastMdatPos; //This is the position of the byte after the last byte of mdat
     int64u                                  FirstMoovPos;

--- a/Source/Resource/Text/Language/DefaultLanguage.csv
+++ b/Source/Resource/Text/Language/DefaultLanguage.csv
@@ -424,6 +424,7 @@ FrameRate_Mode_CFR;Constant
 FrameRate_Mode_VFR;Variable
 FrameRate_Nominal;Nominal frame rate
 FrameRate_Original;Original frame rate
+FrameRate_Real;Real frame rate
 General;General
 Genre;Genre
 Genre_000;Blues

--- a/Source/Resource/Text/Stream/Video.csv
+++ b/Source/Resource/Text/Stream/Video.csv
@@ -195,6 +195,8 @@ FrameRate_Original;; fps;N YFY;;;Original (in the raw stream) frames per second
 FrameRate_Original/String;;;Y NT;;;Original (in the raw stream) frames per second (with measurement)
 FrameRate_Original_Num;;;N NFN;;;Frames per second, numerator
 FrameRate_Original_Den;;;N NFN;;;Frames per second, denominator
+FrameRate_Real;; fps;N YFY;;;Real (capture) frames per second
+FrameRate_Real/String;;;Y NT;;;Real (capture) frames per second (with measurement)
 FrameCount;;;N NIY;;;Number of frames
 Source_FrameCount;;;N NI;;;Source Number of frames
 Standard;;;Y NTY;;;NTSC or PAL


### PR DESCRIPTION
(Unmodified) Android stores high frame rate streams with a "normal" 30 fps stream + MP4 metadata about the real (capture) frame rate.
We show both play back frame rate and real frame rate:

~~~
Frame rate mode                          : Variable
Frame rate                               : 30.045 FPS
Minimum frame rate                       : 28.644 FPS
Maximum frame rate                       : 33.100 FPS
Real frame rate                          : 120.000 FPS
~~~
