### PR TITLE
Dolby Vision Metadata XML: support of versions 4 and 5 and readout of more elements

### DIFF
--- a/Source/MediaInfo/Video/File_DolbyVisionMetadata.cpp
+++ b/Source/MediaInfo/Video/File_DolbyVisionMetadata.cpp
@@ -17,7 +17,7 @@
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
-#if defined(MEDIAINFO_MXF_YES)
+#if defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MXF_YES)
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -52,18 +52,84 @@ bool File_DolbyVisionMetadata::FileHeader_Begin()
     if (!FileHeader_Begin_XML(document))
        return false;
 
-    XMLElement* DolbyVisionGlobalData=document.FirstChildElement();
-    if (!DolbyVisionGlobalData || strcmp(DolbyVisionGlobalData->Name(), "DolbyVisionGlobalData"))
+    string Version;
+    float32 AspectRatio=0;
+    XMLElement* DolbyVisionGlobalData = document.FirstChildElement();
+    if (!DolbyVisionGlobalData)
     {
         Reject("DolbyVisionMetadata");
         return false;
     }
+    
+    if (!strcmp(DolbyVisionGlobalData->Name(), "gsp:DolbyVisionGlobalDataGSP"))
+    {
+        for (DolbyVisionGlobalData = DolbyVisionGlobalData->FirstChildElement(); DolbyVisionGlobalData; DolbyVisionGlobalData = DolbyVisionGlobalData->NextSiblingElement())
+        {
+            if (!strcmp(DolbyVisionGlobalData->Name(), "gsp:Version"))
+                Version = DolbyVisionGlobalData->GetText();
+            if (!strcmp(DolbyVisionGlobalData->Name(), "gsp:Track"))
+                break;
+        }
+        if (!DolbyVisionGlobalData)
+        {
+            Reject("DolbyVisionMetadata");
+            return false;
+        }
+    }
+    else if (!strcmp(DolbyVisionGlobalData->Name(), "dvmd-int:DolbyVisionIntegratedData"))
+    {
+        for (DolbyVisionGlobalData = DolbyVisionGlobalData->FirstChildElement(); DolbyVisionGlobalData; DolbyVisionGlobalData = DolbyVisionGlobalData->NextSiblingElement())
+        {
+            if (!strcmp(DolbyVisionGlobalData->Name(), "dvmd-int:Version"))
+                Version = DolbyVisionGlobalData->GetText();
+            if (!strcmp(DolbyVisionGlobalData->Name(), "dvmd-int:DolbyVisionGlobalData"))
+            {
+                for (DolbyVisionGlobalData = DolbyVisionGlobalData->FirstChildElement(); DolbyVisionGlobalData; DolbyVisionGlobalData = DolbyVisionGlobalData->NextSiblingElement())
+                {
+                    if (!strcmp(DolbyVisionGlobalData->Name(), "dvmd-int:CanvasAspectRatio"))
+                    {
+                        if (const char* Text = DolbyVisionGlobalData->GetText())
+                            if (float32 TextF = Ztring().From_UTF8(Text).To_float32())
+                                AspectRatio = TextF;
+                    }
+                    if (!strcmp(DolbyVisionGlobalData->Name(), "dvmd-int:Track"))
+                        break;
+                }
+                break;
+            }
+        }
+        if (!DolbyVisionGlobalData)
+        {
+            Reject("DolbyVisionMetadata");
+            return false;
+        }
+    }
+    else if (!strcmp(DolbyVisionGlobalData->Name(), "DolbyVisionIntegratedWrapper"))
+    {
+        for (DolbyVisionGlobalData = DolbyVisionGlobalData->FirstChildElement(); DolbyVisionGlobalData; DolbyVisionGlobalData = DolbyVisionGlobalData->NextSiblingElement())
+        {
+            if (!strcmp(DolbyVisionGlobalData->Name(), "DolbyVisionGlobalData"))
+                break;
+        }
+    }
+    else if (strcmp(DolbyVisionGlobalData->Name(), "DolbyVisionGlobalData"))
+        DolbyVisionGlobalData = NULL;
+
+    if (!DolbyVisionGlobalData)
+    {
+        Reject("DolbyVisionMetadata");
+        return false;
+    }
+    if (const char* Text = DolbyVisionGlobalData->Attribute("version"))
+        Version=Text;
 
     Accept("DolbyVisionMetadata");
     Stream_Prepare(Stream_Video);
-    Fill(Stream_Video, 0, "HDR_Format", "Dolby Vision Metadata");
-    if (const char* Text=DolbyVisionGlobalData->Attribute("version"))
-        Fill(Stream_Video, 0, "HDR_Format_Version", Text);
+    Fill(Stream_Video, 0, Video_HDR_Format, "Dolby Vision Metadata");
+    if (!Version.empty())
+        Fill(Stream_Video, 0, Video_HDR_Format_Version, Version);
+    if (AspectRatio)
+        Fill(Stream_Video, 0, Video_DisplayAspectRatio, AspectRatio);
 
     for (XMLElement* DolbyVisionGlobalData_Item=DolbyVisionGlobalData->FirstChildElement(); DolbyVisionGlobalData_Item; DolbyVisionGlobalData_Item=DolbyVisionGlobalData_Item->NextSiblingElement())
     {
@@ -73,13 +139,37 @@ bool File_DolbyVisionMetadata::FileHeader_Begin()
             memset(&Mastering, 0xFF, sizeof(Mastering));
             for (XMLElement* ColorEncoding_Item=DolbyVisionGlobalData_Item->FirstChildElement(); ColorEncoding_Item; ColorEncoding_Item=ColorEncoding_Item->NextSiblingElement())
             {
+                if (!strcmp(ColorEncoding_Item->Name(), "BitDepth"))
+                {
+                    if (const char* Text = ColorEncoding_Item->GetText())
+                    {
+                        Fill(Stream_Video, 0, Video_BitDepth, Text);
+                    }
+                }
+                if (!strcmp(ColorEncoding_Item->Name(), "CanvasAspectRatio"))
+                {
+                    if (const char* Text = ColorEncoding_Item->GetText())
+                        if (float32 TextF = Ztring().From_UTF8(Text).To_float32())
+                            Fill(Stream_Video, 0, Video_DisplayAspectRatio, TextF);
+                }
+                if (!strcmp(ColorEncoding_Item->Name(), "ColorSpace"))
+                {
+                    if (const char* Text = ColorEncoding_Item->GetText())
+                    {
+                        if (!strcmp(Text, "rgb"))
+                            Text = "RGB";
+                        if (!strcmp(Text, "yuv"))
+                            Text = "YUV";
+                        Fill(Stream_Video, 0, Video_ColorSpace, Text);
+                    }
+                }
                 if (!strcmp(ColorEncoding_Item->Name(), "Encoding"))
                 {
                     if (const char* Text=ColorEncoding_Item->GetText())
                     {
                         if (!strcmp(Text, "pq"))
                             Text="PQ";
-                        Fill(Stream_Video, 0, "transfer_characteristics", Text);
+                        Fill(Stream_Video, 0, Video_transfer_characteristics, Text);
                     }
                 }
                 if (!strcmp(ColorEncoding_Item->Name(), "Primaries"))
@@ -115,13 +205,28 @@ bool File_DolbyVisionMetadata::FileHeader_Begin()
                         }
                     }
                 }
+                if (!strcmp(ColorEncoding_Item->Name(), "SignalRange"))
+                {
+                    if (const char* Text = ColorEncoding_Item->GetText())
+                    {
+                        if (!strcmp(Text, "computer"))
+                            Text = "Full";
+                        Fill(Stream_Video, 0, Video_colour_range, Text);
+                    }
+                }
                 if (!strcmp(ColorEncoding_Item->Name(), "WhitePoint"))
                 {
                     if (const char* Text=ColorEncoding_Item->GetText())
                     {
                         ZtringList List;
-                        List.Separator_Set(0, __T(","));
+                        List.Separator_Set(0, __T(" "));
                         List.Write(Ztring(Text));
+                        if (List.size()==1)
+                        {
+                            //Trying with space
+                            List.Separator_Set(0, __T(","));
+                            List.Write(Ztring(Text));
+                        }
                         if (List.size()==2)
                         {
                             Mastering.Primaries[6]=float64_int64s(List[0].To_float64()*50000);
@@ -133,7 +238,44 @@ bool File_DolbyVisionMetadata::FileHeader_Begin()
             Ztring colour_primaries;
             Get_MasteringDisplayColorVolume(colour_primaries, colour_primaries, Mastering); // Second part is not used
             if (!colour_primaries.empty())
-                Fill(Stream_Video, 0, "colour_primaries", colour_primaries);
+                Fill(Stream_Video, 0, Video_colour_primaries, colour_primaries);
+        }
+        if (!strcmp(DolbyVisionGlobalData_Item->Name(), "EditRate"))
+        {
+            if (const char* Text = DolbyVisionGlobalData_Item->GetText())
+            {
+                float32 FrameRate = Ztring().From_UTF8(Text).To_float32();
+                if (FrameRate)
+                {
+                    Text = strchr(Text, ' ');
+                    if (Text)
+                    {
+                        Text++;
+                        float32 FrameRateD = Ztring().From_UTF8(Text).To_float32();
+                        if (FrameRateD)
+                            FrameRate /= FrameRateD;
+                    }
+                }
+                Fill(Stream_Video, 0, Video_FrameRate, FrameRate);
+            }
+        }
+        if (!strcmp(DolbyVisionGlobalData_Item->Name(), "Level6"))
+        {
+            for (XMLElement* Level6_Item = DolbyVisionGlobalData_Item->FirstChildElement(); Level6_Item; Level6_Item = Level6_Item->NextSiblingElement())
+            {
+                if (!strcmp(Level6_Item->Name(), "MaxCLL"))
+                {
+                    if (const char* Text = Level6_Item->GetText())
+                        if (Ztring().From_UTF8(Text).To_float32())
+                            Fill(Stream_Video, 0, Video_MaxCLL, Ztring(Text) + __T(" cd/m2"));
+                }
+                if (!strcmp(Level6_Item->Name(), "MaxFALL"))
+                {
+                    if (const char* Text = Level6_Item->GetText())
+                        if (Ztring().From_UTF8(Text).To_float32())
+                            Fill(Stream_Video, 0, Video_MaxFALL, Ztring(Text) + __T(" cd/m2"));
+                }
+            }
         }
         if (!strcmp(DolbyVisionGlobalData_Item->Name(), "PluginNode"))
         {
@@ -179,8 +321,14 @@ bool File_DolbyVisionMetadata::FileHeader_Begin()
                                                     if (const char* Text=Primaries_Item->GetText())
                                                     {
                                                         ZtringList List;
-                                                        List.Separator_Set(0, __T(","));
+                                                        List.Separator_Set(0, __T(" "));
                                                         List.Write(Ztring(Text));
+                                                        if (List.size()==1)
+                                                        {
+                                                            //Trying with space
+                                                            List.Separator_Set(0, __T(","));
+                                                            List.Write(Ztring(Text));
+                                                        }
                                                         if (List.size()==2)
                                                         {
                                                             Mastering.Primaries[i]=float64_int64s(List[0].To_float64()*50000);
@@ -214,38 +362,120 @@ bool File_DolbyVisionMetadata::FileHeader_Begin()
                                     Ztring colour_primaries, luminance;
                                     Get_MasteringDisplayColorVolume(colour_primaries, luminance, Mastering);
                                     if (!colour_primaries.empty())
-                                        Fill(Stream_Video, 0, "MasteringDisplay_ColorPrimaries", colour_primaries);
+                                        Fill(Stream_Video, 0, Video_MasteringDisplay_ColorPrimaries, colour_primaries);
                                     if (!luminance.empty())
-                                        Fill(Stream_Video, 0, "MasteringDisplay_Luminance", luminance);
+                                        Fill(Stream_Video, 0, Video_MasteringDisplay_Luminance, luminance);
                                 }
                             }
+                        }
+                        if (!strcmp(DolbyEDR_Item->Name(), "MasteringDisplay"))
+                        {
+                            mastering_metadata_2086 Mastering;
+                            memset(&Mastering, 0xFF, sizeof(Mastering));
+                            for (XMLElement* MasteringDisplay_Item=DolbyEDR_Item->FirstChildElement(); MasteringDisplay_Item; MasteringDisplay_Item=MasteringDisplay_Item->NextSiblingElement())
+                            {
+                                if (!strcmp(MasteringDisplay_Item->Name(), "MinimumBrightness"))
+                                {
+                                    if (const char* Text=MasteringDisplay_Item->GetText())
+                                        Mastering.Luminance[0]=float64_int64s(Ztring(Text).To_float64()*10000);
+                                }
+                                if (!strcmp(MasteringDisplay_Item->Name(), "PeakBrightness"))
+                                {
+                                    if (const char* Text=MasteringDisplay_Item->GetText())
+                                        Mastering.Luminance[1]=float64_int64s(Ztring(Text).To_float64()*10000);
+                                }
+                                if (!strcmp(MasteringDisplay_Item->Name(), "Primaries"))
+                                {
+                                    for (XMLElement* Primaries_Item=MasteringDisplay_Item->FirstChildElement(); Primaries_Item; Primaries_Item=Primaries_Item->NextSiblingElement())
+                                    {
+                                        int8u i=(int8u)-1;
+                                        if (!strcmp(Primaries_Item->Name(), "Green"))
+                                            i=0;
+                                        if (!strcmp(Primaries_Item->Name(), "Blue"))
+                                            i=2;
+                                        if (!strcmp(Primaries_Item->Name(), "Red"))
+                                            i=4;
+                                        if (i!=(int8u)-1)
+                                        {
+                                            if (const char* Text=Primaries_Item->GetText())
+                                            {
+                                                ZtringList List;
+                                                List.Separator_Set(0, __T(" "));
+                                                List.Write(Ztring(Text));
+                                                if (List.size()==1)
+                                                {
+                                                    //Trying with space
+                                                    List.Separator_Set(0, __T(","));
+                                                    List.Write(Ztring(Text));
+                                                }
+                                                if (List.size()==2)
+                                                {
+                                                    Mastering.Primaries[i]=float64_int64s(List[0].To_float64()*50000);
+                                                    Mastering.Primaries[i+1]=float64_int64s(List[1].To_float64()*50000);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                if (!strcmp(MasteringDisplay_Item->Name(), "WhitePoint"))
+                                {
+                                    if (const char* Text=MasteringDisplay_Item->GetText())
+                                    {
+                                        ZtringList List;
+                                        List.Separator_Set(0, __T(" "));
+                                        List.Write(Ztring(Text));
+                                        if (List.size()==1)
+                                        {
+                                            //Trying with space
+                                            List.Separator_Set(0, __T(","));
+                                            List.Write(Ztring(Text));
+                                        }
+                                        if (List.size()==2)
+                                        {
+                                            Mastering.Primaries[6]=float64_int64s(List[0].To_float64()*50000);
+                                            Mastering.Primaries[7]=float64_int64s(List[1].To_float64()*50000);
+                                        }
+                                    }
+                                }
+                            }
+                            Ztring colour_primaries, luminance;
+                            Get_MasteringDisplayColorVolume(colour_primaries, luminance, Mastering);
+                            if (!colour_primaries.empty())
+                                Fill(Stream_Video, 0, Video_MasteringDisplay_ColorPrimaries, colour_primaries);
+                            if (!luminance.empty())
+                                Fill(Stream_Video, 0, Video_MasteringDisplay_Luminance, luminance);
                         }
                     }
                 }
             }
         }
-        if (!strcmp(DolbyVisionGlobalData_Item->Name(), "Level6"))
+        if (!strcmp(DolbyVisionGlobalData_Item->Name(), "Rate"))
         {
-            for (XMLElement* Level6_Item=DolbyVisionGlobalData_Item->FirstChildElement(); Level6_Item; Level6_Item=Level6_Item->NextSiblingElement())
+            int64u n = 0, d = 0;
+            for (XMLElement* Rate_Item = DolbyVisionGlobalData_Item->FirstChildElement(); Rate_Item; Rate_Item = Rate_Item->NextSiblingElement())
             {
-                if (!strcmp(Level6_Item->Name(), "MaxCLL"))
-                {
-                    if (const char* Text=Level6_Item->GetText())
-                        if (atof(Text))
-                            Fill(Stream_Video, 0, "MaxCLL", Ztring(Text)+__T(" cd/m2"));
-                }
-                if (!strcmp(Level6_Item->Name(), "MaxFALL"))
-                {
-                    if (const char* Text=Level6_Item->GetText())
-                        if (atof(Text))
-                            Fill(Stream_Video, 0, "MaxFALL", Ztring(Text)+__T(" cd/m2"));
-                }
+                if (!strcmp(Rate_Item->Name(), "d"))
+                    d = Ztring().From_UTF8(Rate_Item->GetText()).To_float32();
+                if (!strcmp(Rate_Item->Name(), "n"))
+                    n = Ztring().From_UTF8(Rate_Item->GetText()).To_float32();
             }
+            if (n && d)
+                Fill(Stream_Video, 0, Video_FrameRate, ((float32)n) / d);
+        }
+        if (!strcmp(DolbyVisionGlobalData_Item->Name(), "TrackName"))
+        {
+            if (const char* Text = DolbyVisionGlobalData_Item->GetText())
+                Fill(Stream_Video, 0, Video_Title, Text);
+        }
+        if (!strcmp(DolbyVisionGlobalData_Item->Name(), "UniqueID"))
+        {
+            if (const char* Text = DolbyVisionGlobalData_Item->GetText())
+                Fill(Stream_Video, 0, Video_UniqueID, Text);
         }
         if (!strcmp(DolbyVisionGlobalData_Item->Name(), "Version"))
         {
             if (const char* Text= DolbyVisionGlobalData_Item->GetText())
-                Fill(Stream_Video, 0, "HDR_Format_Version", Text);
+                Fill(Stream_Video, 0, Video_HDR_Format_Version, Text);
         }
     }
 
@@ -256,5 +486,5 @@ bool File_DolbyVisionMetadata::FileHeader_Begin()
 
 } //NameSpace
 
-#endif //MEDIAINFO_DCP_YES
+#endif //defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MXF_YES)
 


### PR DESCRIPTION
Example with an MXF ISXD file:

```
Video
HDR format                               : Dolby Vision Metadata, Version 5.1.0
Frame rate                               : 24.000 FPS
Color space                              : RGB
Title                                    : track name
Color range                              : Full
Color primaries                          : Display P3
Transfer characteristics                 : PQ
Mastering display color primaries        : Display P3
Mastering display luminance              : min: 0.0001 cd/m2, max: 1000 cd/m2
```