### PR TITLE
MOV/MP4: support of Dolby Vision Metadata XML

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -465,6 +465,11 @@ void File_Mpeg4::Streams_Finish()
         StreamKind_Last=Temp->second.StreamKind;
         StreamPos_Last=Temp->second.StreamPos;
 
+        if (StreamKind_Last==Stream_Max && !Temp->second.MetaFor.empty())
+        {
+            ++Temp;
+            continue;
+        }
         if (StreamKind_Last==Stream_Max && Temp->second.hdlr_SubType)
         {
             Stream_Prepare(Stream_Other);
@@ -675,6 +680,20 @@ void File_Mpeg4::Streams_Finish()
                 if (TempString.size())
                 {
                     Fill(StreamKind_Last, StreamPos_Last, "Menus", TempString.To_UTF8().c_str());
+                    TempString.clear();
+                }
+            }
+            if (!Temp->second.Meta.empty())
+            {
+                for (TrackID = Temp->second.Meta.begin(); TrackID != Temp->second.Meta.end(); ++TrackID)
+                {
+                    Merge(*Streams[*TrackID].Parsers[0], Stream_Video, 0, StreamPos_Last);
+                    if (TempString.size()) TempString.append(__T(","));
+                    TempString.append(Ztring().From_Number(*TrackID));
+                }
+                if (TempString.size())
+                {
+                    Fill(StreamKind_Last, StreamPos_Last, "Metas", TempString.To_UTF8().c_str());
                     TempString.clear();
                 }
             }

--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -172,6 +172,10 @@ private :
     void moov_trak_mdia_minf_stbl_stps();
     void moov_trak_mdia_minf_stbl_stsc();
     void moov_trak_mdia_minf_stbl_stsd();
+    void moov_trak_mdia_minf_stbl_stsd_mebx();
+    void moov_trak_mdia_minf_stbl_stsd_mebx_keys();
+    void moov_trak_mdia_minf_stbl_stsd_mebx_keys_PHDR();
+    void moov_trak_mdia_minf_stbl_stsd_mebx_keys_PHDR_keyd();
     void moov_trak_mdia_minf_stbl_stsd_stpp();
     void moov_trak_mdia_minf_stbl_stsd_stpp_btrt() {moov_trak_mdia_minf_stbl_stsd_xxxx_btrt();}
     void moov_trak_mdia_minf_stbl_stsd_text();
@@ -261,6 +265,7 @@ private :
     void moov_trak_txas();
     void moov_trak_tref();
     void moov_trak_tref_chap();
+    void moov_trak_tref_cdsc();
     void moov_trak_tref_clcp();
     void moov_trak_tref_dpnd();
     void moov_trak_tref_fall();
@@ -466,6 +471,7 @@ private :
         int32u                  mvex_trex_default_sample_duration;
         int32u                  mvex_trex_default_sample_size;
         int32u                  TimeCode_TrackID;
+        int32u                  HasAtomStyle;
         bool                    TimeCode_IsVisual;
         bool                    IsPcm;
         bool                    IsPcmMono;
@@ -491,6 +497,8 @@ private :
         std::vector<int32u>     ForcedFor;
         std::vector<int32u>     Chapters;
         std::vector<int32u>     ChaptersFor;
+        std::vector<int32u>     Meta;
+        std::vector<int32u>     MetaFor;
         float32                 CleanAperture_Width;
         float32                 CleanAperture_Height;
         float32                 CleanAperture_PixelAspectRatio;
@@ -545,6 +553,7 @@ private :
             mvex_trex_default_sample_duration=0;
             mvex_trex_default_sample_size=0;
             TimeCode_TrackID=(int32u)-1;
+            HasAtomStyle=0;
             TimeCode_IsVisual=false;
             IsPcm=false;
             IsPcmMono=false;

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -28,6 +28,7 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/Multiple/File_Mpeg4.h"
+#include "MediaInfo/Video/File_DolbyVisionMetadata.h"
 #if defined(MEDIAINFO_DVDIF_YES)
     #include "MediaInfo/Multiple/File_DvDif.h"
 #endif
@@ -751,6 +752,10 @@ namespace Elements
     const int64u moov_trak_mdia_minf_stbl_stsc=0x73747363;
     const int64u moov_trak_mdia_minf_stbl_stsd=0x73747364;
     const int64u moov_trak_mdia_minf_stbl_stsd_alac=0x616C6163;
+    const int64u moov_trak_mdia_minf_stbl_stsd_mebx=0x6D656278;
+    const int64u moov_trak_mdia_minf_stbl_stsd_mebx_keys=0x6B657973;
+    const int64u moov_trak_mdia_minf_stbl_stsd_mebx_keys_PHDR=0x50484452;
+    const int64u moov_trak_mdia_minf_stbl_stsd_mebx_keys_PHDR_keyd=0x6B657964;
     const int64u moov_trak_mdia_minf_stbl_stsd_mp4a=0x6D703461;
     const int64u moov_trak_mdia_minf_stbl_stsd_mp4s=0x6D703473;
     const int64u moov_trak_mdia_minf_stbl_stsd_mp4v=0x6D703476;
@@ -858,6 +863,7 @@ namespace Elements
     const int64u moov_trak_tref=0x74726566;
     const int64u moov_trak_tref_dpnd=0x64706E64;
     const int64u moov_trak_tref_chap=0x63686170;
+    const int64u moov_trak_tref_cdsc=0x63647363;
     const int64u moov_trak_tref_clcp=0x636C6370;
     const int64u moov_trak_tref_fall=0x66616C6C;
     const int64u moov_trak_tref_folw=0x666F6C77;
@@ -1141,6 +1147,16 @@ void File_Mpeg4::Data_Parse()
                         ATOM(moov_trak_mdia_minf_stbl_stsc)
                         LIST(moov_trak_mdia_minf_stbl_stsd)
                             ATOM_BEGIN
+                            LIST_COMPLETE(moov_trak_mdia_minf_stbl_stsd_mebx)
+                                ATOM_BEGIN
+                                LIST_COMPLETE(moov_trak_mdia_minf_stbl_stsd_mebx_keys)
+                                    ATOM_BEGIN
+                                    LIST_COMPLETE(moov_trak_mdia_minf_stbl_stsd_mebx_keys_PHDR)
+                                        ATOM_BEGIN
+                                        ATOM(moov_trak_mdia_minf_stbl_stsd_mebx_keys_PHDR_keyd)
+                                        ATOM_END
+                                    ATOM_END
+                                ATOM_END
                             LIST_COMPLETE(moov_trak_mdia_minf_stbl_stsd_stpp)
                                 ATOM_BEGIN
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_stpp_btrt)
@@ -1258,6 +1274,7 @@ void File_Mpeg4::Data_Parse()
             LIST(moov_trak_tref)
                 ATOM_BEGIN
                 ATOM(moov_trak_tref_chap)
+                ATOM(moov_trak_tref_cdsc)
                 ATOM(moov_trak_tref_clcp)
                 ATOM(moov_trak_tref_dpnd)
                 ATOM(moov_trak_tref_fall)
@@ -1830,6 +1847,31 @@ void File_Mpeg4::mdat_xxxx()
         mdat_StreamJump();
         return;
     }
+
+    int64u Element_Size2;
+    if (Stream_Temp.HasAtomStyle)
+    {
+        while(Element_Offset<Element_Size)
+        {
+            int32u Size, Type;
+            int8u Version;
+            Get_B4 (Size,                                       "Size");
+            Get_B4 (Type,                                       "Type");
+            Get_B1 (Version,                                    "Version");
+            Skip_B3(                                            "Flags");
+            if (Type==Stream_Temp.HasAtomStyle)
+            {
+                if (Size<12 || Size>Element_Size-(Element_Offset-12))
+                    return; //Problem
+                Element_Size2=Element_Offset+Size-12;
+                break;
+            }
+            Skip_XX(Size-12,                                    "Data (unsupported)");
+        }
+    }
+    else
+        Element_Size2=Element_Size;
+
     #if MEDIAINFO_DEMUX
         if (Stream_Temp.StreamKind!=Stream_Other && Stream_Temp.StreamKind!=Stream_Max)
         {
@@ -1962,7 +2004,7 @@ void File_Mpeg4::mdat_xxxx()
         Stream_Temp.Parsers[Pos]->FrameInfo=FrameInfo;
         #endif //MEDIAINFO_DEMUX
 
-        Open_Buffer_Continue(Stream_Temp.Parsers[Pos], Buffer+Buffer_Offset, (size_t)Element_Size);
+        Open_Buffer_Continue(Stream_Temp.Parsers[Pos], Buffer+Buffer_Offset+(size_t)Element_Offset, (size_t)(Element_Size-Element_Offset));
         #if MEDIAINFO_DEMUX
             if (Config->Demux_EventWasSent && Config->Demux_Unpacketize_Get())
                 Stream_Temp.Demux_EventWasSent=true;
@@ -4806,6 +4848,51 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd()
 }
 
 //---------------------------------------------------------------------------
+void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_mebx()
+{
+    Element_Name("Timed Metadata Sample");
+    
+    //Parsing
+    Skip_B6(                                                    "Reserved");
+    Skip_B2(                                                    "Data reference index");
+
+    Element_ThisIsAList();
+}
+
+//---------------------------------------------------------------------------
+void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_mebx_keys()
+{
+    Element_Name("Metadata Key Table");
+}
+
+//---------------------------------------------------------------------------
+void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_mebx_keys_PHDR()
+{
+    Element_Name("Production HDR");
+}
+
+//---------------------------------------------------------------------------
+void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_mebx_keys_PHDR_keyd()
+{
+    //Parsing
+    int32u key_namespace;
+    string key_value;
+    Get_C4(key_namespace,                                       "key_namespace");
+    Get_String(Element_Size-Element_Offset, key_value,          "key_value");
+
+    {
+        File_DolbyVisionMetadata* Parser=new File_DolbyVisionMetadata;
+        int64u Elemen_Code_Save=Element_Code;
+        Element_Code=moov_trak_tkhd_TrackID; //Element_Code is use for stream identifier
+        Open_Buffer_Init(Parser);
+        Element_Code=Elemen_Code_Save;
+        Streams[moov_trak_tkhd_TrackID].HasAtomStyle=Elements::moov_trak_mdia_minf_stbl_stsd_mebx_keys_PHDR;
+        Streams[moov_trak_tkhd_TrackID].Parsers.push_back(Parser);
+        mdat_MustParse=true; //Data is in MDAT
+    }
+}
+
+//---------------------------------------------------------------------------
 void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_stpp()
 {
     Element_Name("Subtitle (stpp)");
@@ -6452,8 +6539,10 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxx_clli()
     Get_B2(maximum_frame_average_light_level,                   "maximum_frame_average_light_level");
 
     FILLING_BEGIN();
-        Fill(Stream_Video, 0, "MaxCLL", Ztring::ToZtring(maximum_content_light_level) + __T(" cd/m2"));
-        Fill(Stream_Video, 0, "MaxFALL", Ztring::ToZtring(maximum_frame_average_light_level) + __T(" cd/m2"));
+        if (maximum_content_light_level)
+            Fill(Stream_Video, 0, "MaxCLL", Ztring::ToZtring(maximum_content_light_level) + __T(" cd/m2"));
+        if (maximum_frame_average_light_level)
+            Fill(Stream_Video, 0, "MaxFALL", Ztring::ToZtring(maximum_frame_average_light_level) + __T(" cd/m2"));
     FILLING_END();
 }
 
@@ -7903,6 +7992,24 @@ void File_Mpeg4::moov_trak_tref_chap()
             Streams[TrackID].IsChapter=true;
             Streams[TrackID].ChaptersFor.push_back(moov_trak_tkhd_TrackID);
             Streams[moov_trak_tkhd_TrackID].Chapters.push_back(TrackID);
+        FILLING_END();
+    }
+}
+
+//---------------------------------------------------------------------------
+void File_Mpeg4::moov_trak_tref_cdsc()
+{
+    Element_Name("Content Describes");
+
+    //Parsing
+    while (Element_Offset<Element_Size)
+    {
+        int32u TrackID;
+        Get_B4(TrackID,                                         "track-ID");
+
+        FILLING_BEGIN();
+            Streams[TrackID].Meta.push_back(moov_trak_tkhd_TrackID);
+            Streams[moov_trak_tkhd_TrackID].MetaFor.push_back(TrackID);
         FILLING_END();
     }
 }


### PR DESCRIPTION
Dolby Vision Metadata XML can be in a sidecar track, example with a MOV ProRes + Dolby Vision Metadata:

```
Video
ID                                       : 1
Format                                   : ProRes
Format version                           : Version 1
Format profile                           : 4444 XQ
HDR format                               : SMPTE ST 2086, HDR10 compatible / Dolby Vision Metadata, Version 4.0.2
Codec ID                                 : ap4x
Duration                                 : 2 s 458 ms
Bit rate mode                            : Variable
Bit rate                                 : 389 Mb/s
Width                                    : 1 920 pixels
Height                                   : 1 080 pixels
Display aspect ratio                     : 16:9
Frame rate mode                          : Constant
Frame rate                               : 24.000 FPS
Color space                              : YUV
Chroma subsampling                       : 4:4:4
Scan type                                : Progressive
Bits/(Pixel*Frame)                       : 7.821
Stream size                              : 114 MiB (100%)
Title                                    : track name
Writing library                          : adol
Encoded date                             : UTC 2021-04-20 21:05:33
Tagged date                              : UTC 2021-04-20 21:05:33
Color range                              : Full
Color primaries                          : Display P3
Transfer characteristics                 : PQ
Matrix coefficients                      : BT.709
Mastering display color primaries        : Display P3
Mastering display luminance              : min: 0.0001 cd/m2, max: 1000 cd/m2
Metas                                    : 2
```
