### PR TITLE
SMPTE ST 337: support of odd number of channels

### DIFF
--- a/Source/MediaInfo/Audio/File_Adm.cpp
+++ b/Source/MediaInfo/Audio/File_Adm.cpp
@@ -460,6 +460,10 @@ void file_adm_private::parse()
     for (;;) {
         if (tfsxml_next(&p, &b))
             break;
+        if (!tfsxml_cmp_charp(b, "audioFormatExtended"))
+        {
+            audioFormatExtended();
+        }
         if (!tfsxml_cmp_charp(b, "ebuCoreMain"))
         {
             while (!tfsxml_attr(&p, &b, &v)) {
@@ -516,9 +520,6 @@ void file_adm_private::format()
     for (;;) {
         if (tfsxml_next(&p, &b))
             break;
-        if (!tfsxml_cmp_charp(b, "audioFormatExtended")) {
-            audioFormatExtended();
-        }
         if (!tfsxml_cmp_charp(b, "audioFormatCustom")) {
             tfsxml_enter(&p, &b);
             while (!tfsxml_next(&p, &b)) {
@@ -549,6 +550,9 @@ void file_adm_private::format()
                     }
                 }
             }
+        }
+        if (!tfsxml_cmp_charp(b, "audioFormatExtended")) {
+            audioFormatExtended();
         }
     }
 }
@@ -809,8 +813,6 @@ File_Adm::File_Adm()
     Buffer_MaximumSize = 256 * 1024 * 1024;
 
     File_Adm_Private = new file_adm_private();
-
-    MuxingMode=NULL;
 }
 
 //---------------------------------------------------------------------------
@@ -876,7 +878,7 @@ bool File_Adm::FileHeader_Begin()
         Fill(Stream_Audio, StreamPos_Last, Audio_Format, "ADM");
 
     Fill(Stream_Audio, StreamPos_Last, "Metadata_Format", "ADM, Version " + Ztring::ToZtring(File_Adm_Private->Version).To_UTF8());
-    if (MuxingMode)
+    if (!MuxingMode.empty())
         Fill(Stream_Audio, StreamPos_Last, "Metadata_MuxingMode", MuxingMode);
     if (File_Adm_Private->Items[item_audioProgramme].Items.size() == 1 && File_Adm_Private->Items[item_audioProgramme].Items[0].Strings[audioProgramme_audioProgrammeName] == "Atmos_Master") {
         if (!File_Adm_Private->DolbyProfileCanNotBeVersion1 && File_Adm_Private->Version>1)

--- a/Source/MediaInfo/Audio/File_Adm.h
+++ b/Source/MediaInfo/Audio/File_Adm.h
@@ -32,7 +32,7 @@ class File_Adm : public File__Analyze
 {
 public :
     //In
-    const char* MuxingMode;
+    string MuxingMode;
 
     //Constructor/Destructor
     File_Adm();

--- a/Source/MediaInfo/Audio/File_SmpteSt0337.cpp
+++ b/Source/MediaInfo/Audio/File_SmpteSt0337.cpp
@@ -1251,6 +1251,7 @@ void File_SmpteSt0337::Data_Parse()
     int8u data_type_dependent;
     int8u* UncompressedData=NULL;
     size_t UncompressedData_Size=0;
+    string MuxingMode;
     Element_Begin1("Header");
         BS_Begin();
         Skip_S3(Stream_Bits,                                    "Pa");
@@ -1299,7 +1300,22 @@ void File_SmpteSt0337::Data_Parse()
                         Skip_S1(Stream_Bits-16,                 "reserved");
                     Element_End0();
                 }
-                if (Parser || data_stream_number || multiple_chunk_flag || format_type>1 || Track_ID || track_numbers)
+                MuxingMode=string("SMPTE ST 337 / SMPTE ST 2116");
+                if (!data_stream_number && !multiple_chunk_flag && !in_timeline_flag && format_type<=1)
+                {
+                    MuxingMode+=" Level ";
+                    MuxingMode+='A';
+                    if (format_type==1)
+                        MuxingMode+='X';
+                    if (track_numbers<10)
+                        MuxingMode+='1'+track_numbers;
+                    else
+                    {
+                        MuxingMode+='1';
+                        MuxingMode+='0'-10+track_numbers;
+                    }
+                }
+                if (Parser || data_stream_number || multiple_chunk_flag || in_timeline_flag || format_type>1 || Track_ID || track_numbers)
                 {
                     Skip_BS(Data_BS_Remain(),                   "Data (Unsupported)");
                 }
@@ -1462,7 +1478,6 @@ void File_SmpteSt0337::Data_Parse()
             case 32+1 : // ADM
                         #if defined(MEDIAINFO_ADM_YES)
                         {
-                        const char* const MuxingMode="SMPTE ST 337 / SMPTE ST 2116";
                         if (UncompressedData || Element_Offset<Element_Size)
                         {
                             Parser=new File_Adm();

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -3612,9 +3612,14 @@ struct profile_info
 
 void File_Riff::WAVE_axml()
 {
-    if (Element_Size!=Element_TotalSize_Get()-Alignement_ExtraByte)
+    int64u Element_TotalSize=Element_TotalSize_Get();
+    if (Element_Size!=Element_TotalSize-Alignement_ExtraByte)
     {
-        Buffer_MaximumSize=64*1024*1024;
+        if (Buffer_MaximumSize<Element_TotalSize)
+            Buffer_MaximumSize+=Element_TotalSize;
+        size_t* File_Buffer_Size_Hint_Pointer=Config->File_Buffer_Size_Hint_Pointer_Get();
+        if (File_Buffer_Size_Hint_Pointer)
+            (*File_Buffer_Size_Hint_Pointer)=(size_t)(Element_TotalSize-Element_Size);
         Element_WaitForMoreData();
         return; //Must wait for more data
     }
@@ -3682,6 +3687,8 @@ void File_Riff::WAVE_axml()
 
     //Parsing
     File_Adm* Adm_New=new File_Adm;
+    Adm_New->MuxingMode=(Element_Code==Elements::WAVE_bxml)?'b':'a';
+    Adm_New->MuxingMode+="xml";
     Open_Buffer_Init(Adm_New);
     Open_Buffer_Continue(Adm_New, UncompressedData, UncompressedData_Size);
     Finish(Adm_New);


### PR DESCRIPTION
With ADM we can have now a single AES3 half stream (subsample mode) in addition to AES3 pairs.