### PR TITLE
Fix mp4 edts trace info

### DIFF
--- a/Source/MediaInfo/File__Analyze.h
+++ b/Source/MediaInfo/File__Analyze.h
@@ -574,10 +574,12 @@ public :
     void Get_B2   (int16u  &Info, const char* Name);
     void Get_B3   (int32u  &Info, const char* Name);
     void Get_B4   (int32u  &Info, const char* Name);
+    void Get_B4S  (int32s  &Info, const char* Name);
     void Get_B5   (int64u  &Info, const char* Name);
     void Get_B6   (int64u  &Info, const char* Name);
     void Get_B7   (int64u  &Info, const char* Name);
     void Get_B8   (int64u  &Info, const char* Name);
+    void Get_B8S  (int64s  &Info, const char* Name);
     void Get_B16  (int128u &Info, const char* Name);
     void Get_BF2  (float32 &Info, const char* Name);
     void Get_BF4  (float32 &Info, const char* Name);

--- a/Source/MediaInfo/File__Analyze_Buffer.cpp
+++ b/Source/MediaInfo/File__Analyze_Buffer.cpp
@@ -188,6 +188,16 @@ void File__Analyze::Get_B4(int32u &Info, const char* Name)
 }
 
 //---------------------------------------------------------------------------
+void File__Analyze::Get_B4S(int32s &Info, const char* Name)
+{
+    INTEGRITY_SIZE_ATLEAST_INT(4);
+    Info=BigEndian2int32s(Buffer+Buffer_Offset+(size_t)Element_Offset);
+    if (Trace_Activated)
+        Param(Name, Info);
+    Element_Offset+=4;
+}
+
+//---------------------------------------------------------------------------
 void File__Analyze::Get_B5(int64u &Info, const char* Name)
 {
     INTEGRITY_SIZE_ATLEAST_INT(5);
@@ -219,6 +229,15 @@ void File__Analyze::Get_B8(int64u &Info, const char* Name)
 {
     INTEGRITY_SIZE_ATLEAST_INT(8);
     Info=BigEndian2int64u(Buffer+Buffer_Offset+(size_t)Element_Offset);
+    if (Trace_Activated) Param(Name, Info);
+    Element_Offset+=8;
+}
+
+//---------------------------------------------------------------------------
+void File__Analyze::Get_B8S(int64s &Info, const char* Name)
+{
+    INTEGRITY_SIZE_ATLEAST_INT(8);
+    Info=BigEndian2int64s(Buffer+Buffer_Offset+(size_t)Element_Offset);
     if (Trace_Activated) Param(Name, Info);
     Element_Offset+=8;
 }

--- a/Source/MediaInfo/File__Analyze_Buffer_MinimizeSize.cpp
+++ b/Source/MediaInfo/File__Analyze_Buffer_MinimizeSize.cpp
@@ -174,6 +174,14 @@ void File__Analyze::Get_B4_(int32u &Info)
 }
 
 //---------------------------------------------------------------------------
+void File__Analyze::Get_B4S_(int32s &Info)
+{
+    INTEGRITY_SIZE_ATLEAST_INT(4);
+    Info=BigEndian2int32s(Buffer+Buffer_Offset+(size_t)Element_Offset);
+    Element_Offset+=4;
+}
+
+//---------------------------------------------------------------------------
 void File__Analyze::Get_B5_(int64u &Info)
 {
     INTEGRITY_SIZE_ATLEAST_INT(5);
@@ -202,6 +210,14 @@ void File__Analyze::Get_B8_(int64u &Info)
 {
     INTEGRITY_SIZE_ATLEAST_INT(8);
     Info=BigEndian2int64u(Buffer+Buffer_Offset+(size_t)Element_Offset);
+    Element_Offset+=8;
+}
+
+//---------------------------------------------------------------------------
+void File__Analyze::Get_B8S_(int64s &Info)
+{
+    INTEGRITY_SIZE_ATLEAST_INT(8);
+    Info=BigEndian2int64s(Buffer+Buffer_Offset+(size_t)Element_Offset);
     Element_Offset+=8;
 }
 

--- a/Source/MediaInfo/File__Analyze_MinimizeSize.h
+++ b/Source/MediaInfo/File__Analyze_MinimizeSize.h
@@ -372,10 +372,12 @@ public :
     void Get_B2_   (int16u  &Info);
     void Get_B3_   (int32u  &Info);
     void Get_B4_   (int32u  &Info);
+    void Get_B4S_  (int32s  &Info);
     void Get_B5_   (int64u  &Info);
     void Get_B6_   (int64u  &Info);
     void Get_B7_   (int64u  &Info);
     void Get_B8_   (int64u  &Info);
+    void Get_B8S_  (int64s  &Info);
     void Get_B16_  (int128u &Info);
     void Get_BF2_  (float32 &Info);
     void Get_BF4_  (float32 &Info);
@@ -386,10 +388,12 @@ public :
     #define Get_B2(Info, Name) Get_B2_(Info)
     #define Get_B3(Info, Name) Get_B3_(Info)
     #define Get_B4(Info, Name) Get_B4_(Info)
+    #define Get_B4S(Info, Name) Get_B4S_(Info)
     #define Get_B5(Info, Name) Get_B5_(Info)
     #define Get_B6(Info, Name) Get_B6_(Info)
     #define Get_B7(Info, Name) Get_B7_(Info)
     #define Get_B8(Info, Name) Get_B8_(Info)
+    #define Get_B8S(Info, Name) Get_B8S_(Info)
     #define Get_B16(Info, Name) Get_B16_(Info)
     #define Get_BF2(Info, Name) Get_BF2_(Info)
     #define Get_BF4(Info, Name) Get_BF4_(Info)

--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -434,7 +434,7 @@ private :
         struct edts_struct
         {
             int64u  Duration;
-            int64u  Delay;
+            int64s  Delay;
             int32u  Rate;
         };
         std::vector<edts_struct> edts;

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -1469,6 +1469,19 @@ void File_Mpeg4::Data_Parse()
             Get_B8(_INFO,                                       _NAME); \
     } \
 
+// Bigendian signed
+#define Get_BS_DEPENDOFVERSION(_INFO, _NAME) \
+    { \
+        if (Version==0) \
+        { \
+            int32s Info; \
+            Get_B4S(Info,                                        _NAME); \
+            _INFO=Info; \
+        } \
+        else \
+            Get_B8S(_INFO,                                       _NAME); \
+    } \
+
 #define Get_DATE1904_DEPENDOFVERSION(_INFO, _NAME) \
     { \
         if (Version==0) \
@@ -3856,7 +3869,7 @@ void File_Mpeg4::moov_trak_edts_elst()
         stream::edts_struct edts;
         Element_Begin1("Entry");
         Get_B_DEPENDOFVERSION(edts.Duration,                    "Track duration"); Param_Info2C(moov_mvhd_TimeScale, (int64u)edts.Duration*1000/moov_mvhd_TimeScale, " ms");
-        Get_B_DEPENDOFVERSION(edts.Delay,                       "Media time"); Param_Info2C(moov_mvhd_TimeScale && (edts.Delay!=(int32u)-1), (int64u)edts.Delay*1000/moov_mvhd_TimeScale, " ms");
+        Get_BS_DEPENDOFVERSION(edts.Delay,                      "Media time"); Param_Info2C(edts.Delay > 0, edts.Delay, " / media header time scale");
         Get_B4 (edts.Rate,                                      "Media rate"); Param_Info1(((float)edts.Rate)/0x10000);
         Element_End0();
 


### PR DESCRIPTION
1. Media time is signed value
2. Media time is in unit of mdhd time scale. Since mdhd comes after
edts, we don't know mdhd_TimeScale yet when handle edts. Give a hint
to user on which time scale to use.

Fix #1441