### PR TITLE
Dolby E: fix crash with some invalid streams

### DIFF
--- a/Source/MediaInfo/Audio/File_DolbyE.cpp
+++ b/Source/MediaInfo/Audio/File_DolbyE.cpp
@@ -1936,6 +1936,7 @@ void File_DolbyE::metadata_segment()
 
     {
         //CRC test
+        /*
         size_t Pos_End=Buffer_Offset*8+(size_t)Element_Size*8-Data_BS_Remain();
         size_t Pos_Begin=Pos_End-(metadata_segment_size+1)*bit_depth; //+1 for CRC
         int8u BitSkip_Begin=Pos_Begin%8;
@@ -1951,6 +1952,7 @@ void File_DolbyE::metadata_segment()
             // CRC is wrong
             Param_Info1("metadata_crc NOK");
         }
+        */
     }
 
     Element_End0();
@@ -2040,6 +2042,7 @@ void File_DolbyE::guard_band()
     Skip_B2(                                                    "crc");
     {
         //CRC test
+        /*
         size_t Pos_End=Buffer_Offset+Element_Offset;
         size_t Pos_Begin=Pos_End-(element_length+2); //+2 for CRC
 
@@ -2049,6 +2052,7 @@ void File_DolbyE::guard_band()
             // CRC is wrong
             Param_Info1("crc NOK");
         }
+        */
         Element_End0();
         int64u RemainingBytes=Element_Size-Element_Offset;
         if (RemainingBytes && RemainingBytes<bit_depth/4)
@@ -3155,6 +3159,7 @@ void File_DolbyE::audio_segment()
 
             #if MEDIAINFO_TRACE
                 //CRC test
+                /*
                 size_t Pos_End=Buffer_Offset*8+(size_t)Element_Size*8-Data_BS_Remain();
                 int8u BitSkip_Begin=Pos_Begin%8;
                 Pos_Begin/=8;
@@ -3169,6 +3174,7 @@ void File_DolbyE::audio_segment()
                     //CRC is wrong
                     Param_Info1("NOK");
                 }
+                */
             #endif //MEDIAINFO_TRACE
         }
     }
@@ -3247,6 +3253,7 @@ void File_DolbyE::metadata_extension_segment()
 
     #if MEDIAINFO_TRACE
         //CRC test
+        /*
         size_t Pos_End=Buffer_Offset*8+(size_t)Element_Size*8-Data_BS_Remain();
         int8u BitSkip_Begin=Pos_Begin%8;
         Pos_Begin/=8;
@@ -3261,6 +3268,7 @@ void File_DolbyE::metadata_extension_segment()
             //CRC is wrong
             Param_Info1("NOK");
         }
+        */
     #endif //MEDIAINFO_TRACE
 
     Element_End0();
@@ -3327,6 +3335,7 @@ void File_DolbyE::audio_extension_segment()
 
             #if MEDIAINFO_TRACE
                 //CRC test
+                /*
                 size_t Pos_End=Buffer_Offset*8+(size_t)Element_Size*8-Data_BS_Remain();
                 int8u BitSkip_Begin=Pos_Begin%8;
                 Pos_Begin/=8;
@@ -3341,6 +3350,7 @@ void File_DolbyE::audio_extension_segment()
                     //CRC is wrong
                     Param_Info1("NOK");
                 }
+                */
             #endif //MEDIAINFO_TRACE
         }
     }
@@ -3393,6 +3403,7 @@ void File_DolbyE::meter_segment()
 
     #if MEDIAINFO_TRACE
         //CRC test
+        /*
         size_t Pos_End=Buffer_Offset*8+(size_t)Element_Size*8-Data_BS_Remain();
         size_t Pos_Begin=Pos_End-(meter_segment_size+1)*bit_depth; //+1 for CRC
         int8u BitSkip_Begin=Pos_Begin%8;
@@ -3408,6 +3419,7 @@ void File_DolbyE::meter_segment()
             //CRC is wrong
             Param_Info1("NOK");
         }
+        */
     #endif //MEDIAINFO_TRACE
 
     Element_End0();


### PR DESCRIPTION
Disable CRC check as they are buggy.
To do: really fix crashes and good CRC check