### PR TITLE
Replace duplicate CMakeList file entry

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -250,10 +250,9 @@ set(MediaInfoLib_SRCS
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Dxw.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Flv.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Gxf.cpp
+  ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Gxf_TimeCode.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_HdsF4m.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Hls.cpp
-  ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Gxf.cpp
-  ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Gxf_TimeCode.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Ibi.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Ibi_Creation.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File_Ism.cpp


### PR DESCRIPTION
The `/MediaInfo/Multiple/File_Gxf.cpp` is included twice.
I've also moved `/MediaInfo/Multiple/File_G*` files to restore alphabetical order.