### PR TITLE
Fix MediaInfoLib.pro building

### DIFF
--- a/Project/Qt/MediaInfoLib.pro
+++ b/Project/Qt/MediaInfoLib.pro
@@ -141,10 +141,8 @@ HEADERS += \
         ../../Source/MediaInfo/MediaInfoList.h \
         ../../Source/MediaInfo/MediaInfoList_Internal.h \
         ../../Source/MediaInfo/Multiple/File__ReferenceFilesHelper.h \
-        ../../Source/MediaInfo/Multiple/File__ReferenceFilesHelper_Common.h \
         ../../Source/MediaInfo/Multiple/File__ReferenceFilesHelper_Resource.h \
         ../../Source/MediaInfo/Multiple/File__ReferenceFilesHelper_Sequence.h \
-        ../../Source/MediaInfo/Multiple/File__ReferenceFilesHelper_Sequence_Common.h \
         ../../Source/MediaInfo/Multiple/File_Aaf.h \
         ../../Source/MediaInfo/Multiple/File_Ancillary.h \
         ../../Source/MediaInfo/Multiple/File_Bdmv.h \
@@ -272,6 +270,7 @@ SOURCES += \
         ../../Source/MediaInfo/Audio/File_Aac_Others.cpp \
         ../../Source/MediaInfo/Audio/File_Ac3.cpp \
         ../../Source/MediaInfo/Audio/File_Ac4.cpp \
+        ../../Source/MediaInfo/Audio/File_Adm.cpp \
         ../../Source/MediaInfo/Audio/File_Adpcm.cpp \
         ../../Source/MediaInfo/Audio/File_Als.cpp \
         ../../Source/MediaInfo/Audio/File_Amr.cpp \
@@ -281,10 +280,15 @@ SOURCES += \
         ../../Source/MediaInfo/Audio/File_Caf.cpp \
         ../../Source/MediaInfo/Audio/File_Celt.cpp \
         ../../Source/MediaInfo/Audio/File_ChannelGrouping.cpp \
-        ../../Source/MediaInfo/Audio/File_DolbyE.cpp \
+        ../../Source/MediaInfo/Audio/File_ChannelSplitting.cpp \
+        ../../Source/MediaInfo/Audio/File_Dsdiff.cpp \
+        ../../Source/MediaInfo/Audio/File_Dsf.cpp \
         ../../Source/MediaInfo/Audio/File_Dts.cpp \
+        ../../Source/MediaInfo/Audio/File_DolbyAudioMetadata.cpp \
+        ../../Source/MediaInfo/Audio/File_DolbyE.cpp \
         ../../Source/MediaInfo/Audio/File_ExtendedModule.cpp \
         ../../Source/MediaInfo/Audio/File_Flac.cpp \
+        ../../Source/MediaInfo/Audio/File_Iab.cpp \
         ../../Source/MediaInfo/Audio/File_ImpulseTracker.cpp \
         ../../Source/MediaInfo/Audio/File_La.cpp \
         ../../Source/MediaInfo/Audio/File_Midi.cpp \
@@ -308,6 +312,7 @@ SOURCES += \
         ../../Source/MediaInfo/Audio/File_Tak.cpp \
         ../../Source/MediaInfo/Audio/File_Tta.cpp \
         ../../Source/MediaInfo/Audio/File_TwinVQ.cpp \
+        ../../Source/MediaInfo/Audio/File_Usac.cpp \
         ../../Source/MediaInfo/Audio/File_Vorbis.cpp \
         ../../Source/MediaInfo/Audio/File_Wvpk.cpp \
         ../../Source/MediaInfo/Duplicate/File__Duplicate__Base.cpp \
@@ -347,8 +352,8 @@ SOURCES += \
         ../../Source/MediaInfo/Image/File_Png.cpp \
         ../../Source/MediaInfo/Image/File_Psd.cpp \
         ../../Source/MediaInfo/Image/File_Rle.cpp \
-        ../../Source/MediaInfo/Image/File_Tga.cpp \
         ../../Source/MediaInfo/Image/File_Tiff.cpp \
+        ../../Source/MediaInfo/Image/File_Tga.cpp \
         ../../Source/MediaInfo/MediaInfo.cpp \
         ../../Source/MediaInfo/MediaInfo_Config.cpp \
         ../../Source/MediaInfo/MediaInfo_Config_Automatic.cpp \
@@ -386,6 +391,7 @@ SOURCES += \
         ../../Source/MediaInfo/Multiple/File_Ivf.cpp \
         ../../Source/MediaInfo/Multiple/File_Lxf.cpp \
         ../../Source/MediaInfo/Multiple/File_Mk.cpp \
+        ../../Source/MediaInfo/Multiple/File_MiXml.cpp \
         ../../Source/MediaInfo/Multiple/File_Mpeg4.cpp \
         ../../Source/MediaInfo/Multiple/File_Mpeg4_Descriptors.cpp \
         ../../Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp \
@@ -454,7 +460,9 @@ SOURCES += \
         ../../Source/MediaInfo/Video/File_Avc_Duplicate.cpp \
         ../../Source/MediaInfo/Video/File_AvsV.cpp \
         ../../Source/MediaInfo/Video/File_Canopus.cpp \
+        ../../Source/MediaInfo/Video/File_CineForm.cpp \
         ../../Source/MediaInfo/Video/File_Dirac.cpp \
+        ../../Source/MediaInfo/Video/File_DolbyVisionMetadata.cpp \
         ../../Source/MediaInfo/Video/File_Ffv1.cpp \
         ../../Source/MediaInfo/Video/File_Flic.cpp \
         ../../Source/MediaInfo/Video/File_Fraps.cpp \


### PR DESCRIPTION
Current .pro file build process fails with
```
$ qmake
WARNING: Failure to find: ../../Source/MediaInfo/Multiple/File__ReferenceFilesHelper_Common.h
WARNING: Failure to find: ../../Source/MediaInfo/Multiple/File__ReferenceFilesHelper_Sequence_Common.h
```
I've removed the references to these files and then noticed that .pro file lacks a few .cpp file references that CMakeLists.txt has.   
They have been added.   
I also changed the order of a few files to make a filelist in a .pro file looks more similar to the one in CMakeLists.txt , but soon I gave up with this as these small changes might hide the important ones in commit diff.