### PR TITLE
Update C# bitwise Enums to be treated as bitfields

### DIFF
--- a/Source/MediaInfoDLL/MediaInfoDLL.cs
+++ b/Source/MediaInfoDLL/MediaInfoDLL.cs
@@ -52,6 +52,7 @@ namespace MediaInfoLib
         TypeOfValue
     }
 
+    [Flags]
     public enum InfoFileOptions
     {
         FileOption_Nothing      = 0x00,
@@ -60,6 +61,7 @@ namespace MediaInfoLib
         FileOption_Max          = 0x04
     };
 
+    [Flags]
     public enum Status
     {
         None        =       0x00,


### PR DESCRIPTION
The C# example [HowToUse_Dll.cs](https://github.com/MediaArea/MediaInfoLib/blob/master/Source/Example/HowToUse_Dll.cs) is treating the `Status` Enum as a flagged Enum. Although the example technically works, the Enums should be decorated with the Flags attribute to get the full support of flagged Enums in C#. Looks like the `InfoFileOptions` is a bitwise Enum as well, so decorating with the `Flags` attribute, too.