### PR TITLE
AV1: fix parsing of metadata OBU type

### DIFF
--- a/Source/MediaInfo/Video/File_Av1.h
+++ b/Source/MediaInfo/Video/File_Av1.h
@@ -70,6 +70,7 @@ private :
 
     //Helpers
     std::string GOP_Detect(std::string PictureTypes);
+	void Get_leb128(int64u& Info, const char* Name);
 };
 
 } //NameSpace


### PR DESCRIPTION
AV1 parser reads two bytes for _metadata_type_. This is incorrect. The wrong _metadata_type_ is read, which causes lack of HDR metadata for AV1 streams.

According to the [AV1 spec](https://aomediacodec.github.io/av1-spec/av1-spec.pdf) (see section: _5.8.1. General metadata OBU syntax_), this should instead be a `leb128` type.

![image](https://user-images.githubusercontent.com/57538841/142960920-21573649-b901-430d-a4f1-75ea92fca751.png)

This is further confirmed by:
* [aom av1 decoder obu.c](https://aomedia.googlesource.com/aom/+/2e6b85e5d7d87fc2f4b4b04e55f5108604d676db/av1/decoder/obu.c#772)
* [rav1e metadata encoding function](https://github.com/xiph/rav1e/blob/7960160f186149a47a99f7a3e4c52851018266dc/src/header.rs#L220-L262) (line 233 specifically)
* This AV1 HDR sample: [HDR10_SIZZLE_PLUS_UP-FINAL_02_AV1.mp4](https://hdr10plus.org/av1_sample/HDR10_SIZZLE_PLUS_UP-FINAL_02_AV1.mp4)


### This is how it appears with `$ mediainfo HDR10_SIZZLE_PLUS_UP-FINAL_02_AV1.mp4`

## Before patch:
```
General
Complete name                            : HDR10_SIZZLE_PLUS_UP-FINAL_02_AV1.mp4
Format                                   : MPEG-4
Format profile                           : Base Media
Codec ID                                 : isom (isom/iso2/mp41)
File size                                : 66.3 MiB
Duration                                 : 1 min 17 s
Overall bit rate                         : 7 168 kb/s
Writing application                      : Lavf58.27.103

Video
ID                                       : 1
Format                                   : AV1
Format/Info                              : AOMedia Video 1
Format profile                           : Main@L5.0
Codec ID                                 : av01
Duration                                 : 1 min 17 s
Bit rate                                 : 7 037 kb/s
Width                                    : 3 840 pixels
Height                                   : 2 160 pixels
Display aspect ratio                     : 16:9
Frame rate mode                          : Constant
Frame rate                               : 23.976 (24000/1001) FPS
Color space                              : YUV
Chroma subsampling                       : 4:2:0
Bit depth                                : 10 bits
Bits/(Pixel*Frame)                       : 0.035
Stream size                              : 65.1 MiB (98%)
Color range                              : Limited
Color primaries                          : BT.2020
Transfer characteristics                 : PQ
Matrix coefficients                      : BT.2020 non-constant
Codec configuration box                  : av1C

Audio
ID                                       : 2
Format                                   : AAC LC
Format/Info                              : Advanced Audio Codec Low Complexity
Codec ID                                 : mp4a-40-2
Duration                                 : 1 min 17 s
Duration_LastFrame                       : -12 ms
Bit rate mode                            : Constant
Bit rate                                 : 129 kb/s
Channel(s)                               : 2 channels
Channel layout                           : L R
Sampling rate                            : 48.0 kHz
Frame rate                               : 46.875 FPS (1024 SPF)
Compression mode                         : Lossy
Stream size                              : 1.19 MiB (2%)
Default                                  : Yes
Alternate group                          : 1
```

## After patch:
```
General
Complete name                            : HDR10_SIZZLE_PLUS_UP-FINAL_02_AV1.mp4
Format                                   : MPEG-4
Format profile                           : Base Media
Codec ID                                 : isom (isom/iso2/mp41)
File size                                : 66.3 MiB
Duration                                 : 1 min 17 s
Overall bit rate                         : 7 168 kb/s
Writing application                      : Lavf58.27.103

Video
ID                                       : 1
Format                                   : AV1
Format/Info                              : AOMedia Video 1
Format profile                           : Main@L5.0
Codec ID                                 : av01
Duration                                 : 1 min 17 s
Bit rate                                 : 7 037 kb/s
Width                                    : 3 840 pixels
Height                                   : 2 160 pixels
Display aspect ratio                     : 16:9
Frame rate mode                          : Constant
Frame rate                               : 23.976 (24000/1001) FPS
Color space                              : YUV
Chroma subsampling                       : 4:2:0
Bit depth                                : 10 bits
Bits/(Pixel*Frame)                       : 0.035
Stream size                              : 65.1 MiB (98%)
Color range                              : Limited
Color primaries                          : BT.2020
Transfer characteristics                 : PQ
Matrix coefficients                      : BT.2020 non-constant
Mastering display color primaries        : Display P3
Mastering display luminance              : min: 0.0001 cd/m2, max: 1000 cd/m2
Maximum Content Light Level              : 1000 cd/m2
Maximum Frame-Average Light Level        : 400 cd/m2
Codec configuration box                  : av1C

Audio
ID                                       : 2
Format                                   : AAC LC
Format/Info                              : Advanced Audio Codec Low Complexity
Codec ID                                 : mp4a-40-2
Duration                                 : 1 min 17 s
Duration_LastFrame                       : -12 ms
Bit rate mode                            : Constant
Bit rate                                 : 129 kb/s
Channel(s)                               : 2 channels
Channel layout                           : L R
Sampling rate                            : 48.0 kHz
Frame rate                               : 46.875 FPS (1024 SPF)
Compression mode                         : Lossy
Stream size                              : 1.19 MiB (2%)
Default                                  : Yes
Alternate group                          : 1
```