### PR TITLE
[cmake] Allow FindTinyXML to search for tinyxml under Windows

### DIFF
--- a/Project/CMake/cmake/modules/FindTinyXML.cmake
+++ b/Project/CMake/cmake/modules/FindTinyXML.cmake
@@ -8,20 +8,18 @@
 #
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later
 
-if(NOT WIN32)
-  find_package(PkgConfig)
-  if(PKG_CONFIG_FOUND)
-    if(TinyXML_FIND_VERSION)
-      if(TinyXML_FIND_VERSION_EXACT)
-        pkg_check_modules(PC_TINYXML QUIET tinyxml2=${TinyXML_FIND_VERSION})
-      else(TinyXML_FIND_VERSION_EXACT)
-        pkg_check_modules(PC_TINYXML QUIET tinyxml2>=${TinyXML_FIND_VERSION})
-      endif(TinyXML_FIND_VERSION_EXACT)
-    else(TinyXML_FIND_VERSION)
-      pkg_check_modules(PC_TINYXML QUIET tinyxml2)
-    endif(TinyXML_FIND_VERSION)
-  endif(PKG_CONFIG_FOUND)
-endif(NOT WIN32)
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+  if(TinyXML_FIND_VERSION)
+    if(TinyXML_FIND_VERSION_EXACT)
+      pkg_check_modules(PC_TINYXML tinyxml2=${TinyXML_FIND_VERSION})
+    else(TinyXML_FIND_VERSION_EXACT)
+      pkg_check_modules(PC_TINYXML tinyxml2>=${TinyXML_FIND_VERSION})
+    endif(TinyXML_FIND_VERSION_EXACT)
+  else(TinyXML_FIND_VERSION)
+    pkg_check_modules(PC_TINYXML tinyxml2)
+  endif(TinyXML_FIND_VERSION)
+endif(PKG_CONFIG_FOUND)
 
 set(TinyXML_INCLUDE_DIRS ${PC_TINYXML_INCLUDE_DIRS} CACHE PATH "TinyXML include directory" FORCE)
 set(TinyXML_LIBRARY_DIRS ${PC_TINYXML_LIBRARY_DIRS} CACHE PATH "TinyXML library directory" FORCE)
@@ -34,4 +32,4 @@ find_package_handle_standard_args(TinyXML
   )
 
 set(TinyXML_FOUND ${TINYXML_FOUND})
-mark_as_advanced(TinyXML_INCLUDE_DIRS TinyXML_LIBRARY_DIRS TinyXML_LIBRARIES) 
+mark_as_advanced(TinyXML_INCLUDE_DIRS TinyXML_LIBRARY_DIRS TinyXML_LIBRARIES)


### PR DESCRIPTION
This PR implements a small change to allow tinyxml to be found under Windows.  Closes #1452.