### PR TITLE
MKV: Include "Encoding settings" from ENCODER_SETTINGS tag

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -3195,6 +3195,7 @@ void File_Mk::Segment_Tags_Tag_SimpleTag_TagString()
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("DESCRIPTION")) Segment_Tag_SimpleTag_TagNames[0]=__T("Description");
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("ENCODED_BY")) Segment_Tag_SimpleTag_TagNames[0]=__T("EncodedBy");
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("ENCODER")) Segment_Tag_SimpleTag_TagNames[0]=__T("Encoded_Library");
+    if (Segment_Tag_SimpleTag_TagNames[0]==__T("ENCODER_SETTINGS")) Segment_Tag_SimpleTag_TagNames[0]=__T("Encoded_Library_Settings");
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("FPS")) return; //Useless
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("HANDLER_NAME"))
     {


### PR DESCRIPTION
Without this changeset, the ENCODER_SETTINGS tag would not display if set in Matroska tags, vs. setting it into h264/h265 stream. This allows setting this flag on bitstreams that do not allow such tags, for example, AV1.
Entry will display as `Encoding settings` instead of `ENCODER_SETTINGS` and be able to use language system.