### PR TITLE
Fix MediaInfo::speaker_info naming two different types

### DIFF
--- a/Source/MediaInfo/Audio/File_DolbyE.cpp
+++ b/Source/MediaInfo/Audio/File_DolbyE.cpp
@@ -725,6 +725,8 @@ int mgi_bitstream_pos_z_to_Q15(bool pos_z_sign, int8u pos_z_bits)
 }
 
 //---------------------------------------------------------------------------
+namespace
+{
 struct speaker_info
 {
     int8u AzimuthAngle; //0 to 180 (right, if AzimuthDirection is false) or 179 (left, if AzimuthDirection is true)
@@ -742,6 +744,7 @@ bool operator== (const speaker_info& L, const speaker_info& R)
     return L.AzimuthAngle==R.AzimuthAngle
         && L.ElevationDirectionAngle==R.ElevationDirectionAngle
         && L.Flags==R.Flags;
+}
 }
 extern string Aac_ChannelLayout_GetString(const Aac_OutputChannel* const OutputChannels, size_t OutputChannels_Size);
 static const size_t SpeakerInfos_Size=43;


### PR DESCRIPTION
Distinct structs with this name are defined in:
  * Source/MediaInfo/Audio/File_DolbyE.cpp (used only in the same file)
  * Source/MediaInfo/Audio/File_Mpegh3da.h (used also in File_Mpegh3da.cpp)

This violates the One Definition Rule and may potentially lead to runtime problems if runtime type information is ever used, if the types ever gain virtual tables, or if same-signature functions are defined for both types. For a plausible example, this can happen if `File_DolbyE` starts using `std::vector<speaker_info>`, which will generate some member function template instantiations that will have the same names and signatures as the ones already generated by `File_Mpegh3da` (which already uses this vector type) but different code (because the structs’ layouts are different). Depending on exact circumstances, this might cause obvious linker errors, but it might also go unnoticed during build and silently cause the wrong implementation to be used at runtime.

It seems that currently this is not causing practical problems by sheer luck: `operator==` is defined only for one of the two types, `std::vector` is used only with the other, neither type has a virtual table and run-time type information is not used.

To fix, either rename one of the types explicitly or just enclose it in an anonymous namespace. This patch does the latter.

Discovered via a GCC warning (`-Wodr`) when building with link-time optimization.