### PR TITLE
DV: Handle FSC value even if some blocks are corrupted

### DIFF
--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -275,6 +275,8 @@ File_DvDif::File_DvDif()
     Speed_FrameCount_Stts_Fluctuation=0;
     Speed_FrameCount_system[0]=0;
     Speed_FrameCount_system[1]=0;
+    FSC_WasSet_Sum=0;
+    FSC_WasNotSet_Sum=0;
     AbstBf_Current=(0x7FFFFF)<<1;
     AbstBf_Previous=(0x7FFFFF)<<1;
     AbstBf_Previous_MaxAbst=0xFFFFFF;

--- a/Source/MediaInfo/Multiple/File_DvDif.h
+++ b/Source/MediaInfo/Multiple/File_DvDif.h
@@ -209,6 +209,8 @@ protected :
             StoredValues.clear();
         }
     };
+    int16u FSC_WasSet_Sum;
+    int16u FSC_WasNotSet_Sum;
     abst_bf AbstBf_Current_Weighted;
     int32u AbstBf_Current;
     int32u AbstBf_Previous;

--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -78,7 +78,7 @@ void File_DvDif::Read_Buffer_Continue()
                        && Buffer[Buffer_Offset+1]==0x00
                        && Buffer[Buffer_Offset+2]==0x00)) // Ignore NULL
                     {
-                        if ((Buffer[Buffer_Offset+1]&0xF0)==0x00) //Dseq=0
+                        if ((Buffer[Buffer_Offset+1]&0xF0)==0x00 && Buffer[Buffer_Offset+2]==0x00) //Dseq=0 && DBN=0
                         {
                             if ((Buffer[Buffer_Offset+1]&0x08)==0x00) //FSC=0
                             {


### PR DESCRIPTION
Check FSC value of all blocks of a frame instead of the last header block available. It permits to accept corrupted blocks.
If there are too many corrupted blocks FSC value is considered unknown.

We should do same for other items e.g. FSP, for another PR.

Fix https://github.com/mipops/dvrescue/issues/424.