### PR TITLE
DV: consider audio with any value repeated as concealed audio

### DIFF
--- a/Source/MediaInfo/MediaInfo_Events.h
+++ b/Source/MediaInfo/MediaInfo_Events.h
@@ -528,6 +528,7 @@ struct MediaInfo_Event_DvDif_Analysis_Frame_1
     const MediaInfo_int8u*  BlockStatus;
     MediaInfo_int32u        AbstBf;
     MediaInfo_int32u        MoreFlags;
+    const MediaInfo_int8u*  MoreData;
 };
 
 /*-------------------------------------------------------------------------*/

--- a/Source/MediaInfo/Multiple/File_DvDif.h
+++ b/Source/MediaInfo/Multiple/File_DvDif.h
@@ -311,8 +311,18 @@ protected :
     bitset<32> Coherency_Flags;
     std::vector<std::vector<int8u> > audio_source_mode; //Per ChannelGroup and Dseq, -1 means not present
     bitset<ChannelGroup_Count*2> ChannelInfo;
-    std::vector<std::vector<size_t> > Audio_Errors; //Per ChannelGroup and Dseq
+    struct audio_errors
+    {
+        size_t Count;
+        std::set<int16u> Values;
+
+        audio_errors():
+            Count(0)
+        {}
+    };
+    std::vector<std::vector<audio_errors> > Audio_Errors; //Per ChannelGroup and Dseq
     std::vector<std::vector<size_t> > Audio_Errors_TotalPerChannel; //Per Channel and Dseq
+
     struct recZ_Single
     {
         int64u FramePos;


### PR DESCRIPTION
Instead of only 0x8000 as indicated in the standards.

Fix https://github.com/mipops/dvrescue/issues/418