### PR TITLE
HEVC CEA-608/708 support, fix (infinite loop after seek and no new SPS)

### DIFF
--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -2157,7 +2157,7 @@ void File_Avc::slice_header()
 
         //Saving some info
         int32s TemporalReferences_Offset_pic_order_cnt_lsb_Diff=0;
-        if ((*seq_parameter_set_Item)->pic_order_cnt_type!=1 && first_mb_in_slice==0 && (Element_Code!=0x14 || seq_parameter_sets.empty())) //Not slice_layer_extension except if MVC only
+        if ((*seq_parameter_set_Item)->pic_order_cnt_type!=1 && first_mb_in_slice==0 && (Element_Code!=0x14 || seq_parameter_sets.empty()) && TemporalReferences_Reserved) //Not slice_layer_extension except if MVC only
         {
             if (field_pic_flag)
             {

--- a/Source/MediaInfo/Video/File_Hevc.cpp
+++ b/Source/MediaInfo/Video/File_Hevc.cpp
@@ -3012,7 +3012,7 @@ void File_Hevc::slice_segment_header()
         FrameRate=(float64)(*seq_parameter_set_Item)->vui_parameters->time_scale/(*seq_parameter_set_Item)->vui_parameters->num_units_in_tick;
     else
         FrameRate=0;
-    if (first_slice_segment_in_pic_flag && pic_order_cnt_DTS_Ref!=(int64u)-1 && FrameInfo.PTS!=(int64u)-1 && FrameRate)
+    if (first_slice_segment_in_pic_flag && pic_order_cnt_DTS_Ref!=(int64u)-1 && FrameInfo.PTS!=(int64u)-1 && FrameRate && TemporalReferences_Reserved)
     {
         //Frame order detection
         int64s pic_order_cnt=float64_int64s((FrameInfo.PTS-pic_order_cnt_DTS_Ref)*FrameRate/1000000000);


### PR DESCRIPTION
Fix infinite loop with some files after https://github.com/MediaArea/MediaInfoLib/pull/1417.

The AVC part is for security, should never happen due to forced SPS parsing after sync but it may be removed in the future and would trigger the same issue