### PR TITLE
TTML: correct handling of 29.97 DF time codes

### DIFF
--- a/Source/MediaInfo/File__Analyse_Automatic.h
+++ b/Source/MediaInfo/File__Analyse_Automatic.h
@@ -1211,6 +1211,7 @@ enum text
     Text_Duration_String3,
     Text_Duration_String4,
     Text_Duration_String5,
+    Text_Duration_DropFrame,
     Text_Duration_Start_Command,
     Text_Duration_Start_Command_String,
     Text_Duration_Start_Command_String1,

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -2503,8 +2503,19 @@ void File__Analyze::Duration_Duration123(stream_t StreamKind, size_t StreamPos, 
                 bool DropFrame=false;
                 bool DropFrame_IsValid=false;
 
+                // Testing duration source
+                if (!DropFrame_IsValid && StreamKind==Stream_Text)
+                {
+                    const Ztring& Duration_DropFrame=Retrieve_Const(Stream_Text, StreamPos, Text_Duration_DropFrame);
+                    if (!Duration_DropFrame.empty())
+                    {
+                        DropFrame=Duration_DropFrame==__T("Yes");
+                        DropFrame_IsValid=true;
+                    }
+                }
+
                 // Testing time code
-                if (StreamKind==Stream_Video)
+                if (!DropFrame_IsValid && StreamKind==Stream_Video)
                 {
                     Ztring TC=Retrieve(Stream_Video, StreamPos, Video_TimeCode_FirstFrame);
                     if (TC.size()>=11 && TC[2]==__T(':') && TC[5]==__T(':'))

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -5304,6 +5304,7 @@ void MediaInfo_Config_Text (ZtringListList &Info)
     "Duration/String3;;;N NT;;;Play time in format : HH:MM:SS.MMM\n"
     "Duration/String4;;;N NT;;;Play time in format : HH:MM:SS:FF, last colon replaced by semicolon for drop Duration;; ms;N YFY;;;Play time of the stream, in ms\n"
     "Duration/String5;;;N NT;;;Play time in format : HH:MM:SS.mmm (HH:MM:SS:FF)\n"
+    "Duration_DropFrame;;;N YTY;;;If time is in time code, drop frame info\n"
     "Duration_Start_Command;; ms;N YFY;;;Play time of the stream, in ms\n"
     "Duration_Start_Command/String;;;Y NT;;;Play time (formated)\n"
     "Duration_Start_Command/String1;;;N NT;;;Play time in format : HHh MMmn SSs MMMms, XX omited if zero\n"

--- a/Source/MediaInfo/Text/File_Ttml.cpp
+++ b/Source/MediaInfo/Text/File_Ttml.cpp
@@ -22,6 +22,7 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/Text/File_Ttml.h"
+#include "MediaInfo/TimeCode.h"
 #if MEDIAINFO_EVENTS
     #include "MediaInfo/MediaInfo_Config_MediaInfo.h"
     #include "MediaInfo/MediaInfo_Events_Internal.h"
@@ -250,8 +251,9 @@ void File_Ttml::Read_Buffer_Continue()
     }
 
     // Root attributes
-    int64u FrameRate_Num=0;
-    int64u FrameRate_Den=1;
+    int64u FrameRate_Int=0;
+    int64u FrameRateMultiplier_Num=1;
+    int64u FrameRateMultiplier_Den=1;
     bool IsSmpteTt=false, IsEbuTt=false, IsImsc1=false;
     const char* Tt_Attribute;
     Tt_Attribute=Root->Attribute("ttp:frameRate");
@@ -259,29 +261,32 @@ void File_Ttml::Read_Buffer_Continue()
         Tt_Attribute=Root->Attribute("frameRate");
     if (Tt_Attribute)
     {
-        FrameRate_Num=atof(Tt_Attribute);
+        FrameRate_Int=atof(Tt_Attribute);
     }
     Tt_Attribute=Root->Attribute("ttp:frameRateMultiplier");
     if (!Tt_Attribute)
         Tt_Attribute=Root->Attribute("frameRateMultiplier");
     if (Tt_Attribute)
     {
-        FrameRate_Num*=atoi(Tt_Attribute);
+        FrameRateMultiplier_Num=atoi(Tt_Attribute);
         if (const char* Tt_Attribute_Space=strchr(Tt_Attribute, ' '))
         {
-            FrameRate_Den=atoi(Tt_Attribute_Space+1);
+            FrameRateMultiplier_Den=atoi(Tt_Attribute_Space+1);
         }
     }
     float64 FrameRate=0;
-    if (FrameRate_Num && FrameRate_Den)
+    bool FrameRate_Is1001=false;
+    if (FrameRate_Int && FrameRateMultiplier_Num && FrameRateMultiplier_Den)
     {
-        FrameRate=((float64)FrameRate_Num)/FrameRate_Den;
+        FrameRate=((float64)FrameRate_Int)*FrameRateMultiplier_Num/FrameRateMultiplier_Den;
+        if (FrameRateMultiplier_Num==1000 && FrameRateMultiplier_Den==1001)
+            FrameRate_Is1001=true;
         Fill(Stream_General, 0, General_FrameRate, FrameRate);
         Fill(Stream_Text, 0, Text_FrameRate, FrameRate);
-        if (FrameRate_Den!=1)
+        if (FrameRateMultiplier_Den!=1)
         {
-            Fill(Stream_Text, 0, Text_FrameRate_Num, FrameRate_Num);
-            Fill(Stream_Text, 0, Text_FrameRate_Den, FrameRate_Den);
+            Fill(Stream_Text, 0, Text_FrameRate_Num, FrameRate_Int*FrameRateMultiplier_Num);
+            Fill(Stream_Text, 0, Text_FrameRate_Den, FrameRateMultiplier_Den);
         }
     }
     Tt_Attribute=Root->Attribute("xml:lang");
@@ -336,8 +341,8 @@ void File_Ttml::Read_Buffer_Continue()
     #if MEDIAINFO_EVENTS
     tinyxml2::XMLElement*       p=NULL;
     #endif //MEDIAINFO_EVENTS
-    int64u Time_Start=(int64u)-1;
-    int64u Time_End=0;
+    TimeCode Time_Start(0xFF, 0xFF, 0xFF, 0xFF, (int8u)FrameRate_Int, FrameRate_Is1001);
+    TimeCode Time_End(0, 0, 0, 0, (int8u)FrameRate_Int, FrameRate_Is1001);
     int64u FrameCount=0;
     for (XMLElement* tt_element=Root->FirstChildElement(); tt_element; tt_element=tt_element->NextSiblingElement())
     {
@@ -351,19 +356,25 @@ void File_Ttml::Read_Buffer_Continue()
                 {
                     if (const char* Attribute=body_element->Attribute("begin"))
                     {
-                        int64u DTS=Ttml_str2timecode(Attribute, FrameRate);
-                        if (Time_Start>DTS)
-                            Time_Start=DTS;
-                        if (Time_End<DTS)
-                            Time_End=DTS;
+                        TimeCode TC;
+                        TC.FramesPerSecond=(int8u)FrameRate_Int;
+                        TC.FramesPerSecond_Is1001=FrameRate_Is1001;
+                        TC.FromString(Attribute);
+                        if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
+                            Time_Start=TC;
+                        if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
+                            Time_End=TC;
                     }
                     if (const char* Attribute=body_element->Attribute("end"))
                     {
-                        int64u DTS=Ttml_str2timecode(Attribute, FrameRate);
-                        if (Time_Start>DTS)
-                            Time_Start=DTS;
-                        if (Time_End<DTS)
-                            Time_End=DTS;
+                        TimeCode TC;
+                        TC.FramesPerSecond=(int8u)FrameRate_Int;
+                        TC.FramesPerSecond_Is1001=FrameRate_Is1001;
+                        TC.FromString(Attribute);
+                        if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
+                            Time_Start=TC;
+                        if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
+                            Time_End=TC;
                     }
 
                     for (XMLElement* div_element=body_element->FirstChildElement(); div_element; div_element=div_element->NextSiblingElement())
@@ -373,19 +384,25 @@ void File_Ttml::Read_Buffer_Continue()
                         {
                             if (const char* Attribute=div_element->Attribute("begin"))
                             {
-                                int64u DTS=Ttml_str2timecode(Attribute, FrameRate);
-                                if (Time_Start>DTS)
-                                    Time_Start=DTS;
-                                if (Time_End<DTS)
-                                    Time_End=DTS;
+                                TimeCode TC;
+                                TC.FramesPerSecond=(int8u)FrameRate_Int;
+                                TC.FramesPerSecond_Is1001=FrameRate_Is1001;
+                                TC.FromString(Attribute);
+                                if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
+                                    Time_Start=TC;
+                                if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
+                                    Time_End=TC;
                             }
                             if (const char* Attribute=div_element->Attribute("end"))
                             {
-                                int64u DTS=Ttml_str2timecode(Attribute, FrameRate);
-                                if (Time_Start>DTS)
-                                    Time_Start=DTS;
-                                if (Time_End<DTS)
-                                    Time_End=DTS;
+                                TimeCode TC;
+                                TC.FramesPerSecond=(int8u)FrameRate_Int;
+                                TC.FramesPerSecond_Is1001=FrameRate_Is1001;
+                                TC.FromString(Attribute);
+                                if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
+                                    Time_Start=TC;
+                                if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
+                                    Time_End=TC;
                             }
                             if (!div)
                                 div=body_element;
@@ -440,17 +457,24 @@ void File_Ttml::Read_Buffer_Continue()
         }
     }
 
-    if (Time_Start!=(int64u)-1)
+    if (Time_Start!=TimeCode(0xFF, 0xFF, 0xFF, 0xFF, (int8u)FrameRate_Int, FrameRate_Is1001))
     {
-        Fill(Stream_General, 0, General_Duration, (Time_End-Time_Start)/1000000.0);
-        Fill(Stream_Text, 0, Text_Duration, (Time_End-Time_Start)/1000000.0);
-        Fill(Stream_General, 0, General_Duration_Start, Time_Start/1000000.0);
-        Fill(Stream_Text, 0, "Duration_Start", Time_Start/1000000.0);
-        Fill(Stream_General, 0, General_Duration_End, Time_End/1000000.0);
-        Fill(Stream_Text, 0, "Duration_End", Time_End/1000000.0);
+        if (Time_Start.MoreSamples_Frequency)
+        {
+            Time_Start.FramesPerSecond=0;
+            Time_End.FramesPerSecond =0;
+        }
+        Fill(Stream_General, 0, General_Duration, Time_End.ToMilliseconds()-Time_Start.ToMilliseconds());
+        Fill(Stream_Text, 0, Text_Duration, Time_End.ToMilliseconds()-Time_Start.ToMilliseconds());
+        if (!Time_Start.MoreSamples_Frequency)
+            Fill(Stream_Text, 0, Text_Duration_DropFrame, Time_Start.DropFrame?"Yes":"No");
+        Fill(Stream_General, 0, General_Duration_Start, Time_Start.ToMilliseconds());
+        Fill(Stream_Text, 0, Text_Duration_Start, Time_Start.ToMilliseconds());
+        Fill(Stream_General, 0, General_Duration_End, Time_End.ToMilliseconds());
+        Fill(Stream_Text, 0, Text_Duration_End, Time_End.ToMilliseconds());
     }
-    Fill(Stream_Text, 0, Text_FrameRate_Mode, "VFR");
-    Fill(Stream_Text, 0, Text_FrameCount, FrameCount);
+    Fill(Stream_Text, 0, Text_FrameRate_Mode, "CFR");
+    Fill(Stream_Text, 0, Text_Events_Total, FrameCount);
 
     #if MEDIAINFO_DEMUX
         Demux(Buffer, Buffer_Size, ContentType_MainStream);

--- a/Source/MediaInfo/TimeCode.h
+++ b/Source/MediaInfo/TimeCode.h
@@ -27,6 +27,7 @@ public:
     TimeCode ();
     TimeCode (int8u Hours, int8u Minutes, int8u Seconds, int8u Frames, int8u FramesPerSecond, bool DropFrame, bool MustUseSecondField=false, bool IsSecondField=false);
     TimeCode (int64s Frames, int8u FramesPerSecond, bool DropFrame, bool MustUseSecondField=false, bool IsSecondField_=false);
+    TimeCode (const string& Value) {FromString(Value);}
 
     //Operators
     TimeCode &operator ++()
@@ -76,6 +77,9 @@ public:
     }
     void PlusOne();
     void MinusOne();
+    bool FromString(const char* Value, size_t Length); // return false if all fine
+    bool FromString(const char* Value) {return FromString(Value, strlen(Value));}
+    bool FromString(const string& Value) {return FromString(Value.c_str(), Value.size());}
     string ToString();
     int64s ToFrames();
     int64s ToMilliseconds();

--- a/Source/Resource/Text/Stream/Text.csv
+++ b/Source/Resource/Text/Stream/Text.csv
@@ -49,6 +49,7 @@ Duration/String2;;;N NT;;;Play time in format : XXx YYy only, YYy omited if zero
 Duration/String3;;;N NT;;;Play time in format : HH:MM:SS.MMM;
 Duration/String4;;;N NT;;;Play time in format : HH:MM:SS:FF, last colon replaced by semicolon for drop Duration;; ms;N YFY;;;Play time of the stream, in ms;
 Duration/String5;;;N NT;;;Play time in format : HH:MM:SS.mmm (HH:MM:SS:FF)
+Duration_DropFrame;;;N YTY;;;If time is in time code, drop frame info;
 Duration_Start_Command;; ms;N YFY;;;Play time of the stream, in ms;
 Duration_Start_Command/String;;;Y NT;;;Play time (formated);
 Duration_Start_Command/String1;;;N NT;;;Play time in format : HHh MMmn SSs MMMms, XX omited if zero;


### PR DESCRIPTION
Also prepare for hh:mm:ss.zzzzzzzzzSfffffffff style support (used by ADM)