### PR TITLE
TTML: support of timestamps in frames

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -2533,14 +2533,17 @@ void File__Analyze::Duration_Duration123(stream_t StreamKind, size_t StreamPos, 
                 // Testing frame rate (1/1001)
                 if (!DropFrame_IsValid)
                 {
-                    float32 FrameRateF=FrameRateS.To_float32();
                     int32s  FrameRateI=float32_int32s(FrameRateS.To_float32());
-                    float FrameRateF_Min=((float32)FrameRateI)/((float32)1.002);
-                    float FrameRateF_Max=(float32)FrameRateI;
-                    if (FrameRateF>=FrameRateF_Min && FrameRateF<FrameRateF_Max)
-                        DropFrame=true;
-                    else
-                        DropFrame=false;
+                    if (FrameRateI==30) // Flagging drop frame only for 30 DF
+                    {
+                        float32 FrameRateF=FrameRateS.To_float32();
+                        float FrameRateF_Min=((float32)FrameRateI)/((float32)1.002);
+                        float FrameRateF_Max=(float32)FrameRateI;
+                        if (FrameRateF>=FrameRateF_Min && FrameRateF<FrameRateF_Max)
+                            DropFrame=true;
+                        else
+                            DropFrame=false;
+                    }
                 }
 
                 TimeCode TC(FrameCountS.To_int64s(), (int8u)float32_int32s(FrameRateS.To_float32()), DropFrame);

--- a/Source/MediaInfo/Text/File_Ttml.cpp
+++ b/Source/MediaInfo/Text/File_Ttml.cpp
@@ -182,8 +182,8 @@ void File_Ttml::Streams_Accept()
     Stream_Prepare(Stream_Text);
     Fill(Stream_Text, 0, "Format", "TTML");
 
-    Time_Start=TimeCode(0xFF, 0xFF, 0xFF, 0xFF, (int8u)FrameRate_Int, FrameRate_Is1001);
-    Time_End=TimeCode(0, 0, 0, 0, (int8u)FrameRate_Int, FrameRate_Is1001);
+    Time_Start=TimeCode(0xFF, 0xFF, 0xFF, 0xFF, 0, false);
+    Time_End=TimeCode(0, 0, 0, 0, 0, false);
     FrameCount=0;
     LineCount=0;
     FrameRate_Int=0;
@@ -207,12 +207,12 @@ void File_Ttml::Streams_Finish()
         Fill(Stream_Text, 0, Text_FrameRate_Den, FrameRateMultiplier_Den);
     }
 
-    if (Time_Start!=TimeCode(0xFF, 0xFF, 0xFF, 0xFF, (int8u)FrameRate_Int, FrameRate_Is1001))
+    if (Time_Start!=TimeCode(0xFF, 0xFF, 0xFF, 0xFF, 0, false))
     {
         if (Time_Start.MoreSamples_Frequency)
         {
             Time_Start.FramesPerSecond=0;
-            Time_End.FramesPerSecond =0;
+            Time_End.FramesPerSecond=0;
         }
         Fill(Stream_General, 0, General_Duration, Time_End.ToMilliseconds()-Time_Start.ToMilliseconds());
         Fill(Stream_Text, 0, Text_Duration, Time_End.ToMilliseconds()-Time_Start.ToMilliseconds());
@@ -387,22 +387,26 @@ void File_Ttml::Read_Buffer_Continue()
                         TimeCode TC;
                         TC.FramesPerSecond=(int8u)FrameRate_Int;
                         TC.FramesPerSecond_Is1001=FrameRate_Is1001;
-                        TC.FromString(Attribute);
-                        if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
-                            Time_Start=TC;
-                        if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
-                            Time_End=TC;
+                        if (!TC.FromString(Attribute))
+                        {
+                            if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
+                                Time_Start=TC;
+                            if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
+                                Time_End=TC;
+                        }
                     }
                     if (const char* Attribute=body_element->Attribute("end"))
                     {
                         TimeCode TC;
                         TC.FramesPerSecond=(int8u)FrameRate_Int;
                         TC.FramesPerSecond_Is1001=FrameRate_Is1001;
-                        TC.FromString(Attribute);
-                        if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
-                            Time_Start=TC;
-                        if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
-                            Time_End=TC;
+                        if (!TC.FromString(Attribute))
+                        {
+                            if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
+                                Time_Start=TC;
+                            if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
+                                Time_End=TC;
+                        }
                     }
 
                     for (XMLElement* div_element=body_element->FirstChildElement(); div_element; div_element=div_element->NextSiblingElement())
@@ -415,22 +419,26 @@ void File_Ttml::Read_Buffer_Continue()
                                 TimeCode TC;
                                 TC.FramesPerSecond=(int8u)FrameRate_Int;
                                 TC.FramesPerSecond_Is1001=FrameRate_Is1001;
-                                TC.FromString(Attribute);
-                                if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
-                                    Time_Start=TC;
-                                if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
-                                    Time_End=TC;
+                                if (!TC.FromString(Attribute))
+                                {
+                                    if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
+                                        Time_Start=TC;
+                                    if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
+                                        Time_End=TC;
+                                }
                             }
                             if (const char* Attribute=div_element->Attribute("end"))
                             {
                                 TimeCode TC;
                                 TC.FramesPerSecond=(int8u)FrameRate_Int;
                                 TC.FramesPerSecond_Is1001=FrameRate_Is1001;
-                                TC.FromString(Attribute);
-                                if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
-                                    Time_Start=TC;
-                                if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
-                                    Time_End=TC;
+                                if (!TC.FromString(Attribute))
+                                {
+                                    if (Time_Start.ToMilliseconds()>TC.ToMilliseconds())
+                                        Time_Start=TC;
+                                    if (Time_End.ToMilliseconds()<TC.ToMilliseconds())
+                                        Time_End=TC;
+                                }
                             }
                             if (!div)
                                 div=body_element;

--- a/Source/MediaInfo/TimeCode.cpp
+++ b/Source/MediaInfo/TimeCode.cpp
@@ -378,6 +378,38 @@ bool TimeCode::FromString(const char* Value, size_t Length)
         }
         return false;
     }
+    //X.Xf format
+    if (Length>=2
+     && Value[Length-1]=='f')
+    {
+        Length--; //Remove the "f" from the string
+        unsigned char c;
+        int i=0;
+        int32s S=0;
+        int TheoriticalMax=i+PowersOf10_Size;
+        int MaxLength=Length>TheoriticalMax?TheoriticalMax:Length;
+        while (i<MaxLength)
+        {
+            c=(unsigned char)Value[i];
+            c-='0';
+            if (c>9)
+                break;
+            S*=10;
+            S+=c;
+            i++;
+        }
+        if (i!=Length)
+            return true;
+        if (!FramesPerSecond)
+            FramesPerSecond=1; // Arbitrary choosen
+        int32s OneHourInFrames=3600*FramesPerSecond;
+        int32s OneMinuteInFrames=60*FramesPerSecond;
+        Hours=S/OneHourInFrames;
+        Minutes=(S%OneHourInFrames)/OneMinuteInFrames;
+        Seconds=(S%OneMinuteInFrames)/FramesPerSecond;
+        Frames=S%FramesPerSecond;
+        return false;
+    }
 
     return true;
 }


### PR DESCRIPTION
e.g.
``` 
<tt xmlns="http://www.w3.org/ns/ttml"
  xml:lang="en"
  ttp:frameRate="24"
  ttp:frameRateMultiplier="1000 1001">
  <body>
    <div>
      <p begin="24f" end="48f">Hello</p>
    </div>
  </body>
</tt>
```

leads to:
```
Duration                                 : 00:00:01.001 (00:00:01:00)
Start time                               : 00:00:01.001 (00:00:01:00)
End time                                 : 00:00:02.002 (00:00:02:00)
```
