### PR TITLE
XML: does not remove several Format_Profile values except for audio

### DIFF
--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -813,7 +813,7 @@ Ztring MediaInfo_Internal::Inform (stream_t StreamKind, size_t StreamPos, bool I
                             Valeur.erase(SeparatorPos);
                         }
                     }
-                    if ((XML_0_7_78 || JSON) && (Nom==__T("Format_Profile") || Nom==__T("SamplingRate") || Nom==__T("Channel(s)") || Nom==__T("ChannelPositions") || Nom==__T("ChannelLayout")))
+                    if ((XML_0_7_78 || JSON) && StreamKind==Stream_Audio && (Nom==__T("Format_Profile") || Nom==__T("SamplingRate") || Nom==__T("Channel(s)") || Nom==__T("ChannelPositions") || Nom==__T("ChannelLayout")))
                     {
                         size_t SlashPos = Valeur.find(__T(" / "));
                         if (SlashPos!=string::npos)


### PR DESCRIPTION
Due to historical reasons, audio Format_Profile separated by " / " are compatibility profiles e.g. "HE-AACv2 / HE-AAC / AAC", and we don't want to remove the different profiles for other stream kinds because profiles listed are all modern e.g. "SMPTE-TT / EBU-TT / IMSC1" for TTML.