### PR TITLE
DV: fix algorithm for detection non continuous timecode, fix non continuous direction

### DIFF
--- a/Source/MediaInfo/Multiple/File_DvDif.h
+++ b/Source/MediaInfo/Multiple/File_DvDif.h
@@ -272,6 +272,7 @@ protected :
     dvtime Speed_TimeCode_Last;
     dvtime Speed_TimeCode_Current;
     dvtime Speed_TimeCode_Current_Theory;
+    dvtime Speed_TimeCode_Current_Theory2;
     Ztring Speed_TimeCodeZ_First;
     Ztring Speed_TimeCodeZ_Last;
     Ztring Speed_TimeCodeZ_Current;
@@ -283,6 +284,7 @@ protected :
     Ztring Speed_RecTimeZ_Last;
     Ztring Speed_RecTimeZ_Current;
     dvdate Speed_RecDate_Current;
+    dvdate Speed_RecDate_Current_Theory2;
     Ztring Speed_RecDateZ_First;
     Ztring Speed_RecDateZ_Last;
     Ztring Speed_RecDateZ_Current;


### PR DESCRIPTION
There were some incoherencies in the algo for detecting rec date/time or timecode lesser than the previous value (so in DVRescue ` rdt_nc="2"` of ` tc_nc="2"`).

There were some incoherencies with repeated time codes e.g.
00:00:00:00
00:00:00:00 --> ` tc_r="1"`
00:00:00:01 --> ` tc_nc="1"`
(it was previously expecting 00:00:00:02 only, as if the previous time code was wrong, now supporting "wrong" time code and also the increment as if the previous frame was not repeated)

cc @dericed.
