### PR TITLE
TimeCode: handling of some corner cases

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
@@ -59,8 +59,15 @@ void File_Mpeg4_TimeCode::Streams_Fill()
         float64 FrameRate_WithDF=NumberOfFrames;
         if (DropFrame)
         {
+            int FramesToRemove=0;
+            int NumberOfFramesMultiplier=0;
+            while (NumberOfFrames>NumberOfFramesMultiplier)
+            {
+                FramesToRemove+=108;
+                NumberOfFramesMultiplier+=30;
+            }
             float64 FramesPerHour_NDF=FrameRate_WithDF*60*60;
-            FrameRate_WithDF*=(FramesPerHour_NDF-108)/FramesPerHour_NDF;
+            FrameRate_WithDF*=(FramesPerHour_NDF-FramesToRemove)/FramesPerHour_NDF;
         }
 
         Fill(Stream_General, 0, "Delay", Pos_Temp*1000/FrameRate_WithDF, 0);

--- a/Source/MediaInfo/TimeCode.h
+++ b/Source/MediaInfo/TimeCode.h
@@ -32,6 +32,24 @@ public:
     TimeCode(const string& Value) { *this = TimeCode(Value.c_str(), Value.size()); }
 
     //Operators
+    TimeCode& operator +=(const TimeCode& b)
+    {
+        return operator+=(b.ToFrames());
+    }
+    TimeCode& operator +=(const int64s Frames)
+    {
+        FromFrames(ToFrames()+Frames);
+        return *this;
+    }
+    TimeCode& operator -=(const TimeCode& b)
+    {
+        return operator-=(b.ToFrames());
+    }
+    TimeCode& operator -=(const int64s)
+    {
+        FromFrames(ToFrames()-Frames);
+        return *this;
+    }
     TimeCode &operator ++()
     {
         PlusOne();
@@ -51,6 +69,26 @@ public:
     {
         MinusOne();
         return *this;
+    }
+    friend TimeCode operator +(TimeCode a, const TimeCode& b)
+    {
+        a+=b;
+        return a;
+    }
+    friend TimeCode operator +(TimeCode a, const int64s b)
+    {
+        a+=b;
+        return a;
+    }
+    friend TimeCode operator -(TimeCode a, const TimeCode& b)
+    {
+        a-=b;
+        return a;
+    }
+    friend TimeCode operator -(TimeCode a, const int64s b)
+    {
+        a-=b;
+        return a;
     }
     bool operator== (const TimeCode &tc) const
     {
@@ -82,9 +120,10 @@ public:
     bool FromString(const char* Value, size_t Length); // return false if all fine
     bool FromString(const char* Value) {return FromString(Value, strlen(Value));}
     bool FromString(const string& Value) {return FromString(Value.c_str(), Value.size());}
-    string ToString();
-    int64s ToFrames();
-    int64s ToMilliseconds();
+    bool FromFrames(int64s Value);
+    string ToString() const;
+    int64s ToFrames() const;
+    int64s ToMilliseconds() const;
 
 public:
     int8u Hours;


### PR DESCRIPTION
There are some files with weird config e.g. 25 fps with drop frame time code, trying to have a more coherent output in such cases