### PR TITLE
MXF: time code of last frame (MXF TC only), fix

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -4212,11 +4212,14 @@ void File_Mxf::Streams_Finish_Component_ForTimeCode(const int128u ComponentUID, 
             if (Component2->second.MxfTimeCode.RoundedTimecodeBase<=(int8u)-1) // Found files with RoundedTimecodeBase of 0x8000
                 Fill(Stream_Other, StreamPos_Last, Other_FrameRate, Component2->second.MxfTimeCode.RoundedTimecodeBase/(Component2->second.MxfTimeCode.DropFrame?1.001:1.000));
             Fill(Stream_Other, StreamPos_Last, Other_TimeCode_FirstFrame, TC.ToString().c_str());
-            Fill(Stream_Other, StreamPos_Last, Other_FrameCount, Component2->second.Duration);
-            if (TC.FramesPerSecond && Component2->second.Duration)
+            if (Component2->second.Duration && Component2->second.Duration!=(int64u)-1)
             {
-                TC+=Component2->second.Duration-1;
-                Fill(Stream_Other, StreamPos_Last, Other_TimeCode_LastFrame, TC.ToString().c_str());
+                Fill(Stream_Other, StreamPos_Last, Other_FrameCount, Component2->second.Duration);
+                if (TC.FramesPerSecond)
+                {
+                    TC+=Component2->second.Duration-1;
+                    Fill(Stream_Other, StreamPos_Last, Other_TimeCode_LastFrame, TC.ToString().c_str());
+                }
             }
             Fill(Stream_Other, StreamPos_Last, Other_TimeCode_Settings, IsSourcePackage?__T("Source Package"):__T("Material Package"));
             Fill(Stream_Other, StreamPos_Last, Other_TimeCode_Striped, "Yes");


### PR DESCRIPTION
Fix of https://github.com/MediaArea/MediaInfoLib/pull/1520 for unknown durations