### PR TITLE
TTML: Support of more timeExpression flavors

### DIFF
--- a/Source/MediaInfo/Audio/File_Ac3.h
+++ b/Source/MediaInfo/Audio/File_Ac3.h
@@ -188,6 +188,7 @@ private :
     bool   IgnoreCrc_Done;
     bool   IgnoreCrc;
     TimeCode TimeStamp_FirstFrame;
+    int16u   TimeStamp_FirstFrame_SampleNumber;
     size_t TimeStamp_Count;
 };
 

--- a/Source/MediaInfo/Audio/File_DolbyAudioMetadata.cpp
+++ b/Source/MediaInfo/Audio/File_DolbyAudioMetadata.cpp
@@ -320,15 +320,18 @@ void File_DolbyAudioMetadata::Dolby_Atmos_Metadata_Segment()
             TimeCode TC;
             if (((int8s)first_action_time_HH)<0)
             {
-                TC.IsNegative=true;
-                TC.Hours=-((int8s)first_action_time_HH);
+                TC.SetNegative();
+                TC.SetHours(-((int8s)first_action_time_HH));
             }
             else
-                TC.Hours=first_action_time_HH;
-            TC.Minutes=first_action_time_MM;
-            TC.Seconds=first_action_time_SS/100000;
-            TC.MoreSamples_Frequency=100000;
-            TC.MoreSamples=first_action_time_SS%100000;
+                TC.SetHours(first_action_time_HH);
+            const int32u FrameRate=100000;
+            TC.SetMinutes(first_action_time_MM);
+            TC.SetSeconds(first_action_time_SS/FrameRate);
+            TC.SetFrames(first_action_time_SS%FrameRate);
+            TC.SetFramesMax(FrameRate-1);
+            TC.SetIsTime();
+            TC.SetIsValid();
             Fill(Stream_Audio, 0, "Dolby_Atmos_Metadata FirstFrameOfAction", TC.ToString());
             Fill_SetOptions(Stream_Audio, 0, "Dolby_Atmos_Metadata FirstFrameOfAction", "Y NTY");
         }

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -2613,8 +2613,8 @@ void File__Analyze::Duration_Duration123(stream_t StreamKind, size_t StreamPos, 
                     }
                 }
 
-                TimeCode TC(FrameCountS.To_int64s(), (int8u)float32_int32s(FrameRateS.To_float32()), DropFrame && FrameRateI!=FrameRateF);
-                TC.DropFrame=DropFrame;
+                TimeCode TC(FrameCountS.To_int64s(), (int32u)float32_int32s(FrameRateS.To_float32()-1), DropFrame && FrameRateI!=FrameRateF);
+                TC.SetDropFrame(DropFrame);
                 DurationString4.From_UTF8(TC.ToString());
 
                 Fill(StreamKind, StreamPos, Parameter+5, DurationString4); // /String4

--- a/Source/MediaInfo/MediaInfo_Events_Internal.h
+++ b/Source/MediaInfo/MediaInfo_Events_Internal.h
@@ -145,25 +145,25 @@ namespace MediaInfoLib
 
     inline void Events_TimeCode(const TimeCode &Tc, MediaInfo_time_code &Event_TimeCode, char* Event_TimeCode_HR)
     {
-        if (Tc.IsValid())
+        if (Tc.HasValue())
         {
-            Event_TimeCode.Hours=Tc.Hours;
-            Event_TimeCode.Minutes=Tc.Minutes;
-            Event_TimeCode.Seconds=Tc.Seconds;
-            Event_TimeCode.Frames=Tc.Frames;
-            Event_TimeCode.FramesPerSecond=Tc.FramesPerSecond;
-            Event_TimeCode.DropFrame=Tc.DropFrame;
-            Event_TimeCode_HR[ 0]='0'+Tc.Hours/10;
-            Event_TimeCode_HR[ 1]='0'+Tc.Hours%10;
+            Event_TimeCode.Hours=Tc.GetHours();
+            Event_TimeCode.Minutes=Tc.GetMinutes();
+            Event_TimeCode.Seconds=Tc.GetSeconds();
+            Event_TimeCode.Frames=Tc.GetFrames();
+            Event_TimeCode.FramesPerSecond=Tc.GetFramesMax()+1;
+            Event_TimeCode.DropFrame=Tc.GetDropFrame();
+            Event_TimeCode_HR[ 0]='0'+Tc.GetHours()/10;
+            Event_TimeCode_HR[ 1]='0'+Tc.GetHours() %10;
             Event_TimeCode_HR[ 2]=':';
-            Event_TimeCode_HR[ 3]='0'+Tc.Minutes/10;
-            Event_TimeCode_HR[ 4]='0'+Tc.Minutes%10;
+            Event_TimeCode_HR[ 3]='0'+Tc.GetMinutes()/10;
+            Event_TimeCode_HR[ 4]='0'+Tc.GetMinutes()%10;
             Event_TimeCode_HR[ 5]=':';
-            Event_TimeCode_HR[ 6]='0'+Tc.Seconds/10;
-            Event_TimeCode_HR[ 7]='0'+Tc.Seconds%10;
-            Event_TimeCode_HR[ 8]=Tc.DropFrame?';':':';
-            Event_TimeCode_HR[ 9]='0'+Tc.Frames/10;
-            Event_TimeCode_HR[10]='0'+Tc.Frames%10;
+            Event_TimeCode_HR[ 6]='0'+Tc.GetSeconds()/10;
+            Event_TimeCode_HR[ 7]='0'+Tc.GetSeconds()%10;
+            Event_TimeCode_HR[ 8]=Tc.GetFramesMax()?';':':';
+            Event_TimeCode_HR[ 9]='0'+Tc.GetFrames()/10;
+            Event_TimeCode_HR[10]='0'+Tc.GetFrames()%10;
             Event_TimeCode_HR[11]='\0';
             Event_TimeCode_HR[12]='\0';
         }

--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -511,10 +511,10 @@ void File_DvDif::Streams_Fill()
         Fill(Stream_Video, 0, Video_BitRate_Mode, "CBR");
 
     //Delay
-    TimeCode_FirstFrame.FramesPerSecond=(system?25:30);
+    TimeCode_FirstFrame.SetFramesMax(system?24:29);
     if (FrameRate_Multiplicator>=2)
-        TimeCode_FirstFrame.MustUseSecondField=true;
-    if (TimeCode_FirstFrame.IsValid())
+        TimeCode_FirstFrame.SetMustUseSecondField();
+    if (TimeCode_FirstFrame.HasValue())
     {
         string TimeCode_FirstFrame_String=TimeCode_FirstFrame.ToString();
         int64u TimeCode_FirstFrame_ms=TimeCode_FirstFrame.ToMilliseconds();

--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -1007,7 +1007,7 @@ void File_DvDif::Errors_Stats_Update()
             Errors_Stats_Line+=__T("XX:XX:XX:XX");
             #if MEDIAINFO_EVENTS
                 Event.TimeCode|=0x7FFFF<<8;
-                //Event.TimeCode|=Speed_TimeCode_Current.Time.DropFrame<<7;
+                //Event.TimeCode|=Speed_TimeCode_Current.Time.DropFrame()<<7;
                 Event.TimeCode|=0x3F;
             #endif //MEDIAINFO_EVENTS
         }

--- a/Source/MediaInfo/Multiple/File_Gxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Gxf.cpp
@@ -1261,13 +1261,7 @@ void File_Gxf::map()
                     TimeCodes[TrackID].Milliseconds=Hours  *60*60*1000
                                                    +Minutes   *60*1000
                                                    +Seconds      *1000;
-                    MediaInfoLib::TimeCode TC;
-                    TC.Hours=Hours;
-                    TC.Minutes=Minutes;
-                    TC.Seconds=Seconds;
-                    TC.Frames=Fields/2;
-                    TC.DropFrame=DropFrame;
-                    TimeCodes[TrackID].String=TC.ToString();
+                    TimeCodes[TrackID].String= MediaInfoLib::TimeCode(Hours, Minutes, Seconds, Fields/2, 0, DropFrame, false, Fields%2).ToString();
 
                     if (!FrameRate)
                     {

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -3175,7 +3175,7 @@ void File_Mpeg4::IsParsing_mdat_Set()
                                              (TimeCode_String[ 3]-'0') * 10 + (TimeCode_String[ 4]-'0'),
                                              (TimeCode_String[ 6]-'0') * 10 + (TimeCode_String[ 7]-'0'),
                                              (TimeCode_String[ 9]-'0') * 10 + (TimeCode_String[10]-'0'),
-                                             tc->NumberOfFrames,
+                                             tc->NumberOfFrames-1,
                                               TimeCode_String[ 8]==';').ToFrames();
 
             

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
@@ -75,7 +75,7 @@ void File_Mpeg4_TimeCode::Streams_Fill()
 
         Fill(Stream_General, 0, "Delay", Pos_Temp*1000/FrameRate_WithDF, 0);
 
-        TimeCode TC(Pos_Temp, NumberOfFrames, DropFrame);
+        TimeCode TC(Pos_Temp, NumberOfFrames-1, DropFrame);
         Stream_Prepare(Stream_Other);
         Fill(Stream_Other, StreamPos_Last, Other_Type, "Time code");
         Fill(Stream_Other, StreamPos_Last, Other_TimeCode_FirstFrame, TC.ToString().c_str());

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -2515,7 +2515,7 @@ void File_Mxf::Streams_Finish()
     Fill(Stream_General, 0, General_Format_Profile, Mxf_OperationalPattern(OperationalPattern));
 
     //Time codes
-    if (SDTI_TimeCode_StartTimecode.IsValid())
+    if (SDTI_TimeCode_StartTimecode.HasValue())
     {
         bool IsDuplicate=false;
         for (size_t Pos2=0; Pos2<Count_Get(Stream_Other); Pos2++)
@@ -2529,7 +2529,7 @@ void File_Mxf::Streams_Finish()
             Fill(Stream_Other, StreamPos_Last, Other_Format, "SMPTE TC");
             Fill(Stream_Other, StreamPos_Last, Other_MuxingMode, "SDTI");
             Fill(Stream_Other, StreamPos_Last, Other_TimeCode_FirstFrame, SDTI_TimeCode_StartTimecode.ToString());
-            Fill(Stream_Other, StreamPos_Last, Other_FrameRate, SDTI_TimeCode_StartTimecode.FramesPerSecond/(SDTI_TimeCode_StartTimecode.DropFrame?1.001:1.000)*(SDTI_TimeCode_StartTimecode.MustUseSecondField?2:1));
+            Fill(Stream_Other, StreamPos_Last, Other_FrameRate, SDTI_TimeCode_StartTimecode.GetFrameRate());
         }
     }
     if (SystemScheme1_TimeCodeArray_StartTimecode.HasValue())
@@ -3034,7 +3034,7 @@ void File_Mxf::Streams_Finish_Essence(int32u EssenceUID, int128u TrackUID)
         //Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_TimeCode_FirstFrame), TC.ToString().c_str());
         //Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_TimeCode_Source), "Time code track (stripped)");
     }
-    if (SDTI_TimeCode_StartTimecode.IsValid())
+    if (SDTI_TimeCode_StartTimecode.HasValue())
     {
         Fill(StreamKind_Last, StreamPos_Last, "Delay_SDTI", SDTI_TimeCode_StartTimecode.ToMilliseconds());
         if (StreamKind_Last!=Stream_Max)
@@ -4190,14 +4190,14 @@ void File_Mxf::Streams_Finish_Component_ForTimeCode(const int128u ComponentUID, 
         if (Component2!=Components.end() && Component2->second.MxfTimeCode.StartTimecode!=(int64u)-1 && !Config->File_IsReferenced_Get())
         {
             //Note: Origin is not part of the StartTimecode for the first frame in the source package. From specs: "For a Timecode Track with a single Timecode Component and with origin N, where N greater than 0, the timecode value at the Zero Point of the Track equals the start timecode of the Timecode Component incremented by N units."
-            TimeCode TC(Component2->second.MxfTimeCode.StartTimecode+Config->File_IgnoreEditsBefore, (int8u)Component2->second.MxfTimeCode.RoundedTimecodeBase, Component2->second.MxfTimeCode.DropFrame);
+            TimeCode TC=Component2->second.MxfTimeCode.RoundedTimecodeBase<0x8000?TimeCode(Component2->second.MxfTimeCode.StartTimecode+Config->File_IgnoreEditsBefore, Component2->second.MxfTimeCode.RoundedTimecodeBase-1, Component2->second.MxfTimeCode.DropFrame):TimeCode();
             bool IsHybridTimeCode=false;
             if (Component->second.StructuralComponents.size()==2 && !Pos)
             {
                 components::iterator Component_TC2=Components.find(Component->second.StructuralComponents[1]);
                 if (Component_TC2!=Components.end() && Component_TC2->second.MxfTimeCode.StartTimecode!=(int64u)-1)
                 {
-                    TimeCode TC2(Component_TC2->second.MxfTimeCode.StartTimecode+Config->File_IgnoreEditsBefore, (int8u)Component_TC2->second.MxfTimeCode.RoundedTimecodeBase, Component2->second.MxfTimeCode.DropFrame);
+                    TimeCode TC2=Component_TC2->second.MxfTimeCode.RoundedTimecodeBase<0x8000?TimeCode(Component_TC2->second.MxfTimeCode.StartTimecode+Config->File_IgnoreEditsBefore, Component_TC2->second.MxfTimeCode.RoundedTimecodeBase-1, Component2->second.MxfTimeCode.DropFrame):TimeCode();
                     if (TC2.ToFrames()-TC.ToFrames()==2)
                     {
                         TC++;
@@ -4215,7 +4215,7 @@ void File_Mxf::Streams_Finish_Component_ForTimeCode(const int128u ComponentUID, 
             if (Component2->second.Duration && Component2->second.Duration!=(int64u)-1)
             {
                 Fill(Stream_Other, StreamPos_Last, Other_FrameCount, Component2->second.Duration);
-                if (TC.FramesPerSecond)
+                if (TC.GetFramesMax())
                 {
                     TC+=Component2->second.Duration-1;
                     Fill(Stream_Other, StreamPos_Last, Other_TimeCode_LastFrame, TC.ToString().c_str());
@@ -4366,14 +4366,14 @@ void File_Mxf::Streams_Finish_Component_ForAS11(const int128u ComponentUID, floa
                                                     if (AS11->second.PartNumber!=(int16u)-1 && AS11->second.PartTotal!=(int16u)-1)
                                                     {
                                                         string S;
-                                                        S+=TimeCode(TC_Temp+Duration_CurrentPos, FrameRate_TempI, DropFrame_Temp).ToString();
+                                                        S+=TimeCode(TC_Temp+Duration_CurrentPos, FrameRate_TempI-1, DropFrame_Temp).ToString();
                                                         if (DMSegment->second.Duration!=(int64u)-1)
                                                         {
                                                             S+=" + ";
-                                                            S+=TimeCode(DMSegment->second.Duration, FrameRate_TempI, DropFrame_Temp).ToString();
+                                                            S+=TimeCode(DMSegment->second.Duration, FrameRate_TempI-1, DropFrame_Temp).ToString();
                                                             S+=" = ";
                                                             Duration_CurrentPos+=DMSegment->second.Duration;
-                                                            S+=TimeCode(TC_Temp+Duration_CurrentPos, FrameRate_TempI, DropFrame_Temp).ToString();
+                                                            S+=TimeCode(TC_Temp+Duration_CurrentPos, FrameRate_TempI-1, DropFrame_Temp).ToString();
                                                             Duration_Programme+=DMSegment->second.Duration;
                                                         }
                                                         Fill(Stream_Other, StreamPos_Last, Ztring::ToZtring(AS11->second.PartNumber).To_UTF8().c_str(), S);
@@ -4411,13 +4411,13 @@ void File_Mxf::Streams_Finish_Component_ForAS11(const int128u ComponentUID, floa
                                                         Fill(Stream_Other, StreamPos_Last, "AudioLoudnessStandard", Mxf_AS11_AudioLoudnessStandard[AS11->second.AudioLoudnessStandard]);
                                                     Fill(Stream_Other, StreamPos_Last, "AudioComments", AS11->second.AudioComments);
                                                     if (AS11->second.LineUpStart!=(int64u)-1)
-                                                        Fill(Stream_Other, StreamPos_Last, "LineUpStart", Ztring().From_UTF8(TimeCode(TC_Temp+AS11->second.LineUpStart, FrameRate_TempI, DropFrame_Temp).ToString()));
+                                                        Fill(Stream_Other, StreamPos_Last, "LineUpStart", Ztring().From_UTF8(TimeCode(TC_Temp+AS11->second.LineUpStart, FrameRate_TempI-1, DropFrame_Temp).ToString()));
                                                     if (AS11->second.IdentClockStart!=(int64u)-1)
-                                                        Fill(Stream_Other, StreamPos_Last, "IdentClockStart", Ztring().From_UTF8(TimeCode(TC_Temp+AS11->second.IdentClockStart, FrameRate_TempI, DropFrame_Temp).ToString()));
+                                                        Fill(Stream_Other, StreamPos_Last, "IdentClockStart", Ztring().From_UTF8(TimeCode(TC_Temp+AS11->second.IdentClockStart, FrameRate_TempI-1, DropFrame_Temp).ToString()));
                                                     if (AS11->second.TotalNumberOfParts!=(int16u)-1)
                                                         Fill(Stream_Other, StreamPos_Last, "TotalNumberOfParts", AS11->second.TotalNumberOfParts);
                                                     if (AS11->second.TotalProgrammeDuration!=(int64u)-1)
-                                                        Fill(Stream_Other, StreamPos_Last, "TotalProgrammeDuration", Ztring().From_UTF8(TimeCode(AS11->second.TotalProgrammeDuration, FrameRate_TempI, DropFrame_Temp).ToString()));
+                                                        Fill(Stream_Other, StreamPos_Last, "TotalProgrammeDuration", Ztring().From_UTF8(TimeCode(AS11->second.TotalProgrammeDuration, FrameRate_TempI-1, DropFrame_Temp).ToString()));
                                                     if (AS11->second.AudioDescriptionPresent!=(int8u)-1)
                                                         Fill(Stream_Other, StreamPos_Last, "AudioDescriptionPresent", AS11->second.AudioDescriptionPresent?__T("Yes"):__T("No"));
                                                     if (AS11->second.AudioDescriptionType<Mxf_AS11_AudioDescriptionType_Count)
@@ -4449,7 +4449,7 @@ void File_Mxf::Streams_Finish_Component_ForAS11(const int128u ComponentUID, floa
         }
     }
     if (Duration_Programme)
-        Fill(Stream_Other, StreamPos_Last, "TotalProgrammeDuration", TimeCode(Duration_Programme, FrameRate_TempI, DropFrame_Temp).ToString());
+        Fill(Stream_Other, StreamPos_Last, "TotalProgrammeDuration", TimeCode(Duration_Programme, FrameRate_TempI-1, DropFrame_Temp).ToString());
 }
 
 //---------------------------------------------------------------------------
@@ -8780,23 +8780,19 @@ void File_Mxf::SDTI_SystemMetadataPack() //SMPTE 385M + 326M
     Skip_B2(                                                    "continuity count");
 
     //Some computing
-    int8u  FrameRate;
+    static int8u FrameRates_List[3] = { 24, 25, 30 };
+    int8u  FramesMax;
     int8u  RepetitionMaxCount;
-    switch (CPR_Rate) //See SMPTE 326M
+    if (CPR_Rate && CPR_Rate<=0x0C) //See SMPTE 326M)
     {
-        case 0x01 : FrameRate=24;  RepetitionMaxCount=0; break;
-        case 0x02 : FrameRate=25;  RepetitionMaxCount=0; break;
-        case 0x03 : FrameRate=30;  RepetitionMaxCount=0; break;
-        case 0x04 : FrameRate=48;  RepetitionMaxCount=1; break;
-        case 0x05 : FrameRate=50;  RepetitionMaxCount=1; break;
-        case 0x06 : FrameRate=60;  RepetitionMaxCount=1; break;
-        case 0x07 : FrameRate=72;  RepetitionMaxCount=2; break;
-        case 0x08 : FrameRate=75;  RepetitionMaxCount=2; break;
-        case 0x09 : FrameRate=90;  RepetitionMaxCount=2; break;
-        case 0x0A : FrameRate=96;  RepetitionMaxCount=3; break;
-        case 0x0B : FrameRate=100; RepetitionMaxCount=3; break;
-        case 0x0C : FrameRate=120; RepetitionMaxCount=3; break;
-        default   : FrameRate=0;   RepetitionMaxCount=0; break;
+        CPR_Rate--;
+        RepetitionMaxCount=CPR_Rate/3;
+        FramesMax=FrameRates_List[CPR_Rate%3]*(RepetitionMaxCount+1)-1;
+    }
+    else
+    {
+        FramesMax=0;
+        RepetitionMaxCount=0;
     }
 
     //Parsing
@@ -8854,22 +8850,21 @@ void File_Mxf::SDTI_SystemMetadataPack() //SMPTE 385M + 326M
         TimeCode TimeCode_Current(  Hours_Tens  *10+Hours_Units,
                                     Minutes_Tens*10+Minutes_Units,
                                     Seconds_Tens*10+Seconds_Units,
-                                    Frames_Tens *10+Frames_Units,
-                                    FrameRate/(RepetitionMaxCount+1),
-                                    DropFrame,
-                                    RepetitionMaxCount?true:false);
+                                    (Frames_Tens *10+Frames_Units)*(RepetitionMaxCount+1),
+                                    FramesMax,
+                                    DropFrame);
         if (RepetitionMaxCount)
         {
-            if (SDTI_TimeCode_Previous.IsValid() && TimeCode_Current==SDTI_TimeCode_Previous)
+            if (SDTI_TimeCode_Previous.HasValue() && TimeCode_Current==SDTI_TimeCode_Previous)
             {
                 SDTI_TimeCode_RepetitionCount++;
                 TimeCode_Current++;
-                if (!SDTI_TimeCode_StartTimecode.IsValid() && SDTI_TimeCode_RepetitionCount>=RepetitionMaxCount)
+                if (!SDTI_TimeCode_StartTimecode.HasValue() && SDTI_TimeCode_RepetitionCount>=RepetitionMaxCount)
                     SDTI_TimeCode_StartTimecode=SDTI_TimeCode_Previous; //The first time code was the first one of the repetition sequence
             }
             else
             {
-                if (!SDTI_TimeCode_StartTimecode.IsValid() && SDTI_TimeCode_Previous.IsValid())
+                if (!SDTI_TimeCode_StartTimecode.HasValue() && SDTI_TimeCode_Previous.HasValue())
                 {
                     SDTI_TimeCode_StartTimecode=SDTI_TimeCode_Previous;
                     while(SDTI_TimeCode_RepetitionCount<RepetitionMaxCount)
@@ -8882,7 +8877,7 @@ void File_Mxf::SDTI_SystemMetadataPack() //SMPTE 385M + 326M
                 SDTI_TimeCode_Previous=TimeCode_Current;
             }
         }
-        else if (!SDTI_TimeCode_StartTimecode.IsValid())
+        else if (!SDTI_TimeCode_StartTimecode.HasValue())
             SDTI_TimeCode_StartTimecode=TimeCode_Current;
 
         Element_Info1(Ztring().From_UTF8(TimeCode_Current.ToString().c_str()));

--- a/Source/MediaInfo/Text/File_Ttml.cpp
+++ b/Source/MediaInfo/Text/File_Ttml.cpp
@@ -22,8 +22,8 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/Text/File_Ttml.h"
+#include "MediaInfo/MediaInfo_Config_MediaInfo.h"
 #if MEDIAINFO_EVENTS
-    #include "MediaInfo/MediaInfo_Config_MediaInfo.h"
     #include "MediaInfo/MediaInfo_Events_Internal.h"
 #endif //MEDIAINFO_EVENTS
 #include "tinyxml2.h"
@@ -182,8 +182,6 @@ void File_Ttml::Streams_Accept()
     Stream_Prepare(Stream_Text);
     Fill(Stream_Text, 0, "Format", "TTML");
 
-    Time_Begin=TimeCode(0xFF, 0xFF, 0xFF, 0xFF, 0, false);
-    Time_End=TimeCode(0, 0, 0, 0, 0, false);
     FrameCount=0;
     LineCount=0;
     LineMaxCountPerEvent=0;
@@ -209,13 +207,13 @@ void File_Ttml::Streams_Finish()
         Fill(Stream_Text, 0, Text_FrameRate_Den, FrameRateMultiplier_Den);
     }
 
-    if (Time_Begin!=TimeCode(0xFF, 0xFF, 0xFF, 0xFF, 0, false))
+    if (Time_End.HasValue() && Time_Begin.HasValue())
     {
         Fill(Stream_General, 0, General_Duration, Time_End.ToMilliseconds()-Time_Begin.ToMilliseconds());
         Fill(Stream_Text, 0, Text_Duration, Time_End.ToMilliseconds()-Time_Begin.ToMilliseconds());
-        if (!Time_Begin.MoreSamples_Frequency)
+        if (!Time_Begin.GetIsTime())
             Fill(Stream_Text, 0, Text_TimeCode_FirstFrame, Time_Begin.ToString());
-        if (!Time_End.MoreSamples_Frequency && Time_End.FramesPerSecond)
+        if (!Time_End.GetIsTime() && Time_End>Time_Begin)
         {
             TimeCode LastFrame=Time_End;
             LastFrame--;
@@ -347,6 +345,25 @@ void File_Ttml::Read_Buffer_Continue()
             FrameRateMultiplier_Den=atoi(Tt_Attribute_Space+1);
         }
     }
+    Tt_Attribute=Root->Attribute("ttp:tickRate");
+    if (Tt_Attribute)
+        tickRate=atoi(Tt_Attribute);
+    if (!FrameRate_Int && !tickRate)
+    {
+        #if MEDIAINFO_ADVANCED
+            float64 FrameRate_F=Video_FrameRate_Rounded(Config->File_DefaultFrameRate_Get());
+            if (!FrameRate_F)
+                FrameRate_F=30/1.001;
+        #else //MEDIAINFO_ADVANCED
+            const float64 FrameRate_F=30/1.001;
+        #endif //MEDIAINFO_ADVANCED
+        FrameRate_Int=float64_int64s(FrameRate_F);
+        if (FrameRate_Int != FrameRate_F)
+        {
+            FrameRateMultiplier_Num=1000;
+            FrameRateMultiplier_Den=float64_int64s(FrameRate_Int/FrameRate_F*1000);
+        }
+    }
     if (FrameRate_Int && FrameRateMultiplier_Num && FrameRateMultiplier_Den)
     {
         FrameRate=((float64)FrameRate_Int)*FrameRateMultiplier_Num/FrameRateMultiplier_Den;
@@ -368,9 +385,6 @@ void File_Ttml::Read_Buffer_Continue()
     {
         Fill(Stream_Text, 0, "Duration_Base", Tt_Attribute);
     }
-    Tt_Attribute=Root->Attribute("ttp:tickRate");
-    if (Tt_Attribute)
-        tickRate=atoi(Tt_Attribute);
     for (const XMLAttribute* tt_attribute=Root->FirstAttribute(); tt_attribute; tt_attribute=tt_attribute->Next())
     {
         if (strstr(tt_attribute->Name(), "smpte"))
@@ -415,37 +429,48 @@ void File_Ttml::Read_Buffer_Continue()
         //body
         if (!strcmp(tt_element->Value(), "body"))
         {
+            TimeCode Time_Template;
+            Time_Template.SetFramesMax((int32u)(FrameRate_Int?(FrameRate_Int-1):(tickRate?(tickRate-1):0)));
+            Time_Template.Set1001(FrameRate_Is1001);
+
             for (XMLElement* body_element=tt_element->FirstChildElement(); body_element; body_element=body_element->NextSiblingElement())
             {
                 //div
                 if (!strcmp(body_element->Value(), "div"))
                 {
-                    TimeCode Time_Begin_New(0xFF, 0xFF, 0xFF, 0xFF, 0, false);
-                    TimeCode Time_End_New(0, 0, 0, 0, 0, false);
+                    TimeCode Time_Begin_New=Time_Template;
+                    TimeCode Time_End_New=Time_Template;
 
                     if (const char* Attribute=body_element->Attribute("begin"))
                     {
-                        Time_Begin_New.FramesPerSecond=(int8u)FrameRate_Int;
-                        Time_Begin_New.FramesPerSecond_Is1001=FrameRate_Is1001;
-                        Time_Begin_New.MoreSamples_Frequency=tickRate;
                         if (!Time_Begin_New.FromString(Attribute))
                         {
-                            if (Time_Begin.ToMilliseconds()>Time_Begin_New.ToMilliseconds())
+                            if (!Time_Begin.HasValue() || Time_Begin>Time_Begin_New)
                                 Time_Begin=Time_Begin_New;
-                            if (Time_End.ToMilliseconds()<Time_Begin_New.ToMilliseconds())
+                            if (!Time_End.HasValue() || Time_End<Time_Begin_New)
                                 Time_End=Time_Begin_New;
                         }
                     }
                     if (const char* Attribute=body_element->Attribute("end"))
                     {
-                        Time_End_New.FramesPerSecond=(int8u)FrameRate_Int;
-                        Time_End_New.FramesPerSecond_Is1001=FrameRate_Is1001;
-                        Time_End_New.MoreSamples_Frequency=tickRate;
                         if (!Time_End_New.FromString(Attribute))
                         {
-                            if (Time_Begin.ToMilliseconds()>Time_End_New.ToMilliseconds())
+                            if (!Time_Begin.HasValue() || Time_Begin>Time_End_New)
                                 Time_Begin=Time_End_New;
-                            if (Time_End.ToMilliseconds()<Time_End_New.ToMilliseconds())
+                            if (!Time_End.HasValue() || Time_End<Time_End_New)
+                                Time_End=Time_End_New;
+                        }
+                    }
+                    if (const char* Attribute=body_element->Attribute("dur"))
+                    {
+                        TimeCode Time_Dur_New=Time_Template;
+                        if (Time_Begin.HasValue() && !Time_Dur_New.FromString(Attribute))
+                        {
+                            Time_End_New=Time_Begin_New;
+                            Time_End_New+=Time_Dur_New;
+                            if (!Time_Begin.HasValue() || Time_Begin>Time_End_New)
+                                Time_Begin=Time_End_New;
+                            if (!Time_End.HasValue() || Time_End<Time_End_New)
                                 Time_End=Time_End_New;
                         }
                     }
@@ -457,27 +482,34 @@ void File_Ttml::Read_Buffer_Continue()
                         {
                             if (const char* Attribute=div_element->Attribute("begin"))
                             {
-                                Time_Begin_New.FramesPerSecond=(int8u)FrameRate_Int;
-                                Time_Begin_New.FramesPerSecond_Is1001=FrameRate_Is1001;
-                                Time_Begin_New.MoreSamples_Frequency=tickRate;
                                 if (!Time_Begin_New.FromString(Attribute))
                                 {
-                                    if (Time_Begin.ToMilliseconds()>Time_Begin_New.ToMilliseconds())
+                                    if (!Time_Begin.HasValue() || Time_Begin>Time_Begin_New)
                                         Time_Begin=Time_Begin_New;
-                                    if (Time_End.ToMilliseconds()<Time_Begin_New.ToMilliseconds())
+                                    if (!Time_End.HasValue() || Time_End<Time_Begin_New)
                                         Time_End=Time_Begin_New;
                                 }
                             }
                             if (const char* Attribute=div_element->Attribute("end"))
                             {
-                                Time_End_New.FramesPerSecond=(int8u)FrameRate_Int;
-                                Time_End_New.FramesPerSecond_Is1001=FrameRate_Is1001;
-                                Time_End_New.MoreSamples_Frequency=tickRate;
                                 if (!Time_End_New.FromString(Attribute))
                                 {
-                                    if (Time_Begin.ToMilliseconds()>Time_End_New.ToMilliseconds())
+                                    if (!Time_Begin.HasValue() || Time_Begin>Time_End_New)
                                         Time_Begin=Time_End_New;
-                                    if (Time_End.ToMilliseconds()<Time_End_New.ToMilliseconds())
+                                    if (!Time_End.HasValue() || Time_End<Time_End_New)
+                                        Time_End=Time_End_New;
+                                }
+                            }
+                            if (const char* Attribute=div_element->Attribute("dur"))
+                            {
+                                TimeCode Time_Dur_New=Time_Template;
+                                if (Time_Begin.HasValue() && !Time_Dur_New.FromString(Attribute))
+                                {
+                                    Time_End_New=Time_Begin_New;
+                                    Time_End_New+=Time_Dur_New;
+                                    if (!Time_Begin.HasValue() || Time_Begin>Time_End_New)
+                                        Time_Begin=Time_End_New;
+                                    if (!Time_End.HasValue() || Time_End<Time_End_New)
                                         Time_End=Time_End_New;
                                 }
                             }
@@ -495,7 +527,7 @@ void File_Ttml::Read_Buffer_Continue()
                             }
                             LineCount+=LineCount_New;
 
-                            if (Time_Begin_New!=TimeCode(0xFF, 0xFF, 0xFF, 0xFF, 0, false))
+                            if (Time_Begin_New.HasValue())
                             {
                                 // Not supporting back to the past
                                 for (size_t i=0; i<TimeLine.size(); i++)
@@ -509,7 +541,7 @@ void File_Ttml::Read_Buffer_Continue()
                                 }
 
                                 // Empty
-                                if (!TimeLine.empty() && TimeLine[TimeLine.size()-1].Time_End.ToMilliseconds()<Time_Begin_New.ToMilliseconds() && TimeLine[TimeLine.size()-1].Time_End!=TimeCode(0, 0, 0, 0, 0, false))
+                                if (!TimeLine.empty() && TimeLine[TimeLine.size()-1].Time_End.HasValue() && TimeLine[TimeLine.size()-1].Time_End.ToMilliseconds()<Time_Begin_New.ToMilliseconds())
                                     EmptyCount++;
 
                                 // Checking same times
@@ -531,10 +563,10 @@ void File_Ttml::Read_Buffer_Continue()
                                     for (size_t i=0; i<TimeLine.size(); i++)
                                     {
                                         if (Time_Begin_New.ToMilliseconds()==TimeLine[i].Time_Begin.ToMilliseconds()
-                                         || (Time_Begin_New.ToMilliseconds()==TimeLine[i].Time_End.ToMilliseconds() && TimeLine[i].Time_End!=TimeCode(0, 0, 0, 0, 0, false)))
+                                         || (TimeLine[i].Time_End.HasValue() && Time_Begin_New.ToMilliseconds()==TimeLine[i].Time_End.ToMilliseconds()))
                                             CreateFrame_Begin=0;
                                         if (Time_End_New.ToMilliseconds()!=TimeLine[i].Time_Begin.ToMilliseconds()
-                                         && (Time_End_New.ToMilliseconds()!=TimeLine[i].Time_End.ToMilliseconds() && TimeLine[i].Time_End!=TimeCode(0, 0, 0, 0, 0, false)))
+                                         && (TimeLine[i].Time_End.HasValue() && Time_End_New.ToMilliseconds()!=TimeLine[i].Time_End.ToMilliseconds()))
                                             CreateFrame_End=1;
                                     }
                                     FrameCount+=CreateFrame_Begin;

--- a/Source/MediaInfo/TimeCode.cpp
+++ b/Source/MediaInfo/TimeCode.cpp
@@ -18,6 +18,7 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/TimeCode.h"
+#include <limits>
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -33,115 +34,84 @@ namespace MediaInfoLib
 
 //---------------------------------------------------------------------------
 TimeCode::TimeCode ()
-:   Hours((int8u)-1),
-    Minutes((int8u)-1),
-    Seconds((int8u)-1),
-    Frames((int8u)-1),
-    MoreSamples(0),
-    MoreSamples_Frequency(0),
-    FramesPerSecond_Is1001(false),
-    FramesPerSecond(0),
-    DropFrame(false),
-    MustUseSecondField(false),
-    IsSecondField(false),
-    IsNegative(false)
 {
+    memset(this, 0, sizeof(TimeCode));
 }
 
 //---------------------------------------------------------------------------
-TimeCode::TimeCode (int8u Hours_, int8u Minutes_, int8u Seconds_, int8u Frames_, int8u FramesPerSecond_, bool DropFrame_, bool MustUseSecondField_, bool IsSecondField_)
+TimeCode::TimeCode (int32u Hours_, int8u Minutes_, int8u Seconds_, int32u Frames_, int32u FramesMax_, bool DropFrame_, bool MustUseSecondField_, bool IsSecondField_)
 :   Hours(Hours_),
     Minutes(Minutes_),
     Seconds(Seconds_),
     Frames(Frames_),
-    MoreSamples(0),
-    MoreSamples_Frequency(0),
-    FramesPerSecond_Is1001(false),
-    FramesPerSecond(FramesPerSecond_),
-    DropFrame(DropFrame_),
-    MustUseSecondField(MustUseSecondField_),
-    IsSecondField(IsSecondField_),
-    IsNegative(false)
+    FramesMax(FramesMax_)
 {
+    if (DropFrame_)
+        Flags.set(DropFrame);
+    if (MustUseSecondField_)
+        Flags.set(MustUseSecondField);
+    if (IsSecondField_)
+        Flags.set(IsSecondField);
+    Flags.set(IsValid);
 }
 
 //---------------------------------------------------------------------------
-TimeCode::TimeCode (int64s Frames_, int8u FramesPerSecond_, bool DropFrame_, bool MustUseSecondField_, bool IsSecondField_)
-:   FramesPerSecond(FramesPerSecond_),
-    MoreSamples(0),
-    MoreSamples_Frequency(0),
-    FramesPerSecond_Is1001(false),
-    DropFrame(DropFrame_),
-    MustUseSecondField(MustUseSecondField_),
-    IsSecondField(IsSecondField_)
+TimeCode::TimeCode (int64s Frames_, int32u FramesMax_, bool DropFrame_, bool MustUseSecondField_, bool IsSecondField_)
+:   FramesMax(FramesMax_)
 {
+    if (DropFrame_)
+        Flags.set(DropFrame);
+    if (MustUseSecondField_)
+        Flags.set(MustUseSecondField);
+    if (IsSecondField_)
+        Flags.set(IsSecondField);
     FromFrames(Frames_);
 }
 
 bool TimeCode::FromFrames(int64s Frames_)
 {
-    if (!FramesPerSecond)
-    {
-        Frames  = 0;
-        Seconds = 0;
-        Minutes = 0;
-        Hours   = 0;
-        IsNegative = false;
-        return true;
-    }
-
     if (Frames_<0)
     {
-        IsNegative=true;
+        Flags.set(IsNegative);
         Frames_=-Frames_;
     }
     else
-        IsNegative=false;
+        Flags.reset(IsNegative);
 
-    int8u Dropped=0;
-    if (DropFrame)
+    int64u Dropped=Flags.test(DropFrame)?(1+FramesMax/30):0;
+    int32u FrameRate=(int32u)FramesMax+1;
+    int64u Dropped2=Dropped*2;
+    int64u Dropped18=Dropped*18;
+
+    int64u Minutes_Tens = ((int64u)Frames_)/(600*FrameRate-Dropped18); //Count of 10 minutes
+    int64u Minutes_Units = (Frames_-Minutes_Tens*(600*FrameRate-Dropped18))/(60*FrameRate-Dropped2);
+
+    Frames_+=Dropped18*Minutes_Tens+Dropped2*Minutes_Units;
+    if (Minutes_Units && ((Frames_/FrameRate)%60)==0 && (Frames_%FrameRate)<Dropped2) // If Minutes_Tens is not 0 (drop) but count of remaining seconds is 0 and count of remaining frames is less than 2, 1 additional drop was actually counted, removing it
+        Frames_-=Dropped2;
+
+    int64s HoursTemp=(((Frames_/FrameRate)/60)/60);
+    if (HoursTemp>(int8u)-1)
     {
-        Dropped=2;
-        if (FramesPerSecond>30)
-            Dropped+=2;
-        if (FramesPerSecond>60)
-            Dropped+=2;
-        if (FramesPerSecond>90)
-            Dropped+=2;
-        if (FramesPerSecond>120)
-            Dropped+=2;
+        Hours=(int8u)-1;
+        Minutes=59;
+        Seconds=59;
+        Frames=FramesMax;
+        return true;
     }
-
-    int64u Minutes_Tens = Frames_/(600*FramesPerSecond-Dropped*9); //Count of 10 minutes
-    int64u Minutes_Units = (Frames_-Minutes_Tens*(600*FramesPerSecond-Dropped*9))/(60*FramesPerSecond-Dropped);
-
-    Frames_ += 9*Dropped*Minutes_Tens+Dropped*Minutes_Units;
-    if (Minutes_Units && ((Frames_/FramesPerSecond)%60)==0 && (Frames_%FramesPerSecond)<Dropped) // If Minutes_Tens is not 0 (drop) but count of remaining seconds is 0 and count of remaining frames is less than 2, 1 additional drop was actually counted, removing it
-        Frames_-=Dropped;
-
-    Frames  =    Frames_ % FramesPerSecond;
-    Seconds =   (Frames_ / FramesPerSecond) % 60;
-    Minutes =  ((Frames_ / FramesPerSecond) / 60) % 60;
-    int64s Temp = (((Frames_ / FramesPerSecond) / 60) / 60);
-    Hours = (Temp>99 || Temp<-99)?(Temp%24):Temp;
+    Hours=(int8u)HoursTemp;
+    Minutes=((Frames_/FrameRate)/60)%60;
+    Seconds=(Frames_/FrameRate)%60;
+    Frames=(int32u)(Frames_%FrameRate);
+    Flags.reset(IsTime);
+    Flags.set(IsValid);
 
     return false;
 }
 
 //---------------------------------------------------------------------------
 TimeCode::TimeCode (const char* Value, size_t Length)
-:   Hours((int8u)-1),
-    Minutes((int8u)-1),
-    Seconds((int8u)-1),
-    Frames((int8u)-1),
-    MoreSamples(0),
-    MoreSamples_Frequency(0),
-    FramesPerSecond_Is1001(false),
-    FramesPerSecond(0),
-    DropFrame(false),
-    MustUseSecondField(false),
-    IsSecondField(false),
-    IsNegative(false)
+:   FramesMax(0)
 {
     FromString(Value, Length);
 }
@@ -155,21 +125,22 @@ void TimeCode::PlusOne()
 {
     //TODO: negative values
 
-    if (FramesPerSecond==0)
+    if (Flags.test(HasNoFramesInfo))
         return;
-    if (MustUseSecondField)
+
+    if (Flags.test(MustUseSecondField))
     {
-        if (IsSecondField)
+        if (Flags.test(IsSecondField))
         {
             Frames++;
-            IsSecondField=false;
+            Flags.reset(IsSecondField);
         }
         else
-            IsSecondField=true;
+            Flags.set(IsSecondField);
     }
     else
         Frames++;
-    if (Frames>=FramesPerSecond)
+    if (Frames>FramesMax || !Frames)
     {
         Seconds++;
         Frames=0;
@@ -178,8 +149,8 @@ void TimeCode::PlusOne()
             Seconds=0;
             Minutes++;
 
-            if (DropFrame && Minutes%10)
-                Frames=2; //frames 0 and 1 are dropped for every minutes except 00 10 20 30 40 50
+            if (Flags.test(DropFrame) && Minutes%10)
+                Frames=(1+FramesMax/30)*2; //frames 0 and 1 (at 30 fps) are dropped for every minutes except 00 10 20 30 40 50
 
             if (Minutes>=60)
             {
@@ -199,36 +170,45 @@ void TimeCode::MinusOne()
 {
     //TODO: negative values
 
-    if (FramesPerSecond==0)
+    if (Flags.test(HasNoFramesInfo))
         return;
-    if (MustUseSecondField && IsSecondField)
-        IsSecondField=false;
-    else
+
+    if (Flags.test(MustUseSecondField) && Flags.test(IsSecondField))
     {
-        if (Frames==0 || (DropFrame && Minutes%10 && Frames<=2))
-        {
-            Frames=FramesPerSecond;
-            if (Seconds==0)
-            {
-                Seconds=60;
-                if (Minutes==0)
-                {
-                    Minutes=60;
-                    if (Hours==0)
-                        Hours=24;
-                    Hours--;
-                }
-                Minutes--;
-            }
-            Seconds--;
-        }
-        Frames--;
-
-        if (MustUseSecondField)
-            IsSecondField=true;
+        Flags.reset(IsSecondField);
+        return;
     }
-}
 
+    bool d=Flags.test(DropFrame);
+    if (!FramesMax && (!Frames || d))
+        return;
+    if (Flags.test(MustUseSecondField))
+        Flags.set(IsSecondField);
+
+    if (Frames && !(d && Minutes%10 && Frames<(1+FramesMax/30)*2))
+    {
+        Frames--;
+        return;
+    }
+
+    Frames=FramesMax;
+    if (!Seconds)
+    {
+        Seconds=59;
+        if (!Minutes)
+        {
+            Minutes=59;
+            if (!Hours)
+                Hours=24;
+            else
+                Hours--;
+        }
+        else
+            Minutes--;
+    }
+    else
+        Seconds--;
+}
 
 //---------------------------------------------------------------------------
 static const int32s PowersOf10[]=
@@ -248,9 +228,6 @@ static const int PowersOf10_Size=sizeof(PowersOf10)/sizeof(int32s);
 //---------------------------------------------------------------------------
 bool TimeCode::FromString(const char* Value, size_t Length)
 {
-    IsSecondField=false;
-    IsNegative=false;
-
     //hh:mm:ss;ff or hh:mm:ss.zzzzzzzzzSfffffffff formats
     if (Length>7
      && Value[0]>='0' && Value[0]<='9'
@@ -285,7 +262,7 @@ bool TimeCode::FromString(const char* Value, size_t Length)
                     i++;
                 }
                 if (i==Length)
-                    MoreSamples_Frequency=PowersOf10[i-10];
+                    FramesMax=PowersOf10[i-10]-1;
                 else
                 {
                     c=(unsigned char)Value[i];
@@ -294,7 +271,7 @@ bool TimeCode::FromString(const char* Value, size_t Length)
                     i++;
                     TheoriticalMax=i+PowersOf10_Size;
                     MaxLength=Length>TheoriticalMax?TheoriticalMax:Length;
-                    int32s Multiplier=0;
+                    int32u Multiplier=0;
                     while (i<Length)
                     {
                         c=(unsigned char)Value[i];
@@ -311,11 +288,16 @@ bool TimeCode::FromString(const char* Value, size_t Length)
                     }
                     if (i<Length)
                         return true;
-                    MoreSamples_Frequency=Multiplier;
+                    FramesMax=Multiplier-1;
                 }
-                Frames=(int8u)-1;
-                MoreSamples=S;
-                DropFrame=false;
+                Frames=S;
+                Flags.reset(DropFrame);
+                Flags.reset(FramesPerSecond_Is1001);
+                Flags.reset(MustUseSecondField);
+                Flags.reset(IsSecondField);
+                Flags.reset(IsNegative);
+                Flags.reset(HasNoFramesInfo);
+                Flags.set(IsTime);
             }
             //hh:mm:ss;ff format
             else if (Length==11
@@ -323,56 +305,204 @@ bool TimeCode::FromString(const char* Value, size_t Length)
              && Value[9]>='0' && Value[9]<='9'
              && Value[10]>='0' && Value[10]<='9')
             {
-                DropFrame=Value[8]==';';
                 Frames=((Value[9]-'0')*10)+(Value[10]-'0');
-                MoreSamples=0;
+                Flags.set(DropFrame, Value[8]==';');
+                if (Value[8])
+                    Flags.set(FramesPerSecond_Is1001);
+                Flags.reset(IsSecondField);
+                Flags.reset(IsNegative);
+                Flags.reset(HasNoFramesInfo);
+                Flags.reset(IsTime);
             }
             else
+            {
+                *this=TimeCode();
                 return true;
+            }
         }
         else
         {
-            MoreSamples=0;
+            Frames=0;
+            FramesMax=0;
+            Flags.reset(IsSecondField);
+            Flags.reset(IsNegative);
+            Flags.set(HasNoFramesInfo);
+            Flags.reset(IsTime);
         }
         Hours=((Value[0]-'0')*10)+(Value[1]-'0');
         Minutes=((Value[3]-'0')*10)+(Value[4]-'0');
         Seconds=((Value[6]-'0')*10)+(Value[7]-'0');
+        Flags.set(IsValid);
         return false;
     }
-    //X.Xs format
-    if (Length>=2
-     && Value[Length-1]=='s')
+
+    //Get unit
+    if (!Length)
     {
-        Length--; //Remove the "s" from the string
-        unsigned char c;
-        int i=0;
-        int32s S=0;
-        int TheoriticalMax=i+PowersOf10_Size;
-        int MaxLength=Length>TheoriticalMax?TheoriticalMax:Length;
-        while (i<MaxLength)
-        {
+        *this=TimeCode();
+        return true;
+    }
+    char Unit=Value[Length-1];
+    Length--; //Remove the unit from the string
+
+    switch (Unit)
+    {
+        //X.X format based on time
+        case 's':
+        case 'm':
+        case 'h':
+            {
+            if (Unit=='s' && Length && Value[Length-1]=='m')
+            {
+                Length--; //Remove the unit from the string
+                Unit='n'; //Magic value for ms
+            }
+            unsigned char c;
+            int i=0;
+            int32s S=0;
+            int TheoriticalMax=i+PowersOf10_Size;
+            int MaxLength=Length>TheoriticalMax?TheoriticalMax:Length;
+            while (i<MaxLength)
+            {
+                c=(unsigned char)Value[i];
+                c-='0';
+                if (c>9)
+                    break;
+                S*=10;
+                S+=c;
+                i++;
+            }
+            switch (Unit)
+            {
+                case 'n':
+                    Hours=S/3600000;
+                    Minutes=(S%3600000)/60000;
+                    Seconds=(S%60000)/1000;
+                    S%=1000;
+                    break;
+                case 's':
+                    Hours=S/3600;
+                    Minutes=(S%3600)/60;
+                    Seconds=S%60;
+                    break;
+                case 'm':
+                    Hours=S/60;
+                    Minutes=S%60;
+                    break;
+                case 'h':
+                    Hours=S;
+                    break;
+            }
+            Flags.reset();
+            Flags.set(IsTime);
+            Flags.set(IsValid);
             c=(unsigned char)Value[i];
-            c-='0';
-            if (c>9)
-                break;
-            S*=10;
-            S+=c;
-            i++;
-        }
-        Hours=S/3600;
-        Minutes=(S%3600)/60;
-        Seconds=S%60;
-        Frames=(int8u)-1;
-        c=(unsigned char)Value[i];
-        if (c=='.' || c==',')
-        {
-            i++;
-            if (i==Length)
-                return true;
-            size_t i_Start=i;
-            S=0;
-            TheoriticalMax=i+PowersOf10_Size;
-            MaxLength=Length>TheoriticalMax?TheoriticalMax:Length;
+            if (c=='.' || c==',')
+            {
+                i++;
+                if (i==Length)
+                    return true;
+                size_t i_Start=i;
+                int64u T=0;
+                TheoriticalMax=i+PowersOf10_Size;
+                MaxLength=Length>TheoriticalMax?TheoriticalMax:Length;
+                while (i<MaxLength)
+                {
+                    c=(unsigned char)Value[i];
+                    c-='0';
+                    if (c>9)
+                        break;
+                    T*=10;
+                    T+=c;
+                    i++;
+                }
+                if (i!=Length)
+                    return true;
+                int FramesRate_Index=i-1-i_Start;
+                int64u FramesRate=PowersOf10[FramesRate_Index];
+                FramesMax=(int32u)(FramesRate-1);
+                switch (Unit)
+                {
+                    case 'h':
+                    {
+                        T*=3600;
+                        int64u T_Divider=PowersOf10[2];
+                        T=(T+T_Divider/2)/T_Divider;
+                        FramesRate/=T_Divider;
+                        int64u Temp2=T/FramesRate;
+                        Minutes=Temp2/60;
+                        if (Minutes>=60)
+                        {
+                            Minutes=0;
+                            Hours++;
+                        }
+                        Seconds=Temp2%60;
+                        T%=FramesRate;
+                        FramesMax=FramesRate-1;
+                        break;
+                    }
+                    case 'm':
+                    {
+                        T*=60;
+                        int64u T_Divider=PowersOf10[0];
+                        T=(T+T_Divider/2)/T_Divider;
+                        FramesRate/=T_Divider;
+                        Seconds=T/FramesRate;
+                        if (Seconds>=60)
+                        {
+                            Seconds=0;
+                            Minutes++;
+                            if (Minutes>=60)
+                            {
+                                Hours++;
+                                Minutes=0;
+                            }
+                        }
+                        T%=FramesRate;
+                        FramesMax=FramesRate-1;
+                        break;
+                    }
+                    case 'n':
+                    {
+                        FramesRate*=1000;
+                        T+=((int64u)S)*FramesRate;
+                        int64u T_Divider=PowersOf10[1];
+                        if (FramesRate_Index>5)
+                        {
+                            int64u T_Divider=PowersOf10[8-FramesRate_Index];
+                            T=(T+T_Divider/2)/T_Divider;
+                            FramesRate=PowersOf10[8];
+                        }
+                        FramesMax=(int32u)(FramesRate-1);
+                        break;
+                    }
+                }
+                Frames=T;
+            }
+            else if (Unit=='n')
+            {
+                Frames=S;
+                FramesMax=1000;
+            }
+            else
+            {
+                Frames=0;
+                FramesMax=0;
+            }
+            Flags.set(IsValid);
+            return false;
+            }
+            break;
+
+        //X format based on rate
+        case 'f':
+        case 't':
+            {
+            unsigned char c;
+            int i=0;
+            int32s S=0;
+            int TheoriticalMax=i+PowersOf10_Size;
+            int MaxLength=Length>TheoriticalMax?TheoriticalMax:Length;
             while (i<MaxLength)
             {
                 c=(unsigned char)Value[i];
@@ -385,137 +515,105 @@ bool TimeCode::FromString(const char* Value, size_t Length)
             }
             if (i!=Length)
                 return true;
-            MoreSamples_Frequency=PowersOf10[i-1-i_Start];
-            MoreSamples=S;
-        }
-        else
-        {
-            MoreSamples=0;
-            MoreSamples_Frequency=1; // Indicates that it comes from a timestamp
-        }
-        return false;
-    }
-    //X.Xf format
-    if (Length>=2
-     && Value[Length-1]=='f')
-    {
-        Length--; //Remove the "f" from the string
-        unsigned char c;
-        int i=0;
-        int32s S=0;
-        int TheoriticalMax=i+PowersOf10_Size;
-        int MaxLength=Length>TheoriticalMax?TheoriticalMax:Length;
-        while (i<MaxLength)
-        {
-            c=(unsigned char)Value[i];
-            c-='0';
-            if (c>9)
-                break;
-            S*=10;
-            S+=c;
-            i++;
-        }
-        if (i!=Length)
-            return true;
-        if (!FramesPerSecond)
-            FramesPerSecond=1; // Arbitrary choosen
-        int32s OneHourInFrames=3600*FramesPerSecond;
-        int32s OneMinuteInFrames=60*FramesPerSecond;
-        Hours=S/OneHourInFrames;
-        Minutes=(S%OneHourInFrames)/OneMinuteInFrames;
-        Seconds=(S%OneMinuteInFrames)/FramesPerSecond;
-        Frames=S%FramesPerSecond;
-        MoreSamples=0;
-        return false;
-    }
-    //Xt format
-    if (Length>=2
-     && Value[Length-1]=='t')
-    {
-        Length--; //Remove the "t" from the string
-        unsigned char c;
-        int i=0;
-        int64s S=0;
-        int TheoriticalMax=i+PowersOf10_Size;
-        int MaxLength=Length>TheoriticalMax?TheoriticalMax:Length;
-        while (i<MaxLength)
-        {
-            c=(unsigned char)Value[i];
-            c-='0';
-            if (c>9)
-                break;
-            S*=10;
-            S+=c;
-            i++;
-        }
-        if (i!=Length)
-            return true;
-        if (!MoreSamples_Frequency)
-            MoreSamples_Frequency=1; // Arbitrary choosen
-        int64s OneHourInFrequency=3600*MoreSamples_Frequency;
-        int64s OneMinuteInFrequency=60*MoreSamples_Frequency;
-        Hours=S/OneHourInFrequency;
-        Minutes=(S%OneHourInFrequency)/OneMinuteInFrequency;
-        Seconds=(S%OneMinuteInFrequency)/MoreSamples_Frequency;
-        Frames=0; // (int8u)-1;
-        MoreSamples=S%MoreSamples_Frequency;
-        return false;
+            int32u FrameRate=(int32u)FramesMax+1;
+            int32s OneHourInFrames=3600*FrameRate;
+            int32s OneMinuteInFrames=60*FrameRate;
+            Hours=S/OneHourInFrames;
+            Minutes=(S%OneHourInFrames)/OneMinuteInFrames;
+            Seconds=(S%OneMinuteInFrames)/FrameRate;
+            Frames=S%FrameRate;
+            Flags.reset(MustUseSecondField);
+            Flags.reset(IsSecondField);
+            Flags.reset(IsNegative);
+            Flags.reset(HasNoFramesInfo);
+            Flags.set(IsTime, Unit=='t');
+            Flags.set(IsValid);
+            return false;
+            }
+            break;
     }
 
+    *this=TimeCode();
     return true;
 }
 
 //---------------------------------------------------------------------------
 string TimeCode::ToString() const
 {
+    if (!HasValue())
+        return string();
     string TC;
-    if (IsNegative)
+    if (Flags.test(IsNegative))
         TC+='-';
-    TC+=('0'+Hours/10);
-    TC+=('0'+Hours%10);
-    TC+=':';
-    TC+=('0'+Minutes/10);
-    TC+=('0'+Minutes%10);
-    TC+=':';
-    TC+=('0'+Seconds/10);
-    TC+=('0'+Seconds%10);
-    if (Frames!=(int8u)-1)
+    int8u HH=Hours;
+    if (HH>100)
     {
-        TC+=DropFrame?';':':';
-        TC+=('0'+(Frames*(MustUseSecondField?2:1)+(IsSecondField?1:0))/10);
-        TC+=('0'+(Frames*(MustUseSecondField?2:1)+(IsSecondField?1:0))%10);
+        TC+=to_string(HH/100);
+        HH%=100;
     }
-    if (MoreSamples_Frequency)
+    TC+=('0'+HH/10);
+    TC+=('0'+HH%10);
+    TC+=':';
+    int8u MM=Minutes;
+    if (MM>100)
+    {
+        TC+=('0'+MM/100);
+        MM%=100;
+    }
+    TC+=('0'+MM/10);
+    TC+=('0'+MM%10);
+    TC+=':';
+    int8u SS=Seconds;
+    if (SS>100)
+    {
+        TC+=('0'+SS/100);
+        SS%=100;
+    }
+    TC+=('0'+SS/10);
+    TC+=('0'+SS%10);
+    bool d=Flags.test(DropFrame);
+    bool t=Flags.test(IsTime);
+    if (!t && d)
+        TC+=';';
+    if (t)
     {
         int AfterCommaMinus1;
-        int32s MoreSamples_Temp;
-        if (MoreSamples<0)
-        {
-            AfterCommaMinus1=-1;
-            TC+='-';
-            MoreSamples_Temp=-MoreSamples;
-        }
-        else
-        {
-            AfterCommaMinus1=PowersOf10_Size;
-            while ((--AfterCommaMinus1)>=0 && PowersOf10[AfterCommaMinus1]!=MoreSamples_Frequency);
-            TC+=(Frames!=(int8u)-1 || AfterCommaMinus1<0)?'+':'.';
-            MoreSamples_Temp=MoreSamples;
-        }
-        if ((Frames!=(int8u)-1 || AfterCommaMinus1<0))
+        AfterCommaMinus1=PowersOf10_Size;
+        auto FrameRate=FramesMax+1;
+        while ((--AfterCommaMinus1)>=0 && PowersOf10[AfterCommaMinus1]!=FrameRate);
+        TC+='.';
+        if (AfterCommaMinus1<0)
         {
             stringstream s;
-            s<<MoreSamples_Temp;
+            s<<Frames;
             TC+=s.str();
             TC+='S';
             s.str(string());
-            s<<MoreSamples_Frequency;
+            s<<FrameRate;
             TC+=s.str();
         }
         else
         {
             for (int i=0; i<=AfterCommaMinus1;i++)
-                TC+='0'+(MoreSamples_Temp/(i==AfterCommaMinus1?1:PowersOf10[AfterCommaMinus1-i-1])%10);
+                TC+='0'+(Frames/(i==AfterCommaMinus1?1:PowersOf10[AfterCommaMinus1-i-1])%10);
+        }
+    }
+    else if (!Flags.test(HasNoFramesInfo))
+    {
+        if (!d)
+            TC+=':';
+        auto FF=Frames;
+        if (FF>=100)
+        {
+            TC+=to_string(FF/100);
+            FF%=100;
+        }
+        TC+=('0'+(FF/10));
+        TC+=('0'+(FF%10));
+        if (Flags.test(MustUseSecondField) || Flags.test(IsSecondField))
+        {
+            TC+='.';
+            TC+=('0'+Flags.test(IsSecondField));
         }
     }
 
@@ -525,71 +623,46 @@ string TimeCode::ToString() const
 //---------------------------------------------------------------------------
 int64s TimeCode::ToFrames() const
 {
-    if (!FramesPerSecond)
+    if (!HasValue())
         return 0;
 
     int64s TC=(int64s(Hours)     *3600
              + int64s(Minutes)   *  60
-             + int64s(Seconds)        )*int64s(FramesPerSecond)
-             + int64s(Frames);
+             + int64s(Seconds)        )*(FramesMax+1);
 
-    if (DropFrame)
+    if (Flags.test(DropFrame) && FramesMax)
     {
-        int Dropped=0;
-        int FramesPerSecond2=FramesPerSecond-1;
-        for (;;)
-        {
-            Dropped++;
-            FramesPerSecond2-=30;
-            if (FramesPerSecond2<0)
-                break;
-        }
+        int64u Dropped=FramesMax/30+1;
 
         TC-= int64s(Hours)      *108*Dropped
           + (int64s(Minutes)/10)*18*Dropped
           + (int64s(Minutes)%10)* 2*Dropped;
     }
 
-    TC*=(MustUseSecondField?2:1);
-    TC+=(IsSecondField?1:0);
+    if (!Flags.test(HasNoFramesInfo) && FramesMax)
+        TC+=Frames;
+    if (Flags.test(MustUseSecondField))
+        TC<<=1;
+    if (Flags.test(IsSecondField))
+        TC++;
+    if (Flags.test(IsNegative))
+        TC=-TC;
 
-    return IsNegative?-TC:TC;
+    return TC;
 }
 
 //---------------------------------------------------------------------------
 int64s TimeCode::ToMilliseconds() const
 {
-    if (!FramesPerSecond || Frames==(int8u)-1)
-    {
-        int64s TC=(int64s(Hours)     *3600
-                 + int64s(Minutes)   *  60
-                 + int64s(Seconds)        )*1000;
-        if (Frames!=(int8u)-1)
-        {
-            if (MoreSamples_Frequency)
-            {
-                int32s MoreSamples_Frequency_Duplicate=MoreSamples_Frequency;
-                if (!(MoreSamples_Frequency_Duplicate%1000))
-                    MoreSamples_Frequency_Duplicate/=1000;
-                if (MoreSamples_Frequency_Duplicate<=0xFF)
-                {
-                    TimeCode Duplicate(*this);
-                    Duplicate.FramesPerSecond=(int8u)MoreSamples_Frequency_Duplicate;
-                    return Duplicate.ToMilliseconds();
-                }
-            }
-            TC+=(((int64u)Frames)*1000+0xFF/2)/0xFF;
-        }
-        if (MoreSamples_Frequency)
-            TC+=(((int64s)MoreSamples)*1000+MoreSamples_Frequency/2)/MoreSamples_Frequency;
-        return TC;
-    }
+    if (!HasValue())
+        return 0;
 
-    int64s MS=float64_int64s(ToFrames()*1000*((DropFrame || FramesPerSecond_Is1001)?1.001:1.000)/(FramesPerSecond*(MustUseSecondField?2:1)));
-    if (MoreSamples_Frequency)
-        MS+=(((int64s)MoreSamples)*1000+MoreSamples_Frequency/2)/MoreSamples_Frequency;
+    int64s MS=float64_int64s(ToFrames()*1000*(FramesMax && (Flags.test(DropFrame) || Flags.test(FramesPerSecond_Is1001))?1.001:1.000)/((((int64u)FramesMax)+1)*(Flags.test(MustUseSecondField)?2:1)));
 
-    return IsNegative?-MS:MS;
+    if (Flags.test(IsNegative))
+        MS=-MS;
+
+    return MS;
 }
 
 //***************************************************************************

--- a/Source/MediaInfo/TimeCode.h
+++ b/Source/MediaInfo/TimeCode.h
@@ -11,13 +11,102 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
+#include <cstring>
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
 {
 
 //***************************************************************************
-// Class File_Unknown
+// Class bitset8
+//***************************************************************************
+
+#if __cplusplus >= 201400 || (_MSC_VER >= 1910 && _MSVC_LANG >= 201400)
+    #define constexpr14 constexpr
+#else
+    #define constexpr14
+#endif
+#if __cplusplus >= 202000 || (_MSC_VER >= 1910 && _MSVC_LANG >= 202000)
+    #define constexpr20 constexpr
+#else
+    #define constexpr20
+#endif
+
+class bitset8
+{
+public:
+    class proxy
+    {
+        friend bitset8;
+
+    public:
+        constexpr20 ~proxy() noexcept {}
+
+        constexpr14 proxy& operator=(bool Value) noexcept {
+            ref->set(pos, Value);
+            return *this;
+        }
+
+        constexpr14 proxy& operator=(const proxy& p) noexcept {
+            ref->set(pos, static_cast<bool>(p));
+            return *this;
+        }
+
+        constexpr14 operator bool() const noexcept {
+            return ref->test(pos);
+        }
+
+    private:
+        constexpr14 proxy(bitset8* _ref, size_t _pos) : ref(_ref), pos(_pos) {}
+
+        bitset8* const ref;
+        size_t const pos;
+    };
+
+    constexpr14 bitset8& reset() noexcept
+    {
+        stored=0;
+        return *this;
+    }
+
+    constexpr14 bitset8& reset(size_t pos) noexcept
+    {
+        stored&=~(1<<pos);
+        return *this;
+    }
+
+    constexpr14 bitset8& set(size_t pos) noexcept
+    {
+        stored|=(1<<pos);
+        return *this;
+    }
+
+    constexpr14 bitset8& set(size_t pos, bool val) noexcept
+    {
+        return val?set(pos):reset(pos);
+    }
+
+    constexpr14 bool test(size_t pos) const noexcept
+    {
+        return (stored>>pos)&1;
+    }
+
+    constexpr20 proxy operator[](size_t pos) noexcept
+    {
+        return proxy(this, pos);
+    }
+
+    constexpr14 bool operator[](size_t pos) const noexcept
+    {
+        return test(pos);
+    }
+
+private:
+    int8u stored=0;
+};
+
+//***************************************************************************
+// Class TimeCode
 //***************************************************************************
 
 class TimeCode
@@ -25,8 +114,8 @@ class TimeCode
 public:
     //constructor/Destructor
     TimeCode ();
-    TimeCode (int8u Hours, int8u Minutes, int8u Seconds, int8u Frames, int8u FramesPerSecond, bool DropFrame, bool MustUseSecondField=false, bool IsSecondField=false);
-    TimeCode (int64s Frames, int8u FramesPerSecond, bool DropFrame, bool MustUseSecondField=false, bool IsSecondField_=false);
+    TimeCode (int32u Hours, int8u Minutes, int8u Seconds, int32u Frames, int32u FramesMax, bool DropFrame, bool MustUseSecondField=false, bool IsSecondField=false);
+    TimeCode (int64s Frames, int32u FramesMax, bool DropFrame, bool MustUseSecondField=false, bool IsSecondField_=false);
     TimeCode(const char* Value, size_t Length); // return false if all fine
     TimeCode(const char* Value) { *this = TimeCode(Value, strlen(Value)); }
     TimeCode(const string& Value) { *this = TimeCode(Value.c_str(), Value.size()); }
@@ -34,7 +123,25 @@ public:
     //Operators
     TimeCode& operator +=(const TimeCode& b)
     {
-        return operator+=(b.ToFrames());
+        int64u FrameRate1=GetFramesMax();
+        int64u FrameRate2=b.GetFramesMax();
+        if (FrameRate1==FrameRate2)
+        {
+            bool IsTimeSav=Flags.test(IsTime);
+            *this+=b.ToFrames();
+            Flags.set(IsTime, IsTimeSav);
+            return *this;
+        }
+        FrameRate1++;
+        FrameRate2++;
+        int64u Frames1=ToFrames();
+        int64u Frames2=b.ToFrames();
+        int64u Result=Frames1*FrameRate2+Frames2*FrameRate1;
+        Result=(Result+FrameRate2/2)/FrameRate2;
+        bool IsTimeSav=Flags.test(IsTime);
+        FromFrames(Result);
+        Flags.set(IsTime, IsTimeSav);
+        return *this;
     }
     TimeCode& operator +=(const int64s Frames)
     {
@@ -92,28 +199,56 @@ public:
     }
     bool operator== (const TimeCode &tc) const
     {
-        return Hours                ==tc.Hours
-            && Minutes              ==tc.Minutes
-            && Seconds              ==tc.Seconds
-            && Frames               ==tc.Frames
-            && FramesPerSecond      ==tc.FramesPerSecond
-            && DropFrame            ==tc.DropFrame
-            && MustUseSecondField   ==tc.MustUseSecondField
-            && IsSecondField        ==tc.IsSecondField;
+        return Hours==tc.Hours
+            && Minutes==tc.Minutes
+            && Seconds==tc.Seconds
+            && Frames==tc.Frames;
     }
     bool operator!= (const TimeCode &tc) const
     {
         return !(*this == tc);
     }
+    bool operator< (const TimeCode& tc) const
+    {
+        int64u Total1=((int64u)Hours)  <<16
+                    | ((int64u)Minutes)<< 8
+                    | ((int64u)Seconds);
+        int64u Total2=((int64u)tc.Hours)  <<16
+                    | ((int64u)tc.Minutes)<< 8
+                    | ((int64u)tc.Seconds);
+        if (Total1==Total2)
+        {
+            if (FramesMax==tc.FramesMax)
+                return Frames<tc.Frames;
+            int64u Mix1=((int64s)Frames)*(((int64s)tc.FramesMax)+1);
+            int64u Mix2=((int64s)tc.Frames)*(((int64s)FramesMax)+1);
+            return Mix1<Mix2;
+        }
+        return Total1<Total2;
+    }
+    bool operator> (const TimeCode& tc) const
+    {
+        int64u Total1 = ((int64u)Hours) << 16
+                    | ((int64u)Minutes)<< 8
+                    | ((int64u)Seconds);
+        int64u Total2=((int64u)tc.Hours)  <<16
+                    | ((int64u)tc.Minutes)<< 8
+                    | ((int64u)tc.Seconds);
+        if (Total1==Total2)
+        {
+            if (FramesMax==tc.FramesMax)
+                return Frames>tc.Frames;
+            int64u Mix1=((int64s)Frames)*(((int64s)tc.FramesMax)+1);
+            int64u Mix2=((int64s)tc.Frames)*(((int64s)FramesMax)+1);
+            return Mix1>Mix2;
+        }
+        return Total1>Total2;
+    }
 
     //Helpers
-    bool IsValid() const
-    {
-        return FramesPerSecond && HasValue();
-    }
     bool HasValue() const
     {
-        return Hours!=(int8u)-1;
+        return Flags.test(IsValid);
     }
     void PlusOne();
     void MinusOne();
@@ -125,19 +260,49 @@ public:
     int64s ToFrames() const;
     int64s ToMilliseconds() const;
 
-public:
-    int8u Hours;
+    int32u GetHours() const { return Hours; }
+    void SetHours(int32u Value) { Hours=Value; }
+    int8u GetMinutes() const { return Minutes; }
+    void SetMinutes(int8u Value) { Minutes=Value; }
+    int8u GetSeconds() const { return Seconds; }
+    void SetSeconds(int8u Value) { Seconds=Value; }
+    int32u GetFrames() const { return Frames; }
+    void SetFrames(int32u Value) { Frames=Value; }
+    int32u GetFramesMax() const { return FramesMax; }
+    void SetFramesMax(int32u Value=0) { FramesMax=Value; }
+    bool GetDropFrame() const { return Flags.test(DropFrame); }
+    void SetDropFrame(bool Value=true) { Flags.set(DropFrame, Value); }
+    bool GetNegative() const { return Flags.test(IsNegative); }
+    void SetNegative(bool Value=true) { Flags.set(IsNegative, Value); }
+    bool Get1001() const { return Flags.test(FramesPerSecond_Is1001); }
+    void Set1001(bool Value=true) { Flags.set(FramesPerSecond_Is1001, Value); }
+    bool GetMustUseSecondField() const { return Flags.test(MustUseSecondField); }
+    void SetMustUseSecondField(bool Value=true) { Flags.set(MustUseSecondField, Value); }
+    bool GetIsTime() const { return Flags.test(IsTime); }
+    void SetIsTime(bool Value=true) { Flags.set(IsTime, Value); }
+    bool GetIsValid() const { return Flags.test(IsValid); }
+    void SetIsValid(bool Value=true) { Flags.set(IsValid, Value); }
+    float GetFrameRate() { return (FramesMax+1)/((Flags.test(DropFrame) || Flags.test(FramesPerSecond_Is1001))?1.001:1.000);}
+
+private:
+    int32u Frames;
+    int32u FramesMax;
+    int32u Hours;
     int8u Minutes;
     int8u Seconds;
-    int8u Frames;
-    int32s MoreSamples;
-    int32s MoreSamples_Frequency;
-    bool  FramesPerSecond_Is1001;
-    int8u FramesPerSecond;
-    bool  DropFrame;
-    bool  MustUseSecondField;
-    bool  IsSecondField;
-    bool  IsNegative;
+    enum flag
+    {
+        DropFrame,
+        FramesPerSecond_Is1001,
+        MustUseSecondField,
+        IsSecondField,
+        IsNegative,
+        HasNoFramesInfo,
+        IsTime,
+        IsValid,
+        Flag_Max
+    };
+    bitset8 Flags;
 };
 
 Ztring Date_MJD(int16u Date);

--- a/Source/MediaInfo/Video/File_Mpegv.cpp
+++ b/Source/MediaInfo/Video/File_Mpegv.cpp
@@ -1584,25 +1584,14 @@ void File_Mpegv::Streams_Finish()
     }
     else if (!TimeCodeIsNotTrustable && Time_End_Seconds!=Error && FrameRate)
     {
-        TimeCode Time_Begin_TC;
-        const int8u ceilFrameRate=(int8u)ceil(FrameRate);
-        Time_Begin_TC.FramesPerSecond=ceilFrameRate;
-        Time_Begin_TC.DropFrame=group_start_IsParsed?group_start_drop_frame_flag:((FrameRate-ceilFrameRate)?true:false);
-        Time_Begin_TC.Hours=(int8u)(Time_Begin_Seconds/3600);
-        Time_Begin_TC.Minutes=(int8u)((Time_Begin_Seconds%3600)/60);
-        Time_Begin_TC.Seconds=(int8u)(Time_Begin_Seconds%60);
-        Time_Begin_TC.Frames=(int8u)Time_Begin_Frames;
-        TimeCode Time_End_TC;
-        Time_End_TC.FramesPerSecond=ceilFrameRate;
-        Time_End_TC.DropFrame=Time_Begin_TC.DropFrame;
-        Time_End_TC.Hours=(int8u)(Time_End_Seconds/3600);
-        Time_End_TC.Minutes=(int8u)((Time_End_Seconds%3600)/60);
-        Time_End_TC.Seconds=(int8u)(Time_End_Seconds%60);
-        Time_End_TC.Frames=(int8u)Time_End_Frames;
-        int64u Time_Begin_FrameCount=Time_Begin_TC.ToFrames();
-        int64u Time_End_FrameCount = Time_End_TC.ToFrames();
-        Fill(Stream_Video, 0, Video_FrameCount, Time_End_FrameCount-Time_Begin_FrameCount, 0);
-        Fill(Stream_Video, 0, Video_Duration, (Time_End_FrameCount-Time_Begin_FrameCount)/FrameRate*1000, 0);
+        const int32u ceilFrameRate=(int32u)ceil(FrameRate);
+        bool DropFrame=group_start_IsParsed?group_start_drop_frame_flag:((FrameRate==ceilFrameRate)?true:false);
+        int32u FramesMax=ceilFrameRate-1;
+        TimeCode Time_Begin_TC(Time_Begin_Seconds/3600, (int8u)((Time_Begin_Seconds%3600)/60), (int8u)(Time_Begin_Seconds%60), Time_Begin_Frames, FramesMax, DropFrame);
+        TimeCode Time_End_TC  (Time_End_Seconds  /3600, (int8u)((Time_End_Seconds  %3600)/60), (int8u)(Time_End_Seconds  %60), Time_End_Frames  , FramesMax, DropFrame);
+        int64u FrameCount=Time_End_TC.ToFrames()-Time_Begin_TC.ToFrames();
+        Fill(Stream_Video, 0, Video_FrameCount, FrameCount, 0);
+        Fill(Stream_Video, 0, Video_Duration, FrameCount/FrameRate*1000, 0);
     }
 
     //picture_coding_types


### PR DESCRIPTION
timing like `begin="0.0388888h" dur="0.09167m"` is now supported.

With also refactoring of time code class in order to handle more corner cases.