### PR TITLE
MPEG-4/MOV: support of time codes >30 fps

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -5084,6 +5084,8 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_tmcd()
         mdat_Pos_ToParseInPriority_StreamIDs.push_back(moov_trak_tkhd_TrackID);
         Streams[moov_trak_tkhd_TrackID].IsPriorityStream=true;
         Parser->NumberOfFrames=NumberOfFrames; //tc->FrameDuration?(((float64)tc->TimeScale)/tc->FrameDuration):0;
+        if (tc->FrameDuration && NumberOfFrames)
+            Parser->FrameMultiplier=((int64u)tc->TimeScale+tc->FrameDuration/2)/tc->FrameDuration/NumberOfFrames;
         Parser->DropFrame=tc->DropFrame;
         Parser->NegativeTimes=tc->NegativeTimes;
         Parser->tkhd_Duration=Streams[moov_trak_tkhd_TrackID].tkhd_Duration;

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
@@ -43,6 +43,7 @@ File_Mpeg4_TimeCode::File_Mpeg4_TimeCode()
     FirstEditOffset=0;
     FirstEditDuration=(int64u)-1;
     NumberOfFrames=0;
+    FrameMultiplier=1;
     DropFrame=false;
     NegativeTimes=false;
     tkhd_Duration=0;
@@ -76,6 +77,13 @@ void File_Mpeg4_TimeCode::Streams_Fill()
         Fill(Stream_General, 0, "Delay", Pos_Temp*1000/FrameRate_WithDF, 0);
 
         TimeCode TC(Pos_Temp, NumberOfFrames-1, DropFrame);
+        if (FrameMultiplier>1)
+        {
+            int64s Frames=TC.GetFrames();
+            TC-=TC.GetFrames();
+            TC=TimeCode(TC.ToFrames()*FrameMultiplier, NumberOfFrames*FrameMultiplier-1, DropFrame);
+            TC+=Frames*FrameMultiplier;
+        }
         Stream_Prepare(Stream_Other);
         Fill(Stream_Other, StreamPos_Last, Other_Type, "Time code");
         Fill(Stream_Other, StreamPos_Last, Other_TimeCode_FirstFrame, TC.ToString().c_str());
@@ -97,7 +105,7 @@ void File_Mpeg4_TimeCode::Streams_Fill()
             }
             else
             {
-                float64 FrameCountF=(float64)tkhd_Duration/mvhd_Duration_TimeScale*FrameRate_WithDF;
+                float64 FrameCountF=(float64)tkhd_Duration/mvhd_Duration_TimeScale*FrameRate_WithDF*FrameMultiplier;
                 FrameCount=(int64u)FrameCountF;
                 if (FrameCount!=FrameCountF && FrameCount*1000!=float64_int64s(FrameCountF*1000000/1001)) // TODO: better catch of 1/1.001
                     FrameCount++;

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
@@ -27,6 +27,7 @@ public :
     int8u   NumberOfFrames;
     bool    DropFrame;
     bool    NegativeTimes;
+    int64u  FrameMultiplier;
     int64s  FirstEditOffset;
     int64u  FirstEditDuration;
     int64u  tkhd_Duration;


### PR DESCRIPTION
Handle of multiplied frame count when frame rate is more than NumberOfFrames

Fix https://github.com/MediaArea/MediaInfoLib/pull/1511#issuecomment-1098269135.