### PR TITLE
AAC: option for complete parse of all frames or none or partial

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac.cpp
+++ b/Source/MediaInfo/Audio/File_Aac.cpp
@@ -77,6 +77,7 @@ File_Aac::File_Aac()
     adts_buffer_fullness_Is7FF=false;
     #if MEDIAINFO_ADVANCED
         aac_frame_length_Total=0;
+        ParseCompletely=0;
     #endif //MEDIAINFO_ADVANCED
 
     //Temp - Main
@@ -289,7 +290,12 @@ void File_Aac::Read_Buffer_Continue()
         return;
 
     if (Frame_Count==0)
+    {
         PTS_Begin=FrameInfo.PTS;
+        #if MEDIAINFO_ADVANCED
+            ParseCompletely=Config->File_Macroblocks_Parse_Get();
+        #endif //MEDIAINFO_ADVANCED
+    }
 
     switch(Mode)
     {

--- a/Source/MediaInfo/Audio/File_Aac.h
+++ b/Source/MediaInfo/Audio/File_Aac.h
@@ -242,6 +242,9 @@ protected :
     bool    adts_buffer_fullness_Is7FF;
     #if MEDIAINFO_ADVANCED
         int64u  aac_frame_length_Total;
+        int     ParseCompletely;
+    #else //MEDIAINFO_ADVANCED
+        static constexpr int ParseCompletely=0;
     #endif //MEDIAINFO_ADVANCED
 
     //***********************************************************************

--- a/Source/MediaInfo/Audio/File_Aac_GeneralAudio.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_GeneralAudio.cpp
@@ -23,6 +23,7 @@
 //---------------------------------------------------------------------------
 #include "MediaInfo/Audio/File_Aac.h"
 #include "MediaInfo/Audio/File_Aac_GeneralAudio.h"
+#include "MediaInfo/MediaInfo_Config_MediaInfo.h"
 using namespace std;
 //---------------------------------------------------------------------------
 
@@ -317,21 +318,6 @@ void File_Aac::program_config_element()
 //---------------------------------------------------------------------------
 void File_Aac::raw_data_block()
 {
-    if (Frame_Count>Frame_Count_Valid)
-    {
-        Skip_BS(Data_BS_Remain(),                               "Data");
-        return; //Parsing completely only first frames
-    }
-
-    raw_data_block_Pos=0;
-
-    if (audioObjectType!=2)
-    {
-        Skip_BS(Data_BS_Remain(),                               "Data");
-        Frame_Count++;
-        return; //We test only AAC LC
-    }
-
     if (sampling_frequency_index>=13)
     {
         Trusted_IsNot("(Problem)");
@@ -340,7 +326,16 @@ void File_Aac::raw_data_block()
     }
 
     //Parsing
+    if ((ParseCompletely<1 && Status[IsFilled])
+     ||  ParseCompletely<0
+     ||  audioObjectType!=2)
+    {
+        Skip_BS(Data_BS_Remain(),                               "raw_data_block");
+    }
+    else
+    {
     Element_Begin1("raw_data_block");
+    raw_data_block_Pos=0;
     int8u id_syn_ele=0, id_syn_ele_Previous;
     do
     {
@@ -381,6 +376,7 @@ void File_Aac::raw_data_block()
     if (Element_IsOK() && Data_BS_Remain()%8)
         Skip_S1(Data_BS_Remain()%8,                             "byte_alignment");
     Element_End0();
+    }
 }
 
 //---------------------------------------------------------------------------
@@ -660,6 +656,12 @@ void File_Aac::fill_element(int8u id_syn_ele)
 //---------------------------------------------------------------------------
 void File_Aac::gain_control_data()
 {
+    if (Retrieve_Const(Stream_Audio, 0, "GainControl_Present").empty())
+    {
+        Fill(Stream_Audio, 0, "GainControl_Present", "Yes");
+        Fill_SetOptions(Stream_Audio, 0, "GainControl_Present", "N NTY");
+    }
+
     int8u max_band, adjust_num, aloc_bits, aloc_bits0;
     int8u wd_max=0;
     switch(window_sequence)

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -233,7 +233,7 @@ MediaInfo_Config_MediaInfo::MediaInfo_Config_MediaInfo()
         File_DvDif_Analysis=false;
     #endif //defined(MEDIAINFO_DVDIF_ANALYZE_YES)
     #if MEDIAINFO_MACROBLOCKS
-        File_Macroblocks_Parse=false;
+        File_Macroblocks_Parse=0;
     #endif //MEDIAINFO_MACROBLOCKS
     File_GrowingFile_Delay=10;
     File_GrowingFile_Force=false;
@@ -1141,7 +1141,7 @@ Ztring MediaInfo_Config_MediaInfo::Option (const String &Option, const String &V
     else if (Option_Lower==__T("file_macroblocks_parse"))
     {
         #if MEDIAINFO_MACROBLOCKS
-            File_Macroblocks_Parse_Set(!(Value==__T("0") || Value.empty()));
+            File_Macroblocks_Parse_Set(Ztring(Value).To_int32s());
             return __T("");
         #else //MEDIAINFO_MACROBLOCKS
             return __T("Macroblock parsing is disabled due to compilation options");
@@ -1150,7 +1150,7 @@ Ztring MediaInfo_Config_MediaInfo::Option (const String &Option, const String &V
     else if (Option_Lower==__T("file_macroblocks_parse_get"))
     {
         #if MEDIAINFO_MACROBLOCKS
-            return File_Macroblocks_Parse_Get()?"1":"0";
+            return Ztring::ToZtring(File_Macroblocks_Parse_Get());
         #else //MEDIAINFO_MACROBLOCKS
             return __T("Macroblock parsing is disabled due to compilation options");
         #endif //MEDIAINFO_MACROBLOCKS
@@ -3441,13 +3441,13 @@ bool MediaInfo_Config_MediaInfo::File_DvDif_Analysis_Get ()
 
 //---------------------------------------------------------------------------
 #if MEDIAINFO_MACROBLOCKS
-void MediaInfo_Config_MediaInfo::File_Macroblocks_Parse_Set (bool NewValue)
+void MediaInfo_Config_MediaInfo::File_Macroblocks_Parse_Set (int NewValue)
 {
     CriticalSectionLocker CSL(CS);
     File_Macroblocks_Parse=NewValue;
 }
 
-bool MediaInfo_Config_MediaInfo::File_Macroblocks_Parse_Get ()
+int MediaInfo_Config_MediaInfo::File_Macroblocks_Parse_Get ()
 {
     CriticalSectionLocker CSL(CS);
     return File_Macroblocks_Parse;

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
@@ -350,8 +350,8 @@ public :
     bool          File_DvDif_Analysis_Get ();
     #endif //defined(MEDIAINFO_DVDIF_ANALYZE_YES)
     #if MEDIAINFO_MACROBLOCKS
-    void          File_Macroblocks_Parse_Set (bool NewValue);
-    bool          File_Macroblocks_Parse_Get ();
+    void          File_Macroblocks_Parse_Set (int NewValue);
+    int           File_Macroblocks_Parse_Get ();
     #endif //MEDIAINFO_MACROBLOCKS
     void          File_GrowingFile_Delay_Set(float64 Value);
     float64       File_GrowingFile_Delay_Get();
@@ -580,7 +580,7 @@ private :
     bool                    File_DvDif_Analysis;
     #endif //defined(MEDIAINFO_DVDIF_ANALYZE_YES)
     #if MEDIAINFO_MACROBLOCKS
-    bool                    File_Macroblocks_Parse;
+    int                     File_Macroblocks_Parse;
     #endif //MEDIAINFO_MACROBLOCKS
     float64                 File_GrowingFile_Delay;
     bool                    File_GrowingFile_Force;


### PR DESCRIPTION
It permits to catch SBR (HE-AAC) and PS (HE-AACv2) in any frame, or at the opposite no check at all; default is first few frames.
Warning: CPU intensive.
Useful for [LeaveSD](https://github.com/MediaArea/LeaveSD).