### PR TITLE
NSV: better handling of buggy StarDiva agenda negative timestamps

### DIFF
--- a/Source/MediaInfo/TimeCode.cpp
+++ b/Source/MediaInfo/TimeCode.cpp
@@ -91,9 +91,9 @@ bool TimeCode::FromFrames(int64s Frames_)
         Frames_-=Dropped2;
 
     int64s HoursTemp=(((Frames_/FrameRate)/60)/60);
-    if (HoursTemp>(int8u)-1)
+    if (HoursTemp>(int32u)-1)
     {
-        Hours=(int8u)-1;
+        Hours=(int32u)-1;
         Minutes=59;
         Seconds=59;
         Frames=FramesMax;

--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -989,6 +989,8 @@ void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq
             case Video_MasteringDisplay_Luminance:
                 Ignore = Retrieve_Const(Stream_Video, 0, Item->first) == Item->second;
                 break;
+            default:
+                Ignore = false;
             }
             if (!Ignore)
                 Fill(Stream_Video, 0, Item->first, Item->second);


### PR DESCRIPTION
StarDiva behavior is buggy when the agenda is across 2 days, we try to keep as much info as possible from the agenda (but it is no more in synch with the file time line, it is "best effort").