### PR TITLE
Frame rate precise numerator/denominator also for text streams in MOV

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -1219,46 +1219,27 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Paramete
 //---------------------------------------------------------------------------
 void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Parameter, float64 Value, int8u AfterComma, bool Replace)
 {
-    if (StreamKind==Stream_Video && Parameter==Video_FrameRate)
+    if (Parameter==Fill_Parameter(StreamKind, Generic_FrameRate))
     {
-        Clear(StreamKind, StreamPos, Video_FrameRate_Num);
-        Clear(StreamKind, StreamPos, Video_FrameRate_Den);
+        size_t FrameRate_Num=Fill_Parameter(StreamKind, Generic_FrameRate_Num);
+        size_t FrameRate_Den=Fill_Parameter(StreamKind, Generic_FrameRate_Den);
+
+        Clear(StreamKind, StreamPos, FrameRate_Num);
+        Clear(StreamKind, StreamPos, FrameRate_Den);
 
         if (Value)
         {
             if (float64_int64s(Value) - Value*1.001000 > -0.000002
              && float64_int64s(Value) - Value*1.001000 < +0.000002) // Detection of precise 1.001 (e.g. 24000/1001) taking into account precision of 64-bit float
             {
-                Fill(StreamKind, StreamPos, Video_FrameRate_Num,  Value*1001, 0, Replace);
-                Fill(StreamKind, StreamPos, Video_FrameRate_Den,   1001, 10, Replace);
+                Fill(StreamKind, StreamPos, FrameRate_Num, Value*1001,  0, Replace);
+                Fill(StreamKind, StreamPos, FrameRate_Den,       1001, 10, Replace);
             }
             if (float64_int64s(Value) - Value*1.001001 > -0.000002
              && float64_int64s(Value) - Value*1.001001 < +0.000002) // Detection of rounded 1.001 (e.g. 23976/1000) taking into account precision of 64-bit float
             {
-                Fill(StreamKind, StreamPos, Video_FrameRate_Num,  Value*1000, 0, Replace);
-                Fill(StreamKind, StreamPos, Video_FrameRate_Den,   1000, 10, Replace);
-            }
-        }
-    }
-
-    if (StreamKind==Stream_Other && Parameter==Other_FrameRate)
-    {
-        Clear(StreamKind, StreamPos, Other_FrameRate_Num);
-        Clear(StreamKind, StreamPos, Other_FrameRate_Den);
-
-        if (Value)
-        {
-            if (float32_int32s(Value) - Value*1.001000 > -0.000002
-             && float32_int32s(Value) - Value*1.001000 < +0.000002) // Detection of precise 1.001 (e.g. 24000/1001) taking into account precision of 32-bit float
-            {
-                Fill(StreamKind, StreamPos, Other_FrameRate_Num,  Value*1001, 0, Replace);
-                Fill(StreamKind, StreamPos, Other_FrameRate_Den,   1001, 10, Replace);
-            }
-            if (float32_int32s(Value) - Value*1.001001 > -0.000002
-             && float32_int32s(Value) - Value*1.001001 < +0.000002) // Detection of rounded 1.001 (e.g. 23976/1000) taking into account precision of 32-bit float
-            {
-                Fill(StreamKind, StreamPos, Other_FrameRate_Num,  Value*1000, 0, Replace);
-                Fill(StreamKind, StreamPos, Other_FrameRate_Den,   1000, 10, Replace);
+                Fill(StreamKind, StreamPos, FrameRate_Num,  Value*1000,  0, Replace);
+                Fill(StreamKind, StreamPos, FrameRate_Den,        1000, 10, Replace);
             }
         }
     }
@@ -3031,6 +3012,9 @@ size_t File__Analyze::Fill_Parameter(stream_t StreamKind, generic StreamPos)
                                     case Generic_Duration_String4 : return General_Duration_String4;
                                     case Generic_Duration_String5 : return General_Duration_String5;
                                     case Generic_FrameRate : return General_FrameRate;
+                                    case Generic_FrameRate_String: return General_FrameRate_String;
+                                    case Generic_FrameRate_Num: return General_FrameRate_Num;
+                                    case Generic_FrameRate_Den: return General_FrameRate_Den;
                                     case Generic_FrameCount : return General_FrameCount;
                                     case Generic_Delay : return General_Delay;
                                     case Generic_Delay_String : return General_Delay_String;
@@ -3108,6 +3092,9 @@ size_t File__Analyze::Fill_Parameter(stream_t StreamKind, generic StreamPos)
                                     case Generic_BitRate_Encoded : return Video_BitRate_Encoded;
                                     case Generic_BitRate_Encoded_String : return Video_BitRate_Encoded_String;
                                     case Generic_FrameRate : return Video_FrameRate;
+                                    case Generic_FrameRate_String: return Video_FrameRate_String;
+                                    case Generic_FrameRate_Num: return Video_FrameRate_Num;
+                                    case Generic_FrameRate_Den: return Video_FrameRate_Den;
                                     case Generic_FrameCount : return Video_FrameCount;
                                     case Generic_Source_FrameCount : return Video_Source_FrameCount;
                                     case Generic_ColorSpace : return Video_ColorSpace;
@@ -3230,6 +3217,9 @@ size_t File__Analyze::Fill_Parameter(stream_t StreamKind, generic StreamPos)
                                     case Generic_BitRate_Encoded : return Audio_BitRate_Encoded;
                                     case Generic_BitRate_Encoded_String : return Audio_BitRate_Encoded_String;
                                     case Generic_FrameRate : return Audio_FrameRate;
+                                    case Generic_FrameRate_String: return Audio_FrameRate_String;
+                                    case Generic_FrameRate_Num: return Audio_FrameRate_Num;
+                                    case Generic_FrameRate_Den: return Audio_FrameRate_Den;
                                     case Generic_FrameCount : return Audio_FrameCount;
                                     case Generic_Source_FrameCount : return Audio_Source_FrameCount;
                                     case Generic_Resolution : return Audio_Resolution;
@@ -3355,6 +3345,9 @@ size_t File__Analyze::Fill_Parameter(stream_t StreamKind, generic StreamPos)
                                     case Generic_BitRate_Encoded : return Text_BitRate_Encoded;
                                     case Generic_BitRate_Encoded_String : return Text_BitRate_Encoded_String;
                                     case Generic_FrameRate : return Text_FrameRate;
+                                    case Generic_FrameRate_String: return Text_FrameRate_String;
+                                    case Generic_FrameRate_Num: return Text_FrameRate_Num;
+                                    case Generic_FrameRate_Den: return Text_FrameRate_Den;
                                     case Generic_FrameCount : return Text_FrameCount;
                                     case Generic_Source_FrameCount : return Text_Source_FrameCount;
                                     case Generic_ColorSpace : return Text_ColorSpace;
@@ -3457,6 +3450,9 @@ size_t File__Analyze::Fill_Parameter(stream_t StreamKind, generic StreamPos)
                                     case Generic_Duration_String4 : return Other_Duration_String4;
                                     case Generic_Duration_String5 : return Other_Duration_String5;
                                     case Generic_FrameRate : return Other_FrameRate;
+                                    case Generic_FrameRate_String: return Other_FrameRate_String;
+                                    case Generic_FrameRate_Num: return Other_FrameRate_Num;
+                                    case Generic_FrameRate_Den: return Other_FrameRate_Den;
                                     case Generic_FrameCount : return Other_FrameCount;
                                     case Generic_Delay : return Other_Delay;
                                     case Generic_Delay_String : return Other_Delay_String;

--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -1639,24 +1639,23 @@ void File__Analyze::Streams_Finish_HumanReadable_PerStream(stream_t StreamKind, 
             Fill(Stream_Video, StreamPos_Last, Video_FrameRate_String, MediaInfoLib::Config.Language_Get(Retrieve(StreamKind, StreamPos, Video_FrameRate)+__T(" (24/30)"), __T(" fps")), true);
 
         //Special cases - Frame rate
-        if (StreamKind==Stream_Video
-         && Parameter==Video_FrameRate
-         && !Retrieve(StreamKind, StreamPos, Video_FrameRate).empty()
-         && !Retrieve(StreamKind, StreamPos, Video_FrameRate_Num).empty()
-         && !Retrieve(StreamKind, StreamPos, Video_FrameRate_Den).empty())
-            Fill(Stream_Video, StreamPos, Video_FrameRate_String, MediaInfoLib::Config.Language_Get(Retrieve(StreamKind, StreamPos, Video_FrameRate)+__T(" (")+Retrieve(StreamKind, StreamPos, Video_FrameRate_Num)+__T("/")+Retrieve(StreamKind, StreamPos, Video_FrameRate_Den)+__T(")"), __T(" fps")), true);
+        auto FrameRate_Index=Fill_Parameter(StreamKind, Generic_FrameRate);
+        if (Parameter==FrameRate_Index)
+        {
+            const auto& FrameRate=Retrieve_Const(StreamKind, StreamPos, FrameRate_Index);
+            const auto& FrameRate_Num=Retrieve_Const(StreamKind, StreamPos, Fill_Parameter(StreamKind, Generic_FrameRate_Num));
+            const auto& FrameRate_Den=Retrieve_Const(StreamKind, StreamPos, Fill_Parameter(StreamKind, Generic_FrameRate_Den));
+            if (!FrameRate.empty()
+             && !FrameRate_Num.empty()
+             && !FrameRate_Den.empty())
+                Fill(StreamKind, StreamPos, Fill_Parameter(StreamKind, Generic_FrameRate_String), MediaInfoLib::Config.Language_Get(FrameRate+__T(" (")+FrameRate_Num+__T("/")+FrameRate_Den+__T(")"), __T(" fps")), true);
+        }
         if (StreamKind==Stream_Video
          && Parameter==Video_FrameRate_Original
          && !Retrieve(StreamKind, StreamPos, Video_FrameRate_Original).empty()
          && !Retrieve(StreamKind, StreamPos, Video_FrameRate_Original_Num).empty()
          && !Retrieve(StreamKind, StreamPos, Video_FrameRate_Original_Den).empty())
             Fill(Stream_Video, StreamPos, Video_FrameRate_Original_String, MediaInfoLib::Config.Language_Get(Retrieve(StreamKind, StreamPos, Video_FrameRate_Original)+__T(" (")+Retrieve(StreamKind, StreamPos, Video_FrameRate_Original_Num)+__T("/")+Retrieve(StreamKind, StreamPos, Video_FrameRate_Original_Den)+__T(")"), __T(" fps")), true);
-        if (StreamKind==Stream_Other
-         && Parameter==Other_FrameRate
-         && !Retrieve(StreamKind, StreamPos, Other_FrameRate).empty()
-         && !Retrieve(StreamKind, StreamPos, Other_FrameRate_Num).empty()
-         && !Retrieve(StreamKind, StreamPos, Other_FrameRate_Den).empty())
-            Fill(Stream_Other, StreamPos, Other_FrameRate_String, MediaInfoLib::Config.Language_Get(Retrieve(StreamKind, StreamPos, Other_FrameRate)+__T(" (")+Retrieve(StreamKind, StreamPos, Other_FrameRate_Num)+__T("/")+Retrieve(StreamKind, StreamPos, Other_FrameRate_Den)+__T(")"), __T(" fps")), true);
     }
 
     //BitRate_Mode / OverallBitRate_Mode

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -5421,7 +5421,7 @@ void MediaInfo_Config_Text (ZtringListList &Info)
     "FrameRate_Mode;;;N YTY;;;Frame rate mode (CFR, VFR)\n"
     "FrameRate_Mode/String;;;N NT;;;Frame rate mode (Constant, Variable)\n"
     "FrameRate;; fps;N YFY;;;Frames per second\n"
-    "FrameRate/String;;;N NT;;;Frames per second (with measurement)\n"
+    "FrameRate/String;;;Y NT;;;Frames per second (with measurement)\n"
     "FrameRate_Num;;;N NIN;;;Frames per second, numerator\n"
     "FrameRate_Den;;;N NIN;;;Frames per second, denominator\n"
     "FrameRate_Minimum;; fps;N YFY;;;Minimum Frames per second\n"

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -7851,9 +7851,15 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stts()
     }
 
     FILLING_BEGIN();
-        if (StreamKind_Last==Stream_Video)
+        if (StreamKind_Last==Stream_Video || StreamKind_Last==Stream_Text)
         {
-            Fill(Stream_Video, StreamPos_Last, Video_FrameCount, Stream->second.stts_FrameCount);
+            Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_FrameCount), Stream->second.stts_FrameCount);
+            if (NumberOfEntries==1 && Stream->second.mdhd_Duration && Stream->second.mdhd_TimeScale)
+            {
+                auto FrameRate=(((float64)Stream->second.mdhd_Duration)/Stream->second.mdhd_TimeScale);
+                if (FrameRate)
+                    Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_FrameRate), Stream->second.stts_FrameCount/FrameRate);
+            }
 
             #ifdef MEDIAINFO_DVDIF_ANALYZE_YES
                 if (Streams[moov_trak_tkhd_TrackID].IsDvDif)

--- a/Source/MediaInfo/Text/File_Ttml.cpp
+++ b/Source/MediaInfo/Text/File_Ttml.cpp
@@ -196,17 +196,6 @@ void File_Ttml::Streams_Accept()
 //---------------------------------------------------------------------------
 void File_Ttml::Streams_Finish()
 {
-    if (FrameRate)
-    {
-        Fill(Stream_General, 0, General_FrameRate, FrameRate);
-        Fill(Stream_Text, 0, Text_FrameRate, FrameRate);
-    }
-    if (FrameRateMultiplier_Den!=1)
-    {
-        Fill(Stream_Text, 0, Text_FrameRate_Num, FrameRate_Int*FrameRateMultiplier_Num);
-        Fill(Stream_Text, 0, Text_FrameRate_Den, FrameRateMultiplier_Den);
-    }
-
     if (Time_End.HasValue() && Time_Begin.HasValue())
     {
         Fill(Stream_General, 0, General_Duration, Time_End.ToMilliseconds()-Time_Begin.ToMilliseconds());
@@ -348,6 +337,23 @@ void File_Ttml::Read_Buffer_Continue()
     Tt_Attribute=Root->Attribute("ttp:tickRate");
     if (Tt_Attribute)
         tickRate=atoi(Tt_Attribute);
+    if (FrameRate_Int && FrameRateMultiplier_Num && FrameRateMultiplier_Den)
+    {
+        FrameRate=((float64)FrameRate_Int)*FrameRateMultiplier_Num/FrameRateMultiplier_Den;
+        if ((FrameRateMultiplier_Num==1000 && FrameRateMultiplier_Den==1001)
+         || (FrameRateMultiplier_Num==999 && FrameRateMultiplier_Den==1000)) // Seen in a 23.976 file, mistake?
+            FrameRate_Is1001=true;
+    }
+    if (FrameRate)
+    {
+        Fill(Stream_General, 0, General_FrameRate, FrameRate);
+        Fill(Stream_Text, 0, Text_FrameRate, FrameRate);
+    }
+    if (FrameRate_Int && FrameRateMultiplier_Den!=1)
+    {
+        Fill(Stream_Text, 0, Text_FrameRate_Num, FrameRate_Int*FrameRateMultiplier_Num, 10, true);
+        Fill(Stream_Text, 0, Text_FrameRate_Den, FrameRateMultiplier_Den, 10, true);
+    }
     if (!FrameRate_Int && !tickRate)
     {
         #if MEDIAINFO_ADVANCED
@@ -363,13 +369,6 @@ void File_Ttml::Read_Buffer_Continue()
             FrameRateMultiplier_Num=1000;
             FrameRateMultiplier_Den=float64_int64s(FrameRate_Int/FrameRate_F*1000);
         }
-    }
-    if (FrameRate_Int && FrameRateMultiplier_Num && FrameRateMultiplier_Den)
-    {
-        FrameRate=((float64)FrameRate_Int)*FrameRateMultiplier_Num/FrameRateMultiplier_Den;
-        if ((FrameRateMultiplier_Num==1000 && FrameRateMultiplier_Den==1001)
-         || (FrameRateMultiplier_Num==999 && FrameRateMultiplier_Den==1000)) // Seen in a 23.976 file, mistake?
-            FrameRate_Is1001=true;
     }
     Tt_Attribute=Root->Attribute("xml:lang");
     if (!Tt_Attribute)

--- a/Source/Resource/Text/Stream/Text.csv
+++ b/Source/Resource/Text/Stream/Text.csv
@@ -143,7 +143,7 @@ DisplayAspectRatio_Original/String;;;Y NT;;;Original (in the raw stream) Display
 FrameRate_Mode;;;N YTY;;;Frame rate mode (CFR, VFR)
 FrameRate_Mode/String;;;N NT;;;Frame rate mode (Constant, Variable)
 FrameRate;; fps;N YFY;;;Frames per second
-FrameRate/String;;;N NT;;;Frames per second (with measurement)
+FrameRate/String;;;Y NT;;;Frames per second (with measurement)
 FrameRate_Num;;;N NIN;;;Frames per second, numerator
 FrameRate_Den;;;N NIN;;;Frames per second, denominator
 FrameRate_Minimum;; fps;N YFY;;;Minimum Frames per second


### PR DESCRIPTION
Text frame rate becomes `29.970 (29970/1000) FPS`.

Close https://github.com/MediaArea/MediaInfo/issues/610.