### PR TITLE
AAC: option for complete parse of all frames or none or partial, update

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac.cpp
+++ b/Source/MediaInfo/Audio/File_Aac.cpp
@@ -77,8 +77,10 @@ File_Aac::File_Aac()
     adts_buffer_fullness_Is7FF=false;
     #if MEDIAINFO_ADVANCED
         aac_frame_length_Total=0;
-        ParseCompletely=0;
     #endif //MEDIAINFO_ADVANCED
+    #if MEDIAINFO_MACROBLOCKS
+        ParseCompletely=0;
+    #endif //MEDIAINFO_MACROBLOCKS
 
     //Temp - Main
     muxConfigPresent=true;
@@ -292,9 +294,9 @@ void File_Aac::Read_Buffer_Continue()
     if (Frame_Count==0)
     {
         PTS_Begin=FrameInfo.PTS;
-        #if MEDIAINFO_ADVANCED
+        #if MEDIAINFO_MACROBLOCKS
             ParseCompletely=Config->File_Macroblocks_Parse_Get();
-        #endif //MEDIAINFO_ADVANCED
+        #endif //MEDIAINFO_MACROBLOCKS
     }
 
     switch(Mode)

--- a/Source/MediaInfo/Audio/File_Aac.h
+++ b/Source/MediaInfo/Audio/File_Aac.h
@@ -242,10 +242,12 @@ protected :
     bool    adts_buffer_fullness_Is7FF;
     #if MEDIAINFO_ADVANCED
         int64u  aac_frame_length_Total;
-        int     ParseCompletely;
-    #else //MEDIAINFO_ADVANCED
-        static constexpr int ParseCompletely=0;
     #endif //MEDIAINFO_ADVANCED
+    #if MEDIAINFO_MACROBLOCKS
+        int     ParseCompletely;
+    #else //MEDIAINFO_MACROBLOCKS
+        static constexpr int ParseCompletely=0;
+    #endif //MEDIAINFO_MACROBLOCKS
 
     //***********************************************************************
     // Elements - Speech coding (HVXC)


### PR DESCRIPTION
Fix of https://github.com/MediaArea/MediaInfoLib/commit/6eb6494f7658a658872c361b77b3ab3067fdaa54#r73156372