### PR TITLE
DV: option for avoiding useless buffering in some use cases

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -163,6 +163,7 @@ MediaInfo_Config_MediaInfo::MediaInfo_Config_MediaInfo()
         File_MergeBitRateInfo=true;
         File_HighestFormat=true;
         File_ChannelLayout=true;
+        File_FrameIsAlwaysComplete=false;
         #if MEDIAINFO_DEMUX
             File_Demux_Unpacketize_StreamLayoutChange_Skip=false;
         #endif //MEDIAINFO_DEMUX
@@ -548,6 +549,15 @@ Ztring MediaInfo_Config_MediaInfo::Option (const String &Option, const String &V
     {
         #if MEDIAINFO_ADVANCED
             File_ChannelLayout_Set(Value==__T("2018"));
+            return Ztring();
+        #else //MEDIAINFO_ADVANCED
+            return __T("Advanced features are disabled due to compilation options");
+        #endif //MEDIAINFO_ADVANCED
+    }
+    else if (Option_Lower==__T("file_frameisalwayscomplete"))
+    {
+        #if MEDIAINFO_ADVANCED
+            File_FrameIsAlwaysComplete_Set(!(Value==__T("0") || Value.empty()));
             return Ztring();
         #else //MEDIAINFO_ADVANCED
             return __T("Advanced features are disabled due to compilation options");

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
@@ -162,6 +162,8 @@ public :
         bool          File_HighestFormat_Get ();
         void          File_ChannelLayout_Set(bool NewValue);
         bool          File_ChannelLayout_Get();
+        void          File_FrameIsAlwaysComplete_Set(bool NewValue) { File_FrameIsAlwaysComplete = NewValue; }
+        bool          File_FrameIsAlwaysComplete_Get() { return File_FrameIsAlwaysComplete; }
 #endif //MEDIAINFO_ADVANCED
 
     #if MEDIAINFO_DEMUX
@@ -457,6 +459,7 @@ private :
         bool                File_MergeBitRateInfo;
         bool                File_HighestFormat;
         bool                File_ChannelLayout;
+        bool                File_FrameIsAlwaysComplete;
         #if MEDIAINFO_DEMUX
             bool                File_Demux_Unpacketize_StreamLayoutChange_Skip;
         #endif //MEDIAINFO_DEMUX

--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -814,27 +814,34 @@ bool File_DvDif::Demux_UnpacketizeContainer_Test()
      && (CC3(Buffer+Buffer_Offset+6*80)&0xE0F0FF)==0x600000   //Audio 0
      && (CC3(Buffer+Buffer_Offset+7*80)&0xE0F0FF)==0x800000)  //Video 0
     {
-        if (Demux_Offset==0)
+        if (FrameIsAlwaysComplete)
         {
-            Demux_Offset=Buffer_Offset+1;
+            Demux_Offset=Buffer_Size;
         }
+        else
+        {
+            if (Demux_Offset==0)
+            {
+                Demux_Offset=Buffer_Offset+1;
+            }
 
-        while (Demux_Offset+8*80<=Buffer_Size //8 blocks
-            && !((Buffer[Demux_Offset]&0xE0)==0x00   //Speed up the parsing
-              && (CC3(Buffer+Demux_Offset+0*80)&0xE0FCFF)==0x000400   //Header 0 (with FSC==false and FSP==true)
-              && (CC3(Buffer+Demux_Offset+1*80)&0xE0F0FF)==0x200000   //Subcode 0
-              && (CC3(Buffer+Demux_Offset+2*80)&0xE0F0FF)==0x200001   //Subcode 1
-              && (CC3(Buffer+Demux_Offset+3*80)&0xE0F0FF)==0x400000   //VAUX 0
-              && (CC3(Buffer+Demux_Offset+4*80)&0xE0F0FF)==0x400001   //VAUX 1
-              && (CC3(Buffer+Demux_Offset+5*80)&0xE0F0FF)==0x400002   //VAUX 2
-              && (CC3(Buffer+Demux_Offset+6*80)&0xE0F0FF)==0x600000   //Audio 0
-              && (CC3(Buffer+Demux_Offset+7*80)&0xE0F0FF)==0x800000)) //Video 0
-                Demux_Offset++;
+            while (Demux_Offset+8*80<=Buffer_Size //8 blocks
+                && !((Buffer[Demux_Offset]&0xE0)==0x00   //Speed up the parsing
+                  && (CC3(Buffer+Demux_Offset+0*80)&0xE0FCFF)==0x000400   //Header 0 (with FSC==false and FSP==true)
+                  && (CC3(Buffer+Demux_Offset+1*80)&0xE0F0FF)==0x200000   //Subcode 0
+                  && (CC3(Buffer+Demux_Offset+2*80)&0xE0F0FF)==0x200001   //Subcode 1
+                  && (CC3(Buffer+Demux_Offset+3*80)&0xE0F0FF)==0x400000   //VAUX 0
+                  && (CC3(Buffer+Demux_Offset+4*80)&0xE0F0FF)==0x400001   //VAUX 1
+                  && (CC3(Buffer+Demux_Offset+5*80)&0xE0F0FF)==0x400002   //VAUX 2
+                  && (CC3(Buffer+Demux_Offset+6*80)&0xE0F0FF)==0x600000   //Audio 0
+                  && (CC3(Buffer+Demux_Offset+7*80)&0xE0F0FF)==0x800000)) //Video 0
+                    Demux_Offset++;
 
-        if (Demux_Offset+8*80>Buffer_Size && File_Offset+Buffer_Size!=File_Size)
-            return false; //No complete frame
-        if (Demux_Offset+8*80>Buffer_Size && File_Offset+Buffer_Size==File_Size)
-            Demux_Offset=(size_t)(File_Size-File_Offset); //Using the complete buffer (no next sync)
+            if (Demux_Offset+8*80>Buffer_Size && File_Offset+Buffer_Size!=File_Size)
+                return false; //No complete frame
+            if (Demux_Offset+8*80>Buffer_Size && File_Offset+Buffer_Size==File_Size)
+                Demux_Offset=(size_t)(File_Size-File_Offset); //Using the complete buffer (no next sync)
+        }
 
         Element_Code=-1;
         FrameInfo.DTS=FrameInfo.PTS=Speed_FrameCount_system[0]*100100000/3+Speed_FrameCount_system[1]*40000000;

--- a/Source/MediaInfo/Multiple/File_DvDif.h
+++ b/Source/MediaInfo/Multiple/File_DvDif.h
@@ -32,6 +32,7 @@ class File_DvDif : public File__Analyze
 public :
     //In
     int64u Frame_Count_Valid;
+    bool   FrameIsAlwaysComplete;
     int8u  AuxToAnalyze; //Only Aux must be parsed
     bool   IgnoreAudio;
 
@@ -60,6 +61,7 @@ protected :
 
     //Buffer - Global
     #ifdef MEDIAINFO_DVDIF_ANALYZE_YES
+    void Read_Buffer_Init();
     void Read_Buffer_Continue();
     #endif //MEDIAINFO_DVDIF_ANALYZE_YES
     void Read_Buffer_Unsynched();


### PR DESCRIPTION
e.g. for DVRescue and deck input, we know that the provided frame is complete so we don't have to wait to the next bytes for probing if we have a DV50 frame in the case of a DV25 frame.