### PR TITLE
MOV/MPEG-4: Fix frame count for NDF non-integer frame rates

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -5092,6 +5092,8 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_tmcd()
         Parser->mvhd_Duration_TimeScale=moov_mvhd_TimeScale;
         Parser->mdhd_Duration=Streams[moov_trak_tkhd_TrackID].mdhd_Duration;
         Parser->mdhd_Duration_TimeScale=Streams[moov_trak_tkhd_TrackID].mdhd_TimeScale;
+        Parser->tmcd_Duration = tc->FrameDuration;
+        Parser->tmcd_Duration_TimeScale = tc->TimeScale;
 
         //Get delay from timecode track's edit list
         int64s FrameDurationInMediaUnits = tc->FrameDuration * Streams[moov_trak_tkhd_TrackID].mdhd_TimeScale;

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
@@ -34,6 +34,8 @@ public :
     int64u  mvhd_Duration_TimeScale;
     int64u  mdhd_Duration;
     int64u  mdhd_Duration_TimeScale;
+    int64u  tmcd_Duration;
+    int64u  tmcd_Duration_TimeScale;
 
     //Out
     int64s  Pos;


### PR DESCRIPTION
Frame count computing was based on time code frame rate e.g. 24 instead of real frame rate e.g. 23.98.