### PR TITLE
MOV/MPEG-4: List of QuickTime time code discontinuities

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -638,6 +638,7 @@ private :
     mdat_Pos_Type* mdat_Pos_Temp_ToJump;
     mdat_Pos_Type* mdat_Pos_Max;
     std::vector<int32u> mdat_Pos_ToParseInPriority_StreamIDs;
+    std::vector<size_t> mdat_Pos_ToParseInPriority_StreamIDs_ToRemove;
     bool                mdat_Pos_NormalParsing;
     void Skip_NulString(const char* Name);
 

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
@@ -39,6 +39,7 @@ public :
 
     //Out
     int64s  Pos;
+    int64s  Pos_Last;
 
     //Constructor/Destructor
     File_Mpeg4_TimeCode();


### PR DESCRIPTION
Example:

```
Format                                   : QuickTime TC
Duration                                 : 22 s 22 ms
Frame rate                               : 23.976 (24000/1001) FPS
Time code of first frame                 : 00:00:00:00
Time code of last frame                  : 00:00:18:22
Discontinuities                          : 00:00:06:23-00:00:04:01
```

Require ` --ParseSpeed=0.7` or more.

Close https://github.com/MediaArea/MediaConch/issues/231.
