### PR TITLE
Win32: Use non-unicode lib name when unicode is disabled

### DIFF
--- a/Source/MediaInfoDLL/MediaInfoDLL.h
+++ b/Source/MediaInfoDLL/MediaInfoDLL.h
@@ -124,7 +124,7 @@
         #endif //MEDIAINFODLL_NAME
     #else //_UNICODE
         #ifndef MEDIAINFODLL_NAME
-            #define MEDIAINFODLL_NAME L"MediaInfo.dll"
+            #define MEDIAINFODLL_NAME "MediaInfo.dll"
         #endif //MEDIAINFODLL_NAME
     #endif //_UNICODE
 #elif defined(__APPLE__) && defined(__MACH__)


### PR DESCRIPTION
While using newest MediaInfoLib on Windows I wasn't able to compile without Unicode support. 

We must use the non-unicode name as LoadLibrary alias to LoadLibraryA on Windows when _UNICODE is not defined. Therefore LoadLibrary will only accept char*, not wchar_t*.
If we don't do that we get a compilation error when loading the library.