### PR TITLE
Text streams: show stream frame rate if not same as container frame rate , update

### DIFF
--- a/Source/Resource/Text/Stream/Text.csv
+++ b/Source/Resource/Text/Stream/Text.csv
@@ -142,6 +142,8 @@ DisplayAspectRatio_Original;;;N YFY;;;Original (in the raw stream) Display Aspec
 DisplayAspectRatio_Original/String;;;Y NT;;;Original (in the raw stream) Display Aspect ratio
 FrameRate_Mode;;;N YTY;;;Frame rate mode (CFR, VFR)
 FrameRate_Mode/String;;;N NT;;;Frame rate mode (Constant, Variable)
+FrameRate_Mode_Original;;;N YTY;;;Original frame rate mode (CFR, VFR)
+FrameRate_Mode_Original/String;;;Y NT;;;Original frame rate mode (Constant, Variable)
 FrameRate;; fps;N YFY;;;Frames per second
 FrameRate/String;;;Y NT;;;Frames per second (with measurement)
 FrameRate_Num;;;N NIN;;;Frames per second, numerator
@@ -152,8 +154,10 @@ FrameRate_Nominal;; fps;N YFY;;;Nominal Frames per second
 FrameRate_Nominal/String;;;N NT;;;Nominal Frames per second (with measurement)
 FrameRate_Maximum;; fps;N YFY;;;Maximum Frames per second
 FrameRate_Maximum/String;;;N NT;;;Maximum Frames per second (with measurement)
-FrameRate_Original;; fps;N YFY;;;Original (in the raw stream) Frames per second
-FrameRate_Original/String;;;N NT;;;Original (in the raw stream) Frames per second (with measurement)
+FrameRate_Original;; fps;N YFY;;;Original (in the raw stream) frames per second
+FrameRate_Original/String;;;Y NT;;;Original (in the raw stream) frames per second (with measurement)
+FrameRate_Original_Num;;;N NFN;;;Frames per second, numerator
+FrameRate_Original_Den;;;N NFN;;;Frames per second, denominator
 FrameCount;;;N NIY;;;Number of frames
 ElementCount;;;Y NIY;;;Number of displayed elements
 Source_FrameCount;;;N NIY;;;Source Number of frames


### PR DESCRIPTION
Update (missing file update) of https://github.com/MediaArea/MediaInfoLib/pull/1577/files