### PR TITLE
Remove the support for bitcode (ios)

### DIFF
--- a/Project/iOS/build.sh
+++ b/Project/iOS/build.sh
@@ -21,9 +21,9 @@ build_lib()
     export CXX="$(xcrun -sdk iphoneos -find clang++)"
     export AR="$(xcrun -sdk iphoneos -find ar)"
     export RANLIB="$(xcrun -sdk iphoneos -find ranlib)"
-    export CFLAGS="-stdlib=libc++ -fembed-bitcode -arch ${target} -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform.sdk -miphoneos-version-min=$IPHONEOS_DEPLOYMENT_TARGET"
-    export CXXFLAGS="-stdlib=libc++ -fembed-bitcode -arch ${target}  -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform.sdk -miphoneos-version-min=$IPHONEOS_DEPLOYMENT_TARGET"
-    export LDFLAGS="-stdlib=libc++ -fembed-bitcode -arch ${target} -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform.sdk"
+    export CFLAGS="-stdlib=libc++ -arch ${target} -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform.sdk -miphoneos-version-min=$IPHONEOS_DEPLOYMENT_TARGET"
+    export CXXFLAGS="-stdlib=libc++ -arch ${target}  -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform.sdk -miphoneos-version-min=$IPHONEOS_DEPLOYMENT_TARGET"
+    export LDFLAGS="-stdlib=libc++ -arch ${target} -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform.sdk"
 
     pushd "$(dirname "${BASH_SOURCE[0]}")/../GNU/Library"
         ./configure --prefix="$prefix" --disable-shared --enable-static --host=$host-apple-darwin


### PR DESCRIPTION
According to Xcode 14 documentation:

> Deprecations
> Starting with Xcode 14, bitcode is no longer required for watchOS and tvOS applications, and the App Store no longer accepts bitcode submissions from Xcode 14.
> 
> Xcode no longer builds bitcode by default and generates a warning message if a project explicitly enables bitcode: “Building with bitcode is deprecated. Please update your project and/or target settings to disable bitcode.” The capability to build with bitcode will be removed in a future Xcode release. IPAs that contain bitcode will have the bitcode stripped before being submitted to the App Store. Debug symbols for past bitcode submissions remain available for download. (86118779)

> Because bitcode is now deprecated, builds for iOS, tvOS, and watchOS no longer include bitcode by default. (87590506)

https://developer.apple.com/documentation/Xcode-Release-Notes/xcode-14-release-notes