### PR TITLE
Remove python2-mediainfo Arch package

### DIFF
--- a/Project/GNU/PKGBUILD
+++ b/Project/GNU/PKGBUILD
@@ -2,14 +2,14 @@
 # Maintainer: MediaArea.net SARL <info@mediaarea.net>
 # Contributor: hydro <hydro@freenet.de>
 
-pkgname=('libmediainfo' 'python2-mediainfo' 'python-mediainfo')
+pkgname=('libmediainfo' 'python-mediainfo')
 pkgver=22.06
 pkgrel=1
 pkgdesc="shared library for mediainfo"
 arch=('i686' 'x86_64')
 url="http://mediaarea.net"
 license=('BSD-2-Clause')
-makedepends=('libtool' 'automake' 'autoconf' 'python' 'python2')
+makedepends=('libtool' 'automake' 'autoconf' 'python')
 depends=( 'curl' 'libmms' 'libzen>=0.4.39')
 source=(${pkgname}_${pkgver}.orig.tar.xz)
 md5sums=('00000000000000000000000000000000')
@@ -29,15 +29,6 @@ package_libmediainfo() {
     install -dm 755 $pkgdir/usr/include/$i
     install -m 644 $srcdir/MediaInfoLib/Source/$i/*.h $pkgdir/usr/include/$i
   done
-}
-
-package_python2-mediainfo() {
-  pkgdesc="shared library for mediainfo - python2 binding"
-  depends=('python' 'libmediainfo')
-  local dst=$(python2 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-  install -dm 755 $pkgdir/$dst
-  install -m 644 $srcdir/MediaInfoLib/Source/MediaInfoDLL/MediaInfoDLL.py $pkgdir/$dst
-  python2 -m compileall $pkgdir/$dst
 }
 
 package_python-mediainfo() {


### PR DESCRIPTION
python2 support removed from Arch Extra

Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>