### PR TITLE
MOV/MP4: avoid to parse lot of frames if parser fails to parse the frames

### DIFF
--- a/Source/MediaInfo/Audio/File_Pcm.cpp
+++ b/Source/MediaInfo/Audio/File_Pcm.cpp
@@ -22,9 +22,7 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/Audio/File_Pcm.h"
-#if MEDIAINFO_DEMUX
-    #include "MediaInfo/MediaInfo_Config_MediaInfo.h"
-#endif //MEDIAINFO_DEMUX
+#include "MediaInfo/MediaInfo_Config_MediaInfo.h"
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
@@ -297,6 +295,9 @@ bool File_Pcm::FileHeader_Begin()
         Accept();
         Finish();
     }
+
+    if (Frame_Count_Valid==16 && Config->ParseSpeed<0.5)
+        Frame_Count_Valid=1;
 
     return true;
 }

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -2025,7 +2025,7 @@ void File_Mpeg4::mdat_xxxx()
         #endif //MEDIAINFO_DEMUX
         Element_Show();
 
-        if (!Stream_Temp.IsFilled && Stream_Temp.Parsers[Pos]->Status[IsFilled])
+        if (!Stream_Temp.IsFilled && (Stream_Temp.Parsers[Pos]->Status[IsFilled] || Stream_Temp.Parsers[Pos]->Status[IsFinished]))
         {
             #if MEDIAINFO_DEMUX
                 if (Stream_Temp.TimeCode) //If this is a TimeCode track
@@ -7226,7 +7226,16 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxx_glbl()
 
     //Parsing
     for (size_t Pos=0; Pos<Streams[moov_trak_tkhd_TrackID].Parsers.size(); Pos++)
-        Open_Buffer_OutOfBand(Streams[moov_trak_tkhd_TrackID].Parsers[Pos]);
+    {
+        auto& Sub = Streams[moov_trak_tkhd_TrackID].Parsers[Pos];
+        Open_Buffer_OutOfBand(Sub);
+        if (Sub->Status[IsFinished])
+        {
+            delete Sub; //Sub = nullptr;
+            Streams[moov_trak_tkhd_TrackID].Parsers.erase(Streams[moov_trak_tkhd_TrackID].Parsers.begin()+Pos);
+            Pos--;
+        }
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Video/File_ProRes.h
+++ b/Source/MediaInfo/Video/File_ProRes.h
@@ -37,6 +37,7 @@ private :
     void Streams_Fill();
 
     //Buffer - Global
+    void Read_Buffer_OutOfBand();
     void Read_Buffer_Continue ();
 };
 


### PR DESCRIPTION
Fix https://github.com/MediaArea/MediaInfo/issues/655.

Also support correctly FFmpeg glbl atom. Skip all glbl elements but the color range, so ProRes can now have color range info.