### PR TITLE
WAV: display MD5 of content

### DIFF
--- a/Source/MediaInfo/Audio/File_Flac.cpp
+++ b/Source/MediaInfo/Audio/File_Flac.cpp
@@ -173,6 +173,7 @@ void File_Flac::Data_Parse()
 void File_Flac::STREAMINFO()
 {
     //Parsing
+    int128u MD5Stored;
     int64u Samples;
     int32u FrameSize_Min, FrameSize_Max, SampleRate;
     int8u  Channels, BitPerSample;
@@ -186,7 +187,7 @@ void File_Flac::STREAMINFO()
     Get_S1 ( 5, BitPerSample,                                   "BitPerSample"); Param_Info2(BitPerSample+1, " bits"); //(bits per sample)-1. FLAC supports from 4 to 32 bits per sample. Currently the reference encoder and decoders only support up to 24 bits per sample.
     Get_S5 (36, Samples,                                        "Samples");
     BS_End();
-    Skip_B16(                                                   "MD5 signature of the unencoded audio data");
+    Get_B16 (   MD5Stored,                                      "MD5 signature of the unencoded audio data");
 
     FILLING_BEGIN();
         if (SampleRate==0)
@@ -207,6 +208,11 @@ void File_Flac::STREAMINFO()
         Fill(Stream_Audio, 0, Audio_BitDepth, BitPerSample+1);
         if (!IsSub)
             Fill(Stream_Audio, 0, Audio_Duration, Samples*1000/SampleRate);
+        Ztring MD5_PerItem;
+        MD5_PerItem.From_UTF8(uint128toString(MD5Stored, 16));
+        while (MD5_PerItem.size()<32)
+            MD5_PerItem.insert(MD5_PerItem.begin(), '0'); //Padding with 0, this must be a 32-byte string
+        Fill(Stream_Audio, 0, "MD5", MD5_PerItem);
     FILLING_END();
 }
 

--- a/Source/MediaInfo/Audio/File_Flac.cpp
+++ b/Source/MediaInfo/Audio/File_Flac.cpp
@@ -212,7 +212,7 @@ void File_Flac::STREAMINFO()
         MD5_PerItem.From_UTF8(uint128toString(MD5Stored, 16));
         while (MD5_PerItem.size()<32)
             MD5_PerItem.insert(MD5_PerItem.begin(), '0'); //Padding with 0, this must be a 32-byte string
-        Fill(Stream_Audio, 0, "MD5", MD5_PerItem);
+        Fill(Stream_Audio, 0, "MD5_Unencoded", MD5_PerItem);
     FILLING_END();
 }
 

--- a/Source/MediaInfo/File__Analyze_Buffer.cpp
+++ b/Source/MediaInfo/File__Analyze_Buffer.cpp
@@ -582,8 +582,8 @@ void File__Analyze::Get_L16(int128u &Info, const char* Name)
 {
     INTEGRITY_SIZE_ATLEAST_INT(16);
     //Info=LittleEndian2int128u(Buffer+Buffer_Offset+(size_t)Element_Offset);
-    Info.hi=LittleEndian2int64u(Buffer+Buffer_Offset+(size_t)Element_Offset);
-    Info.lo=LittleEndian2int64u(Buffer+Buffer_Offset+(size_t)Element_Offset+8);
+    Info.lo=LittleEndian2int64u(Buffer+Buffer_Offset+(size_t)Element_Offset);
+    Info.hi=LittleEndian2int64u(Buffer+Buffer_Offset+(size_t)Element_Offset+8);
     if (Trace_Activated) Param(Name, Info);
     Element_Offset+=16;
 }

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -1001,6 +1001,8 @@ void MediaInfo_Config_DefaultLanguage (Translation &Info)
     "MaxGain;Max gain\n"
     "MaximumMomentaryLoudness;Maximum momentary loudness\n"
     "MaxTruePeak;Max true peak\n"
+    "MD5;MD5\n"
+    "MD5_Unencoded;MD5 of the unencoded content\n"
     "MediaInfo_About;MediaInfo provides easy access to technical and tag information about video and audio files.\r\nExcept the Mac App Store graphical user interface, it is open-source software, which means that it is free of charge to the end user and developers have freedom to study, to improve and to redistribute the program (BSD license)\n"
     "Menu;Menu\n"
     "Menu stream(s);Menu streams\n"

--- a/Source/MediaInfo/Multiple/File_Riff.h
+++ b/Source/MediaInfo/Multiple/File_Riff.h
@@ -331,6 +331,7 @@ private :
     void WAVE_INFO() {AVI__INFO();}
     void WAVE_INFO_xxxx() {AVI__INFO_xxxx ();}
     void WAVE_iXML ();
+    void WAVE_MD5_() { AVI__MD5_(); }
     void WAVE_mext ();
     void wave ();
     void wave_data () {WAVE_data();}

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -2418,7 +2418,6 @@ void File_Riff::AVI__MD5_()
         MD5_PerItem.From_UTF8(uint128toString(MD5Stored, 16));
         while (MD5_PerItem.size()<32)
             MD5_PerItem.insert(MD5_PerItem.begin(), '0'); //Padding with 0, this must be a 32-byte string
-        MD5_PerItem.MakeLowerCase();
         MD5s.push_back(MD5_PerItem);
     }
 }

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -447,6 +447,7 @@ namespace Elements
     const int32u WAVE_id3_=0x69643320;
     const int32u WAVE_INFO=0x494E464F;
     const int32u WAVE_iXML=0x69584D4C;
+    const int32u WAVE_MD5_=0x4D443520;
     const int32u WAVE_mext=0x6D657874;
     const int32u wave=0x77617665;
     const int32u wave_data=0x64617461;
@@ -648,6 +649,7 @@ void File_Riff::Data_Parse()
         LIST(WAVE_INFO)
             ATOM_DEFAULT_ALONE(WAVE_INFO_xxxx)
         ATOM(WAVE_iXML)
+        ATOM(WAVE_MD5_)
         ATOM(WAVE_mext)
         ATOM_END
     LIST(wave)

--- a/Source/Resource/Text/Language/DefaultLanguage.csv
+++ b/Source/Resource/Text/Language/DefaultLanguage.csv
@@ -972,6 +972,8 @@ MaxFALL;Maximum Frame-Average Light Level
 MaxGain;Max gain
 MaximumMomentaryLoudness;Maximum momentary loudness
 MaxTruePeak;Max true peak
+MD5;MD5
+MD5_Unencoded;MD5 of the unencoded content
 MediaInfo_About;MediaInfo provides easy access to technical and tag information about video and audio files.\r\nExcept the Mac App Store graphical user interface, it is open-source software, which means that it is free of charge to the end user and developers have freedom to study, to improve and to redistribute the program (BSD license)
 Menu;Menu
 Menu stream(s);Menu streams


### PR DESCRIPTION
Fix https://github.com/MediaArea/MediaAreaXml/issues/54.
Also display WAV MD5 to MediaInfo report, as well as FLAC MD5 of unencoded content.