### PR TITLE
Fix MSVC2022 project Includes

### DIFF
--- a/Project/MSVC2022/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2022/Library/MediaInfoLib.vcxproj
@@ -672,7 +672,7 @@
     <ClInclude Include="..\..\..\Source\ThirdParty\tinyxml2\tinyxml2.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\ZenLib\Project\MSVC2019\Library\ZenLib.vcxproj">
+    <ProjectReference Include="..\..\..\..\ZenLib\Project\MSVC2022\Library\ZenLib.vcxproj">
       <Project>{0da1da7d-f393-4e7c-a7ce-cb5c6a67bc94}</Project>
     </ProjectReference>
     <ProjectReference Include="..\..\..\..\zlib\contrib\vstudio\vc17\zlibstat.vcxproj">

--- a/Project/MSVC2022/RegressionTest/RegressionTest.vcxproj
+++ b/Project/MSVC2022/RegressionTest/RegressionTest.vcxproj
@@ -30,7 +30,7 @@
     <ClInclude Include="..\..\..\Source\ThirdParty\md5\md5.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\ZenLib\Project\MSVC2019\Library\ZenLib.vcxproj">
+    <ProjectReference Include="..\..\..\..\ZenLib\Project\MSVC2022\Library\ZenLib.vcxproj">
       <Project>{0da1da7d-f393-4e7c-a7ce-cb5c6a67bc94}</Project>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
The MSVC2022 project Includes point to the MSVC2019 project for ZenLib. Point to the MSVC2022 project instead to prevent build failures on systems with only the v143 toolset.