### PR TITLE
AAC: Add missing code in sbr_channel_pair_element() (#1624)

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac_GeneralAudio_Sbr.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_GeneralAudio_Sbr.cpp
@@ -583,6 +583,7 @@ void File_Aac::sbr_channel_pair_element()
         //Coupling
         sbr->bs_num_env    [1]=sbr->bs_num_env    [0];
         sbr->bs_num_noise  [1]=sbr->bs_num_noise  [0];
+        sbr->bs_amp_res    [1]=sbr->bs_amp_res    [0];
         for (int8u env=0; env<sbr->bs_num_env[0]; env++)
             sbr->bs_freq_res[1][env]=sbr->bs_freq_res[0][env];
     }


### PR DESCRIPTION
Modified bs_amp_res value to handle correctly when bs_coupling=1 in sbr_channel_pair_element().
If the bs_coupling value is 1, the bs_amp_res value for each channel must be the same.

reference: ISO-IEC 14496-3 (2019) - Table 4.119 (4.5.2.8)
ffmpeg code : https://www.ffmpeg.org/doxygen/3.2/aacsbr__template_8c_source.html#l009999 (See copy_sbr_grid() and read_sbr_channel_pair_element() functions)

Issue: https://github.com/MediaArea/MediaInfoLib/issues/1624