### PR TITLE
MPEG-Audio: proper support of Helix MP3 encoder detection

### DIFF
--- a/Source/MediaInfo/Audio/File_Mpega.cpp
+++ b/Source/MediaInfo/Audio/File_Mpega.cpp
@@ -1445,6 +1445,8 @@ void File_Mpega::Header_Encoders_Lame()
              ||  Tag[4]=='3' && Tag[8]>='0' && Tag[8]<='9')                                                     // v3.xy0-v3.xy9
                 HasInfoTag=true;
         }
+        if (Name==0x4C414D45 && Tag[4]=='H') // "LAMEH", Helix MP3 encoder
+            HasInfoTag=true;
         if (Name==0x4C332E39   // "L3.9"
          && Tag[4]=='9')
             HasInfoTag=true; //Form old code, to be confirmed: Ugly version string in Lame 3.99.1 "L3.99r1\0".


### PR DESCRIPTION
Fix https://github.com/MediaArea/MediaInfoLib/issues/1637.

```
Writing library                          : LAMEH5.21
Encoding settings                        : -m  -lowpass 11.7
```

```
Writing library                          : LAMEH5.21
Encoding settings                        : -m  -V 5 -q 0 -lowpass 15.8
```
