### PR TITLE
MXF: quicker parsing when fast parsing is requested

### DIFF
--- a/Source/MediaInfo/Audio/File_Ac3.cpp
+++ b/Source/MediaInfo/Audio/File_Ac3.cpp
@@ -1811,7 +1811,7 @@ bool File_Ac3::Synchronize()
 void File_Ac3::Synched_Init()
 {
     if (!Frame_Count_Valid)
-        Frame_Count_Valid=Config->ParseSpeed>=0.3?32:2;
+        Frame_Count_Valid=Config->ParseSpeed>=0.3?32:(IsSub?1:2);
 
     //FrameInfo
     PTS_End=0;

--- a/Source/MediaInfo/Audio/File_Ac4.cpp
+++ b/Source/MediaInfo/Audio/File_Ac4.cpp
@@ -1866,7 +1866,7 @@ void File_Ac4::Synched_Init()
     Accept();
     
     if (!Frame_Count_Valid)
-        Frame_Count_Valid=Config->ParseSpeed>=0.3?128:2;
+        Frame_Count_Valid=Config->ParseSpeed>=0.3?128:(IsSub?1:2);
 
     //FrameInfo
     PTS_End=0;

--- a/Source/MediaInfo/Audio/File_Dts.cpp
+++ b/Source/MediaInfo/Audio/File_Dts.cpp
@@ -766,7 +766,7 @@ bool File_Dts::FileHeader_Begin()
 
     //All should be OK...
     if (!Frame_Count_Valid)
-        Frame_Count_Valid=Config->ParseSpeed>=0.3?32:2;
+        Frame_Count_Valid=Config->ParseSpeed>=0.3?32:(IsSub?1:2);
     return true;
 }
 

--- a/Source/MediaInfo/Audio/File_Iab.h
+++ b/Source/MediaInfo/Audio/File_Iab.h
@@ -57,7 +57,12 @@ private :
     {
         vector<int32u> ChannelLayout;
     };
-    vector<object> Objects;
+    struct frame
+    {
+        vector<object> Objects;
+    };
+    frame                       Frame;
+    frame                       F;
 
     //Helpers
     void Get_Plex(int8u Bits, int32u& Info, const char* Name);

--- a/Source/MediaInfo/Audio/File_Mpega.cpp
+++ b/Source/MediaInfo/Audio/File_Mpega.cpp
@@ -584,7 +584,7 @@ bool File_Mpega::FileHeader_Begin()
 
     //Seems OK
     if (!Frame_Count_Valid)
-        Frame_Count_Valid=Config->ParseSpeed>=0.5?128:(Config->ParseSpeed>=0.3?32:4);
+        Frame_Count_Valid=Config->ParseSpeed>=0.5?128:(Config->ParseSpeed>=0.3?32:(IsSub?1:4));
     return true;
 }
 

--- a/Source/MediaInfo/Audio/File_SmpteSt0331.cpp
+++ b/Source/MediaInfo/Audio/File_SmpteSt0331.cpp
@@ -160,6 +160,7 @@ void File_SmpteSt0331::Read_Buffer_Continue()
 
     Skip_XX(Element_Size-4,                             "Data");
 
+    Frame_Count++;
     Frame_Count_InThisBlock++;
     if (Frame_Count_NotParsedIncluded!=(int64u)-1)
         Frame_Count_NotParsedIncluded++;
@@ -179,22 +180,10 @@ void File_SmpteSt0331::Read_Buffer_Continue()
     #endif //MEDIAINFO_DEMUX
 
     FILLING_BEGIN();
-    if (!Status[IsAccepted])
-    {
-        Accept("SMPTE ST 331");
-
-        int8u Channels=0;
-        for (int8u Pos=0; Pos<8; Pos++)
-        {
-            if (Channels_valid&(1<<Pos))
-                Channels++;
-            Element_Offset+=4;
-        }
-
-        Stream_Prepare(Stream_Audio);
-        Fill(Stream_Audio, 0, Audio_Format, "PCM");
-        Fill(Stream_Audio, 0, Audio_Channel_s_, Channels);
-    }
+        if (!Status[IsAccepted])
+            Accept("SMPTE ST 331");
+        if (!Status[IsFilled])
+            Fill("SMPTE ST 331");
     FILLING_END();
 }
 

--- a/Source/MediaInfo/Multiple/File_Ancillary.cpp
+++ b/Source/MediaInfo/Multiple/File_Ancillary.cpp
@@ -458,6 +458,8 @@ void File_Ancillary::Read_Buffer_AfterParsing()
     Frame_Count_InThisBlock++;
     if (Frame_Count_NotParsedIncluded!=(int64u)-1)
         Frame_Count_NotParsedIncluded++;
+    if (!Status[IsFilled] && Config->ParseSpeed<=0)
+        Fill();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -236,7 +236,7 @@ File_DvDif::File_DvDif()
     Buffer_TotalBytes_FirstSynched_Max=64*1024;
 
     //In
-    Frame_Count_Valid=2;
+    Frame_Count_Valid=IsSub?1:2;
     AuxToAnalyze=0x00; //No Aux to analyze
     IgnoreAudio=false;
 

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -4895,6 +4895,15 @@ void File_Mxf::Read_Buffer_AfterParsing()
         if (File_GoTo==(int64u)-1)
             GoToFromEnd(0);
     }
+
+    if (IsSub)
+    {
+        Frame_Count++;
+        if (Frame_Count_NotParsedIncluded!=(int64u)-1)
+            Frame_Count_NotParsedIncluded++;
+        if (!Status[IsFilled] && Config->ParseSpeed<=0)
+            Fill();
+    }
 }
 
 //---------------------------------------------------------------------------
@@ -5102,7 +5111,7 @@ void File_Mxf::Read_Buffer_Unsynched()
 #if (MEDIAINFO_DEMUX || MEDIAINFO_SEEK) && defined(MEDIAINFO_FILE_YES)
 bool File_Mxf::DetectDuration ()
 {
-    if (Duration_Detected)
+    if (Config->ParseSpeed<=0 || Duration_Detected)
         return false;
 
     MediaInfo_Internal MI;
@@ -6640,7 +6649,6 @@ void File_Mxf::Data_Parse()
                             Parsing_Size=Element_Size-Element_Offset; // There is a problem
                         if (Parsing_Size>Array_Size)
                             Parsing_Size=Array_Size; // There is a problem
-                        (*Parser)->Frame_Count=Frame_Count;
                         (*Parser)->Frame_Count_NotParsedIncluded=Frame_Count_NotParsedIncluded;
                         Open_Buffer_Continue((*Parser), Buffer+Buffer_Offset+(size_t)(Element_Offset), Parsing_Size);
                         if ((Code_Compare4&0xFF00FF00)==0x17000100 && LineNumber==21 && (*Parser)->Count_Get(Stream_Text)==0)
@@ -6655,8 +6663,18 @@ void File_Mxf::Data_Parse()
                             Skip_XX(Array_Size-Parsing_Size,    "Padding");
                         Element_End0();
                     }
-                    if (IsSub)
-                        Frame_Count++;
+                    if (!Essence->second.IsFilled && (!Count || (Essence->second.Parsers.size()==1 && Essence->second.Parsers[0]->Status[IsFilled])))
+                    {
+                        if (Streams_Count>0)
+                            Streams_Count--;
+                        Essence->second.IsFilled=true;
+                        if (Config->ParseSpeed<1.0 && IsSub)
+                        {
+                            Fill();
+                            Open_Buffer_Unsynch();
+                            Finish();
+                        }
+                    }
                 }
             }
             else
@@ -6836,7 +6854,7 @@ void File_Mxf::Data_Parse()
     }
 
     if ((!IsParsingEnd && IsParsingMiddle_MaxOffset==(int64u)-1 && Config->ParseSpeed<1.0)
-     && ((!IsSub && File_Offset>=Buffer_PaddingBytes+0x4000000) //TODO: 64 MB by default (security), should be changed
+     && ((!IsSub && File_Offset>=Buffer_PaddingBytes+(Config->ParseSpeed<=0?0x1000000:0x4000000)) //TODO: 64 MB by default (security), should be changed
       || (Streams_Count==0 && !Descriptors.empty())))
     {
         Fill();
@@ -16697,6 +16715,9 @@ void File_Mxf::Get_BER(int64u &Value, const char* Name)
 //---------------------------------------------------------------------------
 void File_Mxf::ChooseParser(const essences::iterator &Essence, const descriptors::iterator &Descriptor)
 {
+    if (Config->ParseSpeed<0)
+        return;
+
     if ((Descriptor->second.EssenceCompression.hi&0xFFFFFFFFFFFFFF00LL)!=0x060E2B3404010100LL || (Descriptor->second.EssenceCompression.lo&0xFF00000000000000LL)!=0x0400000000000000LL)
         return ChooseParser__FromEssenceContainer (Essence, Descriptor);
 
@@ -16948,6 +16969,9 @@ void File_Mxf::ChooseParser__FromEssenceContainer(const essences::iterator &Esse
 //---------------------------------------------------------------------------
 void File_Mxf::ChooseParser__FromEssence(const essences::iterator &Essence, const descriptors::iterator &Descriptor)
 {
+    if (Config->ParseSpeed<0)
+        return;
+
     int32u Code_Compare3=Code.lo>>32;
 
     switch (Code_Compare3)
@@ -18152,7 +18176,7 @@ bool File_Mxf::BookMark_Needed()
 {
     Frame_Count_NotParsedIncluded=(int64u)-1;
 
-    if (MayHaveCaptionsInStream && !IsSub && IsParsingEnd && File_Size!=(int64u)-1 && Config->ParseSpeed && Config->ParseSpeed<1 && IsParsingMiddle_MaxOffset==(int64u)-1 && File_Size/2>0x4000000) //TODO: 64 MB by default; // Do not search in the middle of the file if quick pass or full pass
+    if (MayHaveCaptionsInStream && !IsSub && IsParsingEnd && File_Size!=(int64u)-1 && Config->ParseSpeed>0 && Config->ParseSpeed<1 && IsParsingMiddle_MaxOffset==(int64u)-1 && File_Size/2>0x4000000) //TODO: 64 MB by default; // Do not search in the middle of the file if quick pass or full pass
     {
         IsParsingMiddle_MaxOffset=File_Size/2+0x4000000; //TODO: 64 MB by default;
         GoTo(File_Size/2);

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -4236,7 +4236,7 @@ void File_Riff::Parser_Pcm(stream& StreamItem, int16u Channels, int16u BitsPerSa
     #if defined(MEDIAINFO_DTS_YES)
     {
         File_Dts* Parser=new File_Dts;
-        Parser->Frame_Count_Valid=2;
+        Parser->Frame_Count_Valid=8;
         Parser->ShouldContinueParsing=true;
         #if MEDIAINFO_DEMUX
             if (Config->Demux_Unpacketize_Get() && Retrieve(Stream_General, 0, General_Format)==__T("Wave"))

--- a/Source/MediaInfo/Multiple/File_Vbi.cpp
+++ b/Source/MediaInfo/Multiple/File_Vbi.cpp
@@ -25,6 +25,7 @@
 #if defined(MEDIAINFO_TELETEXT_YES)
     #include "MediaInfo/Text/File_Teletext.h"
 #endif
+#include "MediaInfo/MediaInfo_Config_MediaInfo.h"
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -91,6 +92,8 @@ void File_Vbi::Read_Buffer_Continue()
     Frame_Count_InThisBlock++;
     if (Frame_Count_NotParsedIncluded!=(int64u)-1)
         Frame_Count_NotParsedIncluded++;
+    if (!Status[IsFilled] && Config->ParseSpeed<=0)
+        Fill();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Video/File_Av1.cpp
+++ b/Source/MediaInfo/Video/File_Av1.cpp
@@ -121,7 +121,7 @@ void File_Av1::Streams_Accept()
     Fill(Stream_Video, 0, Video_Format, "AV1");
 
     if (!Frame_Count_Valid)
-        Frame_Count_Valid=Config->ParseSpeed>=0.3?8:2;
+        Frame_Count_Valid=Config->ParseSpeed>=0.3?8:(IsSub?1:2);
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -1469,7 +1469,7 @@ bool File_Avc::Demux_UnpacketizeContainer_Test()
 void File_Avc::Synched_Init()
 {
     if (!Frame_Count_Valid)
-        Frame_Count_Valid=Config->ParseSpeed>=0.3?512:2;
+        Frame_Count_Valid=Config->ParseSpeed>=0.3?512:(IsSub?1:2);
 
     //FrameInfo
     PTS_End=0;

--- a/Source/MediaInfo/Video/File_H263.cpp
+++ b/Source/MediaInfo/Video/File_H263.cpp
@@ -239,7 +239,7 @@ bool File_H263::Synched_Test()
 void File_H263::Synched_Init()
 {
     if (!Frame_Count_Valid)
-        Frame_Count_Valid=Config->ParseSpeed>=0.3?8:2;
+        Frame_Count_Valid=Config->ParseSpeed>=0.3?8:(IsSub?1:2);
 
     //Temp
     PAR_W=12;

--- a/Source/MediaInfo/Video/File_Hevc.cpp
+++ b/Source/MediaInfo/Video/File_Hevc.cpp
@@ -920,7 +920,7 @@ bool File_Hevc::Demux_UnpacketizeContainer_Test()
 void File_Hevc::Synched_Init()
 {
     if (!Frame_Count_Valid)
-        Frame_Count_Valid=Config->ParseSpeed>=0.3?16:16; //Note: should be replaced by "512:2" when I-frame/GOP detection is OK
+        Frame_Count_Valid=Config->ParseSpeed>=0.3?16:(IsSub?1:2); //Note: should be replaced by "512:2" when I-frame/GOP detection is OK
 
     //FrameInfo
     PTS_End=0;

--- a/Source/MediaInfo/Video/File_Mpeg4v.cpp
+++ b/Source/MediaInfo/Video/File_Mpeg4v.cpp
@@ -304,7 +304,7 @@ bool File_Mpeg4v::Synched_Test()
 void File_Mpeg4v::Synched_Init()
 {
     if (!Frame_Count_Valid)
-        Frame_Count_Valid=Config->ParseSpeed>=0.3?30:2;
+        Frame_Count_Valid=Config->ParseSpeed>=0.3?30:(IsSub?1:2);
 
     //Count of a Packets
     IVOP_Count=0;

--- a/Source/MediaInfo/Video/File_Mpegv.cpp
+++ b/Source/MediaInfo/Video/File_Mpegv.cpp
@@ -1755,7 +1755,7 @@ bool File_Mpegv::Synched_Test()
 void File_Mpegv::Synched_Init()
 {
     if (!Frame_Count_Valid)
-        Frame_Count_Valid=Config->ParseSpeed>=0.3?512:2;
+        Frame_Count_Valid=Config->ParseSpeed>=0.3?512:(IsSub?1:2);
 
     //Temp
     BVOP_Count=0;

--- a/Source/MediaInfo/Video/File_Vc1.cpp
+++ b/Source/MediaInfo/Video/File_Vc1.cpp
@@ -230,7 +230,7 @@ File_Vc1::File_Vc1()
     Frame_Count_NotParsedIncluded=0;
 
     //In
-    Frame_Count_Valid=30;
+    Frame_Count_Valid=0;
     FrameIsAlwaysComplete=false;
     From_WMV3=false;
     Only_0D=false;
@@ -266,6 +266,9 @@ void File_Vc1::Streams_Accept()
     Fill(Stream_Video, 0, Video_Format, "VC-1");
     Fill(Stream_Video, 0, Video_Codec, From_WMV3?"WMV3":"VC-1"); //For compatibility with the old reaction
     Fill(Stream_Video, 0, Video_BitDepth, 8);
+
+    if (!Frame_Count_Valid)
+        Frame_Count_Valid=Config->ParseSpeed>=0.3?30:(IsSub?1:2);
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Video/File_Vc3.cpp
+++ b/Source/MediaInfo/Video/File_Vc3.cpp
@@ -436,7 +436,7 @@ File_Vc3::File_Vc3()
 :File__Analyze()
 {
     //In
-    Frame_Count_Valid=2;
+    Frame_Count_Valid=0;
     FrameRate=0;
 
     //Parsers
@@ -459,6 +459,13 @@ File_Vc3::~File_Vc3()
 //***************************************************************************
 // Streams management
 //***************************************************************************
+
+//---------------------------------------------------------------------------
+void File_Vc3::Streams_Accept()
+{
+    if (Frame_Count_Valid)
+        Frame_Count_Valid=IsSub?1:2;
+}
 
 //---------------------------------------------------------------------------
 void File_Vc3::Streams_Fill()

--- a/Source/MediaInfo/Video/File_Vc3.h
+++ b/Source/MediaInfo/Video/File_Vc3.h
@@ -40,6 +40,7 @@ public :
 
 private :
     //Streams management
+    void Streams_Accept();
     void Streams_Fill();
     void Streams_Finish();
 

--- a/Source/MediaInfo/Video/File_Vp8.cpp
+++ b/Source/MediaInfo/Video/File_Vp8.cpp
@@ -66,7 +66,7 @@ File_Vp8::~File_Vp8()
 void File_Vp8::Streams_Accept()
 {
     if (!Frame_Count_Valid)
-        Frame_Count_Valid=Config->ParseSpeed>=0.3?32:4;
+        Frame_Count_Valid=Config->ParseSpeed>=0.3?32:(IsSub?1:4);
 
     Stream_Prepare(Stream_Video);
 }


### PR DESCRIPTION
Reduce the count of bytes read from disk/network when ` --ParseSpeed=0` is used.

Focused on MXF but may also slightly improve the result for other containers as a collateral effect.