### PR TITLE
MOV/MP4: option for parsing only the header, no parsing of any frame

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -2382,7 +2382,7 @@ bool File_Mpeg4::BookMark_Needed()
         }
     #endif //MEDIAINFO_HASH
 
-    if (!mdat_MustParse || File_GoTo!=(int64u)-1)
+    if (!mdat_MustParse || File_GoTo!=(int64u)-1 || Config->ParseSpeed<0)
         return false;
 
     //Handling of some wrong stsz and stsc atoms (ADPCM)

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -1802,6 +1802,14 @@ void File_Mpeg4::mdat()
     }
     Element_Name("Data");
 
+    if (Config->ParseSpeed<=-1 && !Streams.empty())
+    {
+        if (File_Offset+Buffer_Offset+Element_TotalSize_Get()>File_Size)
+            Fill(Stream_General, 0, "IsTruncated", "Yes");
+        Finish();
+        return;
+    }
+
     //Sizes
     if (Retrieve(Stream_General, 0, General_HeaderSize).empty())
     {


### PR DESCRIPTION
Greatly reduce the count of bytes read from disk, should be used only if stream metadata is not useful.
 --ParseSpeed=-0.5: parse the header and test other root atoms (truncated file detection still active as usual).
 --ParseSpeed=-1: parse the header only (truncated file detection active only if header is at the end of the file or if mdat atom end is more than file size).