### PR TITLE
Structs with the same name in the same namespace confuses GCC

### DIFF
--- a/Source/MediaInfo/Text/File_Ttml.cpp
+++ b/Source/MediaInfo/Text/File_Ttml.cpp
@@ -248,19 +248,6 @@ bool File_Ttml::FileHeader_Begin()
     return true;
 }
 
-//---------------------------------------------------------------------------
-struct timeline
-{
-    TimeCode    Time_Begin;
-    TimeCode    Time_End;
-    size_t      LineCount;
-
-    timeline(TimeCode Time_Begin_, TimeCode Time_End_, size_t LineCount_)
-        : Time_Begin(Time_Begin_)
-        , Time_End(Time_End_)
-        , LineCount(LineCount_)
-    {}
-};
 void File_Ttml::Read_Buffer_Continue()
 {
     if (!IsSub && File_Offset+Buffer_Offset+Element_Offset)

--- a/Source/MediaInfo/Text/File_Ttml.h
+++ b/Source/MediaInfo/Text/File_Ttml.h
@@ -43,6 +43,20 @@ public :
     #endif //MEDIAINFO_EVENTS
 
 private :
+    //Types
+    struct timeline
+    {
+        TimeCode    Time_Begin;
+        TimeCode    Time_End;
+        size_t      LineCount;
+
+        timeline(TimeCode Time_Begin_, TimeCode Time_End_, size_t LineCount_)
+            : Time_Begin(Time_Begin_)
+            , Time_End(Time_End_)
+            , LineCount(LineCount_)
+        {}
+    };
+
     //Streams management
     void Streams_Accept();
     void Streams_Finish();


### PR DESCRIPTION
Fixes MediaArea/MediaInfo#666

Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>