### PR TITLE
MOV/MP4: support of TTML with images

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -103,6 +103,7 @@ private :
     void moof_traf_sbgp() { moov_trak_mdia_minf_stbl_sbgp(); }
     void moof_traf_sgpd() { moov_trak_mdia_minf_stbl_sgpd(); }
     void moof_traf_sdtp();
+    void moof_traf_subs() { moov_trak_mdia_minf_stbl_subs(); }
     void moof_traf_tfdt();
     void moof_traf_tfhd();
     void moof_traf_trun();
@@ -254,6 +255,7 @@ private :
     void moov_trak_mdia_minf_stbl_stss();
     void moov_trak_mdia_minf_stbl_stsz();
     void moov_trak_mdia_minf_stbl_stts();
+    void moov_trak_mdia_minf_stbl_subs();
     void moov_trak_mdia_minf_stbl_stz2() {moov_trak_mdia_minf_stbl_stsz();}
     void moov_trak_meta() {moov_meta();}
     void moov_trak_meta_hdlr() {moov_meta_hdlr();}
@@ -386,6 +388,7 @@ private :
     int32u                                  moov_meta_hdlr_Type;
     std::string                             moov_meta_ilst_xxxx_name_Name;
     size_t                                  moov_trak_mdia_minf_stbl_stsd_Pos;
+    size_t                                  moov_trak_mdia_minf_stbl_stsz_Pos;
     int32u                                  moov_trak_tkhd_TrackID;
     float32                                 moov_trak_tkhd_Width;
     float32                                 moov_trak_tkhd_Height;
@@ -456,8 +459,10 @@ private :
         };
         std::vector<stsc_struct> stsc;
         std::vector<int64u>     stsz;
+        std::vector<int32u>     stsz_FirstSubSampleSize;
         std::vector<int64u>     stsz_Total; //TODO: merge with stsz
         int64u                  stsz_StreamSize; //TODO: merge with stsz
+        int64u                  stsz_MoreThan2_Count;
         std::vector<int64u>     stss; //Sync Sample, base=0
         int64u                  FramePos_Offset;
         struct stts_struct
@@ -551,6 +556,7 @@ private :
             hdlr_Manufacturer=0x00000000;
             FramePos_Offset=0;
             stsz_StreamSize=0;
+            stsz_MoreThan2_Count=0;
             stsz_Sample_Size=0;
             stsz_Sample_Multiplier=1;
             stsz_Sample_Count=0;


### PR DESCRIPTION
and `stpp` CodecID is correctly mapped to TTML.