### PR TITLE
Mediainfo gets stuck because of bad fallback code for udta mov atoms

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -2898,7 +2898,7 @@ Ztring File_Mpeg4::Language_Get(int16u Language)
     if (Language==0x7FFF || Language==0xFFFF)
         return Ztring();
 
-    if (Language<0x100)
+    if (Language<0x400)
         return Mpeg4_Language_Apple(Language);
 
     Ztring ToReturn;


### PR DESCRIPTION
Whenever mediainfo encounters an unknown udta user data type it will fallback to parsing the content of the user data as a list of strings using the `File_Mpeg4::moov_udta_xxxx`method. This seems ill advised seeing as the Quicktime reference pages explicitly says to ignore unknown user data types (https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html)

However, assuming that this string fallback is wanted, it should at least not get stuck when interpreting something which is not a string as if it was a string. Further more, even if the user data actually is a list of strings it only parses the first string correctly. 

I first observed the behavior of mediainfo getting stuck on one of our customers files. However I'm not free to distribute this file so I had to make my own files that reproduce the issue. In order to make my own flavor of custom metadata I actually had to patch ffmpeg since it natively only allows me to write a "meta" user data type. I've attached to files to this PR.

The following file will make mediainfo get stuck because it if the udta is treated as a string it ends up with a trailing non-zero byte:

[unknown_bad_udta.mp4](https://user-images.githubusercontent.com/114919425/218735436-9478e25e-8711-45a8-acda-267913843785.mp4)


The following file has an unknown udta user type which is two subsequent strings. Mediainfo will not get stuck, but if it is run with --Details=1 it will be clear that it was not able to parse either of the strings.

[unknown_string_udta.mp4](https://user-images.githubusercontent.com/114919425/218735870-3859bf85-c5fe-462c-8a8d-651b9736b1f0.mp4)

The files in questions was created by ffmpeg by applying the following patch to the n4.4.3 tag of ffmpeg:
```
diff --git a/libavformat/movenc.c b/libavformat/movenc.c
index 8a06de2fd2..820b5ba426 100644
--- a/libavformat/movenc.c
+++ b/libavformat/movenc.c
@@ -82,6 +82,8 @@ static const AVOption options[] = {
     { "prefer_icc", "If writing colr atom prioritise usage of ICC profile if it exists in stream packet side data", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_PREFER_ICC}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, "movflags" },
     { "write_gama", "Write deprecated gama atom", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_WRITE_GAMA}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, "movflags" },
     { "use_metadata_tags", "Use mdta atom for metadata.", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_USE_MDTA}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, "movflags" },
+    { "write_unknown_string_udta", "Write a mdta used to reproduce wrong string parsing in mediainfo", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_WRITE_UNKNOWN_STRING_MDTA}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, "movflags" },
+    { "write_unknown_bad_udta", "Write a udta for reproducing a bug that makes mediainfo get stuck.", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_WRITE_UNKNOWN_BAD_MDTA}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, "movflags" },
     { "skip_trailer", "Skip writing the mfra/tfra/mfro trailer for fragmented files", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_SKIP_TRAILER}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, "movflags" },
     { "negative_cts_offsets", "Use negative CTS offsets (reducing the need for edit lists)", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_NEGATIVE_CTS_OFFSETS}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, "movflags" },
     FF_RTP_FLAG_OPTS(MOVMuxContext, rtp_flags),
@@ -3878,18 +3880,35 @@ static int mov_write_meta_tag(AVIOContext *pb, MOVMuxContext *mov,
 {
     int size = 0;
     int64_t pos = avio_tell(pb);
-    avio_wb32(pb, 0); /* size */
-    ffio_wfourcc(pb, "meta");
     avio_wb32(pb, 0);
-    if (mov->flags & FF_MOV_FLAG_USE_MDTA) {
-        mov_write_mdta_hdlr_tag(pb, mov, s);
-        mov_write_mdta_keys_tag(pb, mov, s);
-        mov_write_mdta_ilst_tag(pb, mov, s);
-    }
-    else {
-        /* iTunes metadata tag */
-        mov_write_itunes_hdlr_tag(pb, mov, s);
-        mov_write_ilst_tag(pb, mov, s);
+    if (mov->flags & FF_MOV_FLAG_WRITE_UNKNOWN_STRING_MDTA) {
+      const char* string1 = "I am a string user data";
+      const char* string2 = "I am a following string user data";
+      ffio_wfourcc(pb, "unks");
+      avio_wb32(pb, strlen(string1));
+      avio_write(pb, string1, strlen(string1));
+      avio_wb32(pb, strlen(string2));
+      avio_write(pb, string2, strlen(string2));
+    } else if (mov->flags & FF_MOV_FLAG_WRITE_UNKNOWN_BAD_MDTA) {
+      const char* bad = "I am bad user data.";
+      ffio_wfourcc(pb, "unkb");
+      avio_wb32(pb, strlen(bad));
+      avio_write(pb, bad, strlen(bad));
+      // Write one trailing non-zero byte. This will get mediainfo stuck
+      // in an infinite loop
+      avio_w8(pb, 42);
+    } else {
+      ffio_wfourcc(pb, "meta");
+      avio_wb32(pb, 0);
+      if (mov->flags & FF_MOV_FLAG_USE_MDTA) {
+          mov_write_mdta_hdlr_tag(pb, mov, s);
+          mov_write_mdta_keys_tag(pb, mov, s);
+          mov_write_mdta_ilst_tag(pb, mov, s);
+      }
+      else {
+          mov_write_itunes_hdlr_tag(pb, mov, s);
+          mov_write_ilst_tag(pb, mov, s);
+      }
     }
     size = update_size(pb, pos);
     return size;
diff --git a/libavformat/movenc.h b/libavformat/movenc.h
index cdbc4074c3..07a470cdc3 100644
--- a/libavformat/movenc.h
+++ b/libavformat/movenc.h
@@ -263,6 +263,8 @@ typedef struct MOVMuxContext {
 #define FF_MOV_FLAG_SKIP_SIDX             (1 << 21)
 #define FF_MOV_FLAG_CMAF                  (1 << 22)
 #define FF_MOV_FLAG_PREFER_ICC            (1 << 23)
+#define FF_MOV_FLAG_WRITE_UNKNOWN_STRING_MDTA   (1 << 24)
+#define FF_MOV_FLAG_WRITE_UNKNOWN_BAD_MDTA      (1 << 25)
 
 int ff_mov_write_packet(AVFormatContext *s, AVPacket *pkt);
```

The files was created by running the following ffmpeg commands:
```
ffmpeg -y -f lavfi -i testsrc=duration=1:size=320x200:rate=1 -movflags write_unknown_bad_udta -metadata foo=bar unknown_bad_udta.mp4
ffmpeg -y -f lavfi -i testsrc=duration=1:size=320x200:rate=1 -movflags write_unknown_string_udta -metadata foo=bar unknown_string_udta.mp4
```

Also, the file from the customer had a user data type of "NCDT" which seems to be documented here: https://exiftool.org/TagNames/Nikon.html#NCDT

The best fix for this particular file is of course to implement NCDT support, but I think it is more important that mediainfo does not get stuck when encountering unknown user data types.

