### PR TITLE
MPEG-7: 3 modes (strict, relaxed, extended)

### DIFF
--- a/Source/MediaInfo/Export/Export_Mpeg7.h
+++ b/Source/MediaInfo/Export/Export_Mpeg7.h
@@ -28,7 +28,8 @@ public :
     ~Export_Mpeg7 ();
 
     //Input
-    Ztring Transform(MediaInfo_Internal &MI);
+    //Version: 0=strict, 1=relaxed (strict best effort), 2=extended
+    Ztring Transform(MediaInfo_Internal &MI, size_t Version=1);
 };
 
 } //NameSpace

--- a/Source/MediaInfo/MediaInfo_Config.cpp
+++ b/Source/MediaInfo/MediaInfo_Config.cpp
@@ -314,16 +314,15 @@ void MediaInfo_Config_Library_VorbisCom       (InfoMap &Info);
 //---------------------------------------------------------------------------
 // Output formats
 
-static const size_t output_formats_item_size = 3;
-static const char* OutputFormats_JSONFields[output_formats_item_size] =
+static const char* OutputFormats_JSONFields[] =
 {
     "name",
     "desc",
     "mime",
 };
+static const size_t output_formats_item_size = sizeof(OutputFormats_JSONFields) / sizeof(decltype(*OutputFormats_JSONFields));
 typedef const char* output_formats_item[output_formats_item_size];
-static const size_t output_formats_size = 15;
-static output_formats_item OutputFormats[output_formats_size] =
+static output_formats_item OutputFormats[] =
 {
     { "Text",                   "Text",                                                         "text/plain",       },
     { "HTML",                   "HTML",                                                         "text/html",        },
@@ -335,12 +334,15 @@ static output_formats_item OutputFormats[output_formats_size] =
     { "EBUCore_1.8_sp_JSON",    "EBUCore 1.8 (JSON; acq. metadata: segment then parameter)",    "text/json",        },
     { "EBUCore_1.6",            "EBUCore 1.6",                                                  "text/xml",         },
     { "FIMS_1.3",               "FIMS 1.3",                                                     "text/xml",         },
-    { "MPEG-7",                 "MPEG-7",                                                       "text/xml",         },
+    { "MPEG-7_Strict",          "MPEG-7 (Strict)",                                              "text/xml",         },
+    { "MPEG-7_Relaxed",         "MPEG-7 (Relaxed)",                                             "text/xml",         },
+    { "MPEG-7_Extended",        "MPEG-7 (Extended)",                                            "text/xml",         },
     { "PBCore_2.1",             "PBCore 2.1",                                                   "text/xml",         },
     { "PBCore_2.0",             "PBCore 2.0",                                                   "text/xml",         },
     { "PBCore_1.2",             "PBCore 1.2",                                                   "text/xml",         },
     { "NISO_Z39.87",            "NISO Z39.87",                                                  "text/xml",         },
 };
+static const size_t output_formats_size = sizeof(OutputFormats) / sizeof(decltype(*OutputFormats));
 
 //---------------------------------------------------------------------------
 

--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -236,6 +236,12 @@ Ztring MediaInfo_Internal::Inform()
     #if defined(MEDIAINFO_MPEG7_YES)
         if (MediaInfoLib::Config.Inform_Get()==__T("MPEG-7"))
             return Export_Mpeg7().Transform(*this);
+        if (MediaInfoLib::Config.Inform_Get()==__T("MPEG-7_Strict"))
+            return Export_Mpeg7().Transform(*this, 0);
+        if (MediaInfoLib::Config.Inform_Get()==__T("MPEG-7_Relaxed"))
+            return Export_Mpeg7().Transform(*this, 1);
+        if (MediaInfoLib::Config.Inform_Get()==__T("MPEG-7_Extended"))
+            return Export_Mpeg7().Transform(*this, 2);
     #endif //defined(MEDIAINFO_MPEG7_YES)
     #if defined(MEDIAINFO_PBCORE_YES)
         if (MediaInfoLib::Config.Inform_Get()==__T("PBCore_1") || MediaInfoLib::Config.Inform_Get()==__T("PBCore1")) // 1.x


### PR DESCRIPTION
Strict: strict conformance to the MPEG-7 XSD
Relaxed: MediaInfo extension in case of important info missing e.g. more than 1 audio track, text track, encryption
Extended: MediaInfo extension in case of minor info missing e.g. open GOP