### PR TITLE
Normalization of date/time in report, update

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -108,7 +108,10 @@ bool DateTime_Adapt(string& Value_)
             return true;
         }
 
+        #if defined(_MSC_VER)
         try
+        #endif
+        #if !defined(__GNUC__) || __GNUC__>=5
         {
             tm t;
             string ValueT(Value);
@@ -189,10 +192,13 @@ bool DateTime_Adapt(string& Value_)
                 }
             }
         }
+        #endif
+        #if defined(_MSC_VER)
         catch (...)
         {
             return false;
         }
+        #endif
     }
     
     // Year


### PR DESCRIPTION
Just removing the try catch, there should be no C++ exception there.