### PR TITLE
ID3v2: fix Genre not showing ID 0 (Blues)

### DIFF
--- a/Source/MediaInfo/Tag/File_Id3v2.cpp
+++ b/Source/MediaInfo/Tag/File_Id3v2.cpp
@@ -1200,7 +1200,7 @@ void File_Id3v2::Fill_Name()
                               {
                                 if (Element_Value.find(__T('('))==0)
                                     Element_Value=Element_Value.SubString(__T("("), __T(")")); //Replace (nn) by nn
-                                if (Element_Value==__T("0") || Element_Value==__T("255"))
+                                if (Element_Value==__T("255"))
                                     Element_Value.clear();
                                 Fill(Stream_General, 0, General_Genre, Element_Value);
                               }


### PR DESCRIPTION
0 is actually is valid value, only 255 is not a valid value.

Fix https://github.com/MediaArea/MediaInfo/issues/682.