### PR TITLE
MXF/PCM: detect silent tracks (full parsing only), update

### DIFF
--- a/Source/MediaInfo/Audio/File_Pcm.cpp
+++ b/Source/MediaInfo/Audio/File_Pcm.cpp
@@ -258,7 +258,7 @@ void File_Pcm::Streams_Finish()
     Frame_Count_NotParsedIncluded=(int64u)-1;
 
     #if MEDIAINFO_CONFORMANCE
-    if (!IsNotSilence)
+    if (Config->ParseSpeed>=1 && !IsNotSilence)
     {
         Fill(Stream_Audio, 0, "ConformanceInfos", "1");
         Fill(Stream_Audio, 0, "ConformanceInfos Content", "Content is silence");


### PR DESCRIPTION
Update after https://github.com/MediaArea/MediaInfoLib/pull/1713