### PR TITLE
USAC: fix usage of NULL in memset

### DIFF
--- a/Source/MediaInfo/Audio/File_Usac.cpp
+++ b/Source/MediaInfo/Audio/File_Usac.cpp
@@ -3158,7 +3158,7 @@ void File_Usac::arithData(size_t ch, int16u N, int16u lg, int16u lg_max, bool ar
     // arith_map_context
     {
         if (arith_reset_flag || C.arithContext[ch].previous_window_size==(int16u)-1)
-            memset(&C.arithContext[ch].q, NULL, sizeof(C.arithContext[ch].q));
+            memset(&C.arithContext[ch].q, 0, sizeof(C.arithContext[ch].q));
         else if (N != C.arithContext[ch].previous_window_size)
         {
             if (!N)

--- a/Source/MediaInfo/Audio/File_Usac.h
+++ b/Source/MediaInfo/Audio/File_Usac.h
@@ -305,7 +305,7 @@ public :
 
         arith_context() :           previous_window_size((int16u)-1)
         {
-            memset(&q, NULL, sizeof(q));
+            memset(&q, 0, sizeof(q));
         }
     };
 


### PR DESCRIPTION
NULL in c++ is not defined to always be 0, it can also be std::nullptr_t.

it is not valid to pass std::nullptr_t to memset, so pass 0 explicitly.