### PR TITLE
S3: accept external crt file also for non geolocated URLs

### DIFF
--- a/Source/MediaInfo/Reader/Reader_libcurl.cpp
+++ b/Source/MediaInfo/Reader/Reader_libcurl.cpp
@@ -550,7 +550,7 @@ void Amazon_AWS_Sign(struct curl_slist* &HttpHeader, const Http::Url &File_URL, 
 };
 
 //---------------------------------------------------------------------------
-string Amazon_AWS_GetRegion(const string &serviceName, const string &bucketName, const Http::Url &File_URL, CURL* Curl, const ZtringList& ExternalHttpHeaders)
+size_t Amazon_AWS_GetRegion(const string &serviceName, const string &bucketName, const Http::Url &File_URL, Reader_libcurl* Reader_Curl, const ZtringList& ExternalHttpHeaders, string& RegionName)
 {
     //Transform the URL to a location request URL
     Http::Url File_URL2=File_URL;
@@ -562,6 +562,7 @@ string Amazon_AWS_GetRegion(const string &serviceName, const string &bucketName,
     struct curl_slist* HttpHeader=NULL;
     Amazon_AWS_Sign(HttpHeader, File_URL2, "us-east-1", serviceName, ExternalHttpHeaders);
     Reader_libcurl_curl_data_getregion Curl_Data2;
+    CURL* Curl=Reader_Curl->Curl_Data->Curl;
     Curl_Data2.Curl=Curl;
     File_URL2.User.clear();
     File_URL2.Password.clear();
@@ -571,7 +572,14 @@ string Amazon_AWS_GetRegion(const string &serviceName, const string &bucketName,
     curl_easy_setopt(Curl, CURLOPT_WRITEDATA, &Curl_Data2);
     curl_easy_setopt(Curl, CURLOPT_HTTPHEADER, HttpHeader);
     curl_easy_setopt(Curl, CURLOPT_URL, FileName_String.c_str());
+    if (Reader_Curl->SetOptions())
+        return 1;
     CURLcode Result=curl_easy_perform(Curl);
+    if (Result)
+    {
+        Reader_Curl->Curl_Log(Result);
+        return 1;
+    }
     curl_easy_setopt(Curl, CURLOPT_WRITEFUNCTION, NULL);
     curl_easy_setopt(Curl, CURLOPT_WRITEDATA, NULL);
     curl_easy_setopt(Curl, CURLOPT_HTTPHEADER, NULL);
@@ -579,10 +587,11 @@ string Amazon_AWS_GetRegion(const string &serviceName, const string &bucketName,
     curl_slist_free_all(HttpHeader);
 
     //We get the region name
-    return Curl_Data2.Amazon_AWS_Region;
+    RegionName=Curl_Data2.Amazon_AWS_Region;
+    return 0;
 }
 
-void Amazon_AWS_Manage(Http::Url &File_URL, Reader_libcurl::curl_data* Curl_Data, const ZtringList& ExternalHttpHeaders)
+size_t Amazon_AWS_Manage(Http::Url &File_URL, Reader_libcurl* Reader_Curl, const ZtringList& ExternalHttpHeaders)
 {
     // Looking for style of URL (Virtual-hosted-style URL Path-style URL), service name, region name
     // Format:
@@ -607,7 +616,8 @@ void Amazon_AWS_Manage(Http::Url &File_URL, Reader_libcurl::curl_data* Curl_Data
         if (AfterLastDot)
         {
             string bucketName=regionName.substr(0, AfterLastDot-1); 
-            regionName=Amazon_AWS_GetRegion(serviceName, bucketName, File_URL, Curl_Data->Curl, ExternalHttpHeaders);
+            if (Amazon_AWS_GetRegion(serviceName, bucketName, File_URL, Reader_Curl, ExternalHttpHeaders, regionName))
+                return 1;
         }
         else
             regionName="us-east-1";
@@ -638,13 +648,15 @@ void Amazon_AWS_Manage(Http::Url &File_URL, Reader_libcurl::curl_data* Curl_Data
     // Handling S3 signature
     if (serviceName=="s3" && !regionName.empty())
     {
-        Amazon_AWS_Sign(Curl_Data->HttpHeader, File_URL, regionName, serviceName, ExternalHttpHeaders);
+        Amazon_AWS_Sign(Reader_Curl->Curl_Data->HttpHeader, File_URL, regionName, serviceName, ExternalHttpHeaders);
 
         //Removing the login/pass FTP-style, not usable by libcurl
         File_URL.User.clear();
         File_URL.Password.clear();
-        Curl_Data->File_Name=Ztring().From_UTF8(File_URL.ToString());
+        Reader_Curl->Curl_Data->File_Name=Ztring().From_UTF8(File_URL.ToString());
     }
+
+    return 0;
 }
 
 //---------------------------------------------------------------------------
@@ -864,9 +876,119 @@ void Reader_libcurl::Curl_Log(int Result)
     MessageString.From_Local(Curl_Data->ErrorBuffer);
     if (MessageString.empty())
         MessageString.From_Local(curl_easy_strerror(CURLcode(Result)));
-    MediaInfoLib::Config.Log_Send(0xC0, 0xFF, 0, Reader_libcurl_FileNameWithoutPasswordAndParameters(Curl_Data->File_Name) + __T(", ") + MessageString);
+    int32u MessageCode;
+    switch (Result)
+    {
+    case CURLE_SSL_CACERT                   : MessageCode = 0xF1010105; break;
+    default                                 : MessageCode = 0;
+    }
+    MediaInfoLib::Config.Log_Send(0xC0, 0xFF, MessageCode, Reader_libcurl_FileNameWithoutPasswordAndParameters(Curl_Data->File_Name) + __T(", ") + MessageString);
 #endif
 }
+
+//---------------------------------------------------------------------------
+size_t Reader_libcurl::SetOptions()
+{
+    if (!Curl_Data->Ssl_CertificateFileName.empty())
+    {
+        CURLcode Result = curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSLCERT, Curl_Data->Ssl_CertificateFileName.c_str());
+        if (Result)
+        {
+            Curl_Log(Result);
+            return 1;
+        }
+    }
+
+    if (!Curl_Data->Ssl_CertificateFormat.empty())
+    {
+        CURLcode Result = curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSLCERTTYPE, Curl_Data->Ssl_CertificateFormat.c_str());
+        if (Result)
+        {
+            Curl_Log(Result);
+            return 1;
+        }
+    }
+
+    if (!Curl_Data->Ssl_PrivateKeyFileName.empty())
+    {
+        CURLcode Result = curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSLKEY, Curl_Data->Ssl_PrivateKeyFileName.c_str());
+        if (Result)
+        {
+            Curl_Log(Result);
+            return 1;
+        }
+    }
+
+    if (!Curl_Data->Ssl_PrivateKeyFormat.empty())
+    {
+        CURLcode Result = curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSLKEYTYPE, Curl_Data->Ssl_PrivateKeyFormat.c_str());
+        if (Result)
+        {
+            Curl_Log(Result);
+            return 1;
+        }
+    }
+
+    if (!Curl_Data->Ssl_CertificateAuthorityFileName.empty())
+    {
+        CURLcode Result = curl_easy_setopt(Curl_Data->Curl, CURLOPT_CAINFO, Curl_Data->Ssl_CertificateAuthorityFileName.c_str());
+        if (Result)
+        {
+            Curl_Log(Result);
+            return 1;
+        }
+    }
+
+    if (!Curl_Data->Ssl_CertificateAuthorityPath.empty())
+    {
+        CURLcode Result = curl_easy_setopt(Curl_Data->Curl, CURLOPT_CAPATH, Curl_Data->Ssl_CertificateAuthorityPath.c_str());
+        if (Result)
+        {
+            Curl_Log(Result);
+            return 1;
+        }
+    }
+    else
+    {
+        CURLcode res;
+        char* cainfo = NULL;
+        #define CURLINFO_STRING   0x100000
+        CURLINFO CURLINFO_CAINFO = (CURLINFO)(CURLINFO_STRING + 61);
+        curl_easy_getinfo(Curl_Data->Curl, CURLINFO_CAINFO, &cainfo);
+        if (cainfo)
+            printf("default ca info path: %s\n", cainfo);
+    }
+
+    if (!Curl_Data->Ssl_CertificateRevocationListFileName.empty())
+    {
+        CURLcode Result = curl_easy_setopt(Curl_Data->Curl, CURLOPT_CRLFILE, Curl_Data->Ssl_CertificateRevocationListFileName.c_str());
+        if (Result)
+        {
+            Curl_Log(Result);
+            return 1;
+        }
+    }
+
+    if (Curl_Data->Ssl_IgnoreSecurity)
+    {
+        CURLcode Result = curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSL_VERIFYPEER, 0);
+        if (Result)
+        {
+            Curl_Log(Result);
+            return 1;
+        }
+
+        Result = curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSL_VERIFYHOST, 0);
+        if (Result)
+        {
+            Curl_Log(Result);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
 //---------------------------------------------------------------------------
 size_t Reader_libcurl::Format_Test_PerParser(MediaInfo_Internal* MI, const String &File_Name)
 {
@@ -1001,7 +1123,8 @@ size_t Reader_libcurl::Format_Test_PerParser(MediaInfo_Internal* MI, const Strin
                     File_URL.User=PercentDecode(File_URL.User);
                     File_URL.Password=PercentDecode(File_URL.Password);
                 }
-                Amazon_AWS_Manage(File_URL, Curl_Data, HttpHeaderStrings);
+                if (Amazon_AWS_Manage(File_URL, this, HttpHeaderStrings))
+                    return 0;
             }
         }
 
@@ -1051,92 +1174,8 @@ size_t Reader_libcurl::Format_Test_PerParser(MediaInfo_Internal* MI, const Strin
 
         if (File_URL.Protocol=="https" || File_URL.Protocol=="ftps")
         {
-            if (!Curl_Data->Ssl_CertificateFileName.empty())
-            {
-                CURLcode Result=curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSLCERT, Curl_Data->Ssl_CertificateFileName.c_str());
-                if (Result)
-                {
-                    Curl_Log(Result);
-                    return 0;
-                }
-            }
-
-            if (!Curl_Data->Ssl_CertificateFormat.empty())
-            {
-                CURLcode Result=curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSLCERTTYPE, Curl_Data->Ssl_CertificateFormat.c_str());
-                if (Result)
-                {
-                    Curl_Log(Result);
-                    return 0;
-                }
-            }
-
-            if (!Curl_Data->Ssl_PrivateKeyFileName.empty())
-            {
-                CURLcode Result=curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSLKEY, Curl_Data->Ssl_PrivateKeyFileName.c_str());
-                if (Result)
-                {
-                    Curl_Log(Result);
-                    return 0;
-                }
-            }
-
-            if (!Curl_Data->Ssl_PrivateKeyFormat.empty())
-            {
-                CURLcode Result=curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSLKEYTYPE, Curl_Data->Ssl_PrivateKeyFormat.c_str());
-                if (Result)
-                {
-                    Curl_Log(Result);
-                    return 0;
-                }
-            }
-
-            if (!Curl_Data->Ssl_CertificateAuthorityFileName.empty())
-            {
-                CURLcode Result=curl_easy_setopt(Curl_Data->Curl, CURLOPT_CAINFO, Curl_Data->Ssl_CertificateAuthorityFileName.c_str());
-                if (Result)
-                {
-                    Curl_Log(Result);
-                    return 0;
-                }
-            }
-
-            if (!Curl_Data->Ssl_CertificateAuthorityPath.empty())
-            {
-                CURLcode Result=curl_easy_setopt(Curl_Data->Curl, CURLOPT_CAPATH, Curl_Data->Ssl_CertificateAuthorityPath.c_str());
-                if (Result)
-                {
-                    Curl_Log(Result);
-                    return 0;
-                }
-            }
-
-            if (!Curl_Data->Ssl_CertificateRevocationListFileName.empty())
-            {
-                CURLcode Result=curl_easy_setopt(Curl_Data->Curl, CURLOPT_CRLFILE, Curl_Data->Ssl_CertificateRevocationListFileName.c_str());
-                if (Result)
-                {
-                    Curl_Log(Result);
-                    return 0;
-                }
-            }
-
-            if (Curl_Data->Ssl_IgnoreSecurity)
-            {
-                CURLcode Result=curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSL_VERIFYPEER, 0);
-                if (Result)
-                {
-                    Curl_Log(Result);
-                    return 0;
-                }
-
-                Result=curl_easy_setopt(Curl_Data->Curl, CURLOPT_SSL_VERIFYHOST, 0);
-                if (Result)
-                {
-                    Curl_Log(Result);
-                    return 0;
-                }
-            }
+            if (SetOptions())
+                return 0;
         }
     }
     string FileName_String=Ztring(Curl_Data->File_Name).To_UTF8();

--- a/Source/MediaInfo/Reader/Reader_libcurl.cpp
+++ b/Source/MediaInfo/Reader/Reader_libcurl.cpp
@@ -1540,13 +1540,23 @@ bool Reader_libcurl::Load(const Ztring File_Name)
             size_t Errors=0;
 
             /* Load library */
+            #if defined(__APPLE__) && defined(__MACH__)
+                #define MEDIAINFODLL_NAME  "libcurl.4.dylib"
+                #define __stdcall
+            #elif !defined (_WIN32) && !defined (WIN32)
+                #define MEDIAINFODLL_NAME  "libcurl.so.4"
+                #define __stdcall
+            #endif //!defined(_WIN32) || defined (WIN32)
             #ifdef MEDIAINFO_GLIBC
                 libcurl_Module=g_module_open(MEDIAINFODLL_NAME, G_MODULE_BIND_LAZY);
             #elif defined (_WIN32) || defined (WIN32)
                 #ifdef WINDOWS_UWP
-                    libcurl_Module=LoadPackagedLibrary(MEDIAINFODLL_NAME, 0);
+                    libcurl_Module=LoadPackagedLibrary(__T("libcurl.dll"), 0);
                 #else
-                    libcurl_Module=LoadLibrary(MEDIAINFODLL_NAME);
+                    if (sizeof(size_t)==8)
+                        libcurl_Module=LoadLibrary(__T("libcurl-x64.dll"));
+                    if (!libcurl_Module)
+                        libcurl_Module=LoadLibrary(__T("libcurl.dll"));
                 #endif
             #else
                 libcurl_Module=dlopen(MEDIAINFODLL_NAME, RTLD_LAZY);

--- a/Source/MediaInfo/Reader/Reader_libcurl.h
+++ b/Source/MediaInfo/Reader/Reader_libcurl.h
@@ -18,6 +18,8 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/Reader/Reader__Base.h"
+typedef void CURL;
+
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
@@ -43,13 +45,12 @@ public :
     // Open/Close library
     static bool Load(const Ztring File_Name=Ztring());
 
-public:
     struct curl_data;
 
-private :
-    curl_data*          Curl_Data;
+    curl_data* Curl_Data;
     void Curl_Log(int Result);
     void Curl_Log(int Result, const Ztring &Message);
+    size_t SetOptions();
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Reader/Reader_libcurl_Include.h
+++ b/Source/MediaInfo/Reader/Reader_libcurl_Include.h
@@ -907,20 +907,6 @@ typedef struct {
 extern "C"
 {
 
-#if defined (_WIN32) || defined (WIN32)
-    #ifdef _UNICODE
-        #define MEDIAINFODLL_NAME  L"libcurl.dll"
-    #else //_UNICODE
-        #define MEDIAINFODLL_NAME  "libcurl.dll"
-    #endif //_UNICODE
-#elif defined(__APPLE__) && defined(__MACH__)
-    #define MEDIAINFODLL_NAME  "libcurl.4.dylib"
-    #define __stdcall
-#else
-    #define MEDIAINFODLL_NAME  "libcurl.so.4"
-    #define __stdcall
-#endif //!defined(_WIN32) || defined (WIN32)
-
 #ifdef MEDIAINFO_GLIBC
     #include <gmodule.h>
     static GModule* libcurl_Module=NULL;


### PR DESCRIPTION
Retrieval of the S3 geolocated path was failing if `curl-ca-bundle.crt` is not embedded in the used curl library and provided by `--Ssl_CertificateFileName=...` option.

And check also `libcurl-x64.dll` presence on Windows.