### PR TITLE
fix drc_decoder_config_curve

### DIFF
--- a/Source/MediaInfo/Audio/File_Ac4.h
+++ b/Source/MediaInfo/Audio/File_Ac4.h
@@ -93,7 +93,7 @@ public :
         int8u drc_attack_threshold;
         int8u drc_release_threshold;
 
-        bool operator==(const drc_decoder_config_curve& C)
+        bool operator==(const drc_decoder_config_curve& C) const
         {
             return !memcmp(this, &C, sizeof(drc_decoder_config_curve));
         }


### PR DESCRIPTION
* fix C2666	'MediaInfoLib::File_Ac4::drc_decoder_config_curve::operator ==': overloaded functions have similar conversions	MediaInfoLib (MediaInfoLib\MediaInfoLib)