### PR TITLE
DTS:X: Fix some streams are DTS:X not IMAX

### DIFF
--- a/Source/MediaInfo/Audio/File_Dts.cpp
+++ b/Source/MediaInfo/Audio/File_Dts.cpp
@@ -2011,12 +2011,12 @@ void File_Dts::Extensions2()
     switch (SyncWord)
     {
         case 0x02000850:
+        case 0xF14000D1:
             Element_Name("X?");
             Presence.set(presence_Extended_X);
             break;
         case 0xF14000D0:
-        case 0xF14000D1:
-            Element_Name("X IMAX");
+            Element_Name("X IMAX?");
             Presence.set(presence_Extended_X); // It was reported that IMAX is detected as X on legacy X decoders
             Presence.set(presence_Extended_IMAX);
             break;


### PR DESCRIPTION
Fix https://github.com/MediaArea/MediaInfo/issues/717.

Note that it is forking from how FFmpeg flags DTS:X IMAX but at it is reverse engineering for both (I presume), I prefer to rely on the report from the ticket.

Edit: not sure