### PR TITLE
Support ST381-4

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mxf.h
+++ b/Source/MediaInfo/Multiple/File_Mxf.h
@@ -1188,6 +1188,9 @@ protected :
     void           ChooseParser_Vc3(const essences::iterator &Essence, const descriptors::iterator &Descriptor);
     void           ChooseParser_TimedText(const essences::iterator &Essence, const descriptors::iterator &Descriptor);
     void           ChooseParser_Aac(const essences::iterator &Essence, const descriptors::iterator &Descriptor);
+    void           ChooseParser_Adif(const essences::iterator& Essence, const descriptors::iterator& Descriptor);
+    void           ChooseParser_Adts(const essences::iterator& Essence, const descriptors::iterator& Descriptor);
+    void           ChooseParser_Latm(const essences::iterator& Essence, const descriptors::iterator& Descriptor);
     void           ChooseParser_Ac3(const essences::iterator &Essence, const descriptors::iterator &Descriptor);
     void           ChooseParser_Alaw(const essences::iterator &Essence, const descriptors::iterator &Descriptor);
     void           ChooseParser_ChannelGrouping(const essences::iterator &Essence, const descriptors::iterator &Descriptor);


### PR DESCRIPTION
This patch adds support for recognizing AAC wrapped in MXF files following the ST 381-4:2017 standard.  This format is used by Harmonic's Spectrum product line to generate proxies during record.  There are a few other vendors in the broadcast industry that also generate files following this standard, but I don't have an exhaustive list.  For a sample file, see [https://harmonicinc.box.com/v/st381-4-sample]().  I don't have sample files to cover all potential variants.

Note that ST 381-4 also includes details about an AacSubDescriptor, but there doesn't seem to be any (immediate) value in parsing it.  I'd be happy to add it, if necessary.

