### PR TITLE
HEVC: fix crash in support of HDR10+

### DIFF
--- a/Source/MediaInfo/Video/File_Hevc.cpp
+++ b/Source/MediaInfo/Video/File_Hevc.cpp
@@ -315,7 +315,7 @@ void File_Hevc::Streams_Fill()
                         break;
                 }
             }
-            if (i==HdrFormat_Max)
+            if (i==HdrFormat_Max && HDR_FirstFieldNonEmpty!=(size_t)-1)
                 Fill(Stream_Video, 0, HDR_Item.first, HDR_Item.second[HDR_FirstFieldNonEmpty]);
             else if (!LegacyStreamDisplay)
             {


### PR DESCRIPTION
Follow up of https://github.com/MediaArea/MediaInfoLib/pull/1757, thank to reminder from https://github.com/MediaArea/MediaInfoLib/commit/22efc689fbe536148cdd1e00d4ccba785695efde#commitcomment-112002219.

Need to have a refactoring of that at some point...