### PR TITLE
MP4: support of ipcm CodecID

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -225,6 +225,7 @@ private :
     void moov_trak_mdia_minf_stbl_stsd_xxxx_btrt();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_ccst();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_chan();
+    void moov_trak_mdia_minf_stbl_stsd_xxxx_chnl();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_clap();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_clli();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_colr();
@@ -256,6 +257,7 @@ private :
     void moov_trak_mdia_minf_stbl_stsd_xxxx_mdcv();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_mhaC();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_pasp();
+    void moov_trak_mdia_minf_stbl_stsd_xxxx_pcmC();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_SA3D();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_sinf();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_sinf_frma();
@@ -440,6 +442,7 @@ private :
     std::vector<std::vector<int32u> >       meta_iprp_ipma_Entries;
     int8u*                                  meta_iprp_ipco_Buffer;
     size_t                                  meta_iprp_ipco_Buffer_Size; //Used as property_index if no buffer
+    int16u                                  channelcount;
     int8u                                   Version_Temp; //Used when box version must be provided to nested boxes
 
     //Data

--- a/Source/Resource/Text/DataBase/CodecID_Audio_Mpeg4.csv
+++ b/Source/Resource/Text/DataBase/CodecID_Audio_Mpeg4.csv
@@ -17,6 +17,7 @@ fLaC;FLAC;;;
 ima4;ADPCM;;;http://www.apple.com/quicktime/download/standalone.html;
 in24;PCM;;;http://www.apple.com/quicktime/download/standalone.html;
 in32;PCM;;;http://www.apple.com/quicktime/download/standalone.html;
+ipcm;PCM;;;;
 lpcm;PCM;;;;
 MAC3;MACE 3;;;;
 MAC6;MACE 6;;;;


### PR DESCRIPTION
Includes `chnl` and `pcmC` atom support.

Fix https://github.com/MediaArea/MediaInfoLib/issues/1781.