### PR TITLE
S-ADM: add S-ADM version and support of 1/1.001 frame rates, update

### DIFF
--- a/Source/MediaInfo/Audio/File_ChannelSplitting.cpp
+++ b/Source/MediaInfo/Audio/File_ChannelSplitting.cpp
@@ -95,7 +95,8 @@ void File_ChannelSplitting::Streams_Fill()
             if (Parsers[0]->Count_Get(Stream_Audio))
             {
                 PcmChannelsCount--;
-                if (Parsers[0]->Get(Stream_Audio, 0, "Metadata_Format").find(__T("ADM"))==0)
+                auto Metadata_Format=Parsers[0]->Get(Stream_Audio, 0, "Metadata_Format");
+                if (Metadata_Format.rfind(__T("ADM"), 0)==0 || Metadata_Format.rfind(__T("S-ADM"), 0)==0)
                     AdmChannelsCount++;
             }
         }

--- a/Source/MediaInfo/Export/Export_Graph.cpp
+++ b/Source/MediaInfo/Export/Export_Graph.cpp
@@ -477,6 +477,8 @@ Ztring Export_Graph::Adm_Graph(MediaInfo_Internal &MI, size_t StreamPos, size_t 
 {
     Ztring ToReturn;
     if (MI.Get(Stream_Audio, StreamPos, __T("Metadata_Format")).find(__T("ADM, "), 0)!=0
+     && MI.Get(Stream_Audio, StreamPos, __T("Metadata_Format")).find(__T("S-ADM, "), 0)!=0
+     && MI.Get(Stream_Audio, StreamPos, __T("Format"))!=__T("MGA")
      && MI.Get(Stream_Audio, StreamPos, __T("Format"))!=__T("IAB"))
         return ToReturn;
 


### PR DESCRIPTION
Fixes after https://github.com/MediaArea/MediaInfoLib/pull/1787.