### PR TITLE
TimeCode: 1/1.001 frame rate was not always detected

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mxf.h
+++ b/Source/MediaInfo/Multiple/File_Mxf.h
@@ -670,6 +670,7 @@ protected :
     bool   FooterPartitionAddress_Jumped;
     bool   PartitionPack_Parsed;
     bool   HeaderPartition_IsOpen;
+    bool   Is1001;
     size_t IdIsAlwaysSame_Offset;
 
     //Primer

--- a/Source/MediaInfo/Text/File_Ttml.cpp
+++ b/Source/MediaInfo/Text/File_Ttml.cpp
@@ -198,8 +198,11 @@ void File_Ttml::Streams_Finish()
 {
     if (Time_End.HasValue() && Time_Begin.HasValue())
     {
-        Fill(Stream_General, 0, General_Duration, Time_End.ToMilliseconds()-Time_Begin.ToMilliseconds());
-        Fill(Stream_Text, 0, Text_Duration, Time_End.ToMilliseconds()-Time_Begin.ToMilliseconds());
+        auto Duration=(Time_End-Time_Begin).ToMilliseconds();
+        if (Time_End.GetFramesMax()!=Time_Begin.GetFramesMax())
+            Duration=Time_End.ToMilliseconds()-Time_Begin.ToMilliseconds();
+        Fill(Stream_General, 0, General_Duration, Duration);
+        Fill(Stream_Text, 0, Text_Duration, Duration);
         if (!Time_Begin.GetIsTime())
             Fill(Stream_Text, 0, Text_TimeCode_FirstFrame, Time_Begin.ToString());
         if (!Time_End.GetIsTime() && Time_End>Time_Begin)
@@ -355,6 +358,8 @@ void File_Ttml::Read_Buffer_Continue()
         {
             FrameRateMultiplier_Num=1000;
             FrameRateMultiplier_Den=float64_int64s(FrameRate_Int/FrameRate_F*1000);
+            if (FrameRateMultiplier_Num==1000 && FrameRateMultiplier_Den==1001)
+                FrameRate_Is1001=true;
         }
     }
     Tt_Attribute=Root->Attribute("xml:lang");

--- a/Source/MediaInfo/TimeCode.cpp
+++ b/Source/MediaInfo/TimeCode.cpp
@@ -309,7 +309,7 @@ bool TimeCode::FromString(const char* Value, size_t Length)
             {
                 Frames=((Value[9]-'0')*10)+(Value[10]-'0');
                 Flags.set(DropFrame, Value[8]==';');
-                if (Value[8])
+                if (Value[8]==';')
                     Flags.set(FramesPerSecond_Is1001);
                 Flags.reset(IsSecondField);
                 Flags.reset(IsNegative);


### PR DESCRIPTION
In MXF SystemScheme (no tip, so using video or audio tracks framerate) and SDTI (`CPR_1_1001`).
In default TTML.
Also avoid a TTML timestamp rounding issue with duration from timecode of end and begin.