### PR TITLE
ADIF: fix wrong detection of lot of files as ADIF

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac.cpp
+++ b/Source/MediaInfo/Audio/File_Aac.cpp
@@ -291,6 +291,8 @@ bool File_Aac::FileHeader_Begin()
         File__Tags_Helper::Accept("ADIF");
         MustSynchronize=false;
     }
+    else if (Mode==Mode_ADIF)
+        File__Tags_Helper::Reject("ADIF");
 
     return true;
 }

--- a/Source/MediaInfo/Audio/File_Aac_GeneralAudio.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_GeneralAudio.cpp
@@ -3123,7 +3123,9 @@ void File_Aac::payload(size_t BitsNotIncluded)
         #if MEDIAINFO_TRACE || MEDIAINFO_CONFORMANCE
         case  42: UsacFrame(BitsNotIncluded); break;
         #endif //MEDIAINFO_TRACE || MEDIAINFO_CONFORMANCE
-        default: Skip_BS(Data_BS_Remain()-BitsNotIncluded,      "payload");
+        default:
+            Skip_BS(Data_BS_Remain()-(BitsNotIncluded!=-1?BitsNotIncluded:0), "payload");
+            Frame_Count=Frame_Count_Valid;
     }
 }
 


### PR DESCRIPTION
Mistake is global but impact is visible only with MEDIAINFO_MINIMIZESIZE