### PR TITLE
MP4/MOV: show right time code of last frame with complex time code tracks

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -2905,6 +2905,7 @@ bool File_Mpeg4::BookMark_Needed()
                 if (StreamTemp.TimeCode && (StreamTemp.stts.size()>1 || (!StreamTemp.stts.empty() && StreamTemp.stts[0].SampleCount>1 && StreamTemp.Parsers.size()==1)))
                 {
                     ((File_Mpeg4_TimeCode*)StreamTemp.Parsers[0])->FirstEditOffset=0;
+                    ((File_Mpeg4_TimeCode*)StreamTemp.Parsers[0])->LastUsedOffset=StreamTemp.LastUsedOffset;
                     if (Config->ParseSpeed<=0.5)
                     {
                         auto StreamID=Temp->StreamID;

--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -2905,9 +2905,13 @@ bool File_Mpeg4::BookMark_Needed()
                 if (StreamTemp.TimeCode && (StreamTemp.stts.size()>1 || (!StreamTemp.stts.empty() && StreamTemp.stts[0].SampleCount>1 && StreamTemp.Parsers.size()==1)))
                 {
                     ((File_Mpeg4_TimeCode*)StreamTemp.Parsers[0])->FirstEditOffset=0;
+                }
+                if (StreamTemp.TimeCode && StreamTemp.Parsers.size()==1)
+                {
                     ((File_Mpeg4_TimeCode*)StreamTemp.Parsers[0])->LastUsedOffset=StreamTemp.LastUsedOffset;
-                    if (Config->ParseSpeed<=0.5)
+                    if (Config->ParseSpeed<=0.5 && StreamTemp.stco.size()>16)
                     {
+                        ((File_Mpeg4_TimeCode*)StreamTemp.Parsers[0])->AllFramesParsed=false;
                         auto StreamID=Temp->StreamID;
                         for (int j=mdat_Pos.size()-1; j>=0; j--)
                             if (StreamID==mdat_Pos[j].StreamID && mdat_Pos[j].Offset!=stco_ToFind && mdat_Pos[j].Offset!=StreamTemp.FirstUsedOffset && mdat_Pos[j].Offset!=StreamTemp.LastUsedOffset)
@@ -2926,6 +2930,8 @@ bool File_Mpeg4::BookMark_Needed()
                             mdat_Pos_Temp=Temp<mdat_Pos_Max?Temp:nullptr;
                         }
                     }
+                    else
+                        ((File_Mpeg4_TimeCode*)StreamTemp.Parsers[0])->AllFramesParsed=true;
                 }
             }
         }

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -5420,6 +5420,7 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_tmcd()
         Parser->mdhd_Duration_TimeScale=Streams[moov_trak_tkhd_TrackID].mdhd_TimeScale;
         Parser->tmcd_Duration = tc->FrameDuration;
         Parser->tmcd_Duration_TimeScale = tc->TimeScale;
+        Parser->DurationsPerFrame=&Streams[moov_trak_tkhd_TrackID].stts;
 
         //Get delay from timecode track's edit list
         int64s FrameDurationInMediaUnits = tc->FrameDuration * Streams[moov_trak_tkhd_TrackID].mdhd_TimeScale;

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
@@ -58,6 +58,7 @@ File_Mpeg4_TimeCode::File_Mpeg4_TimeCode()
     mvhd_Duration_TimeScale=0;
     DurationsPerFrame=nullptr;
     LastUsedOffset=(int64u)-1;
+    AllFramesParsed=false;
 
     //Temp
     FrameMultiplier_Pos=0;
@@ -185,7 +186,7 @@ void File_Mpeg4_TimeCode::Streams_Finish()
                 int64s Frames=TC_Last.GetFrames();
                 TC_Last-=TC_Last.GetFrames();
                 TC_Last=TimeCode((int64_t)(TC_Last.ToFrames()*FrameMultiplier), NumberOfFrames*FrameMultiplier-1, TimeCode::DropFrame(DropFrame));
-                TC_Last+=Frames*FrameMultiplier+(Config->ParseSpeed<=0.5?(FrameMultiplier-1):FrameMultiplier_Pos);
+                TC_Last+=Frames*FrameMultiplier+(AllFramesParsed?FrameMultiplier_Pos:(FrameMultiplier-1));
             }
             Fill(Stream_Other, StreamPos_Last, Other_TimeCode_LastFrame, TC_Last.ToString().c_str());
         }
@@ -229,7 +230,7 @@ void File_Mpeg4_TimeCode::Read_Buffer_Continue()
             if (Config->ParseSpeed<=0.5 && Element_Offset!=Element_Size)
                 Skip_XX(Element_Size-Element_Offset,            "Other positions");
         }
-        else if (Config->ParseSpeed>0.5)
+        else if (AllFramesParsed)
         {
             FrameMultiplier_Pos++;
             if (FrameMultiplier_Pos>=FrameMultiplier)

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.cpp
@@ -240,6 +240,18 @@ void File_Mpeg4_TimeCode::Read_Buffer_Continue()
             }
             if (Pos_Last!=Pos_Last_Temp)
             {
+                bool ShouldIgnore=false;
+                if (Frame_Count_NotParsedIncluded!=(int64u)-1 && DurationsPerFrame && tmcd_Duration)
+                {
+                    int64u Frame_Count_Temp=0;
+                    size_t i=0;
+                    for (; Frame_Count_NotParsedIncluded-Frame_Count_Temp>=(*DurationsPerFrame)[i].SampleCount; i++)
+                        Frame_Count_Temp+=(*DurationsPerFrame)[i].SampleCount;
+                    if (i<DurationsPerFrame->size() && (*DurationsPerFrame)[i].SampleDuration==0)
+                        ShouldIgnore=true;
+                }
+                if (!ShouldIgnore)
+                {
                 const Ztring& Discontinuities=Retrieve_Const(Stream_Other, 0, "Discontinuities");
                 if (Discontinuities.size()>25*10)
                 {
@@ -269,6 +281,7 @@ void File_Mpeg4_TimeCode::Read_Buffer_Continue()
                     Discontinuity+='-';
                     Discontinuity+=TC_Last2.ToString();
                     Fill(Stream_Other, 0, "Discontinuities", Discontinuity);
+                }
                 }
             }
         }

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
@@ -40,6 +40,7 @@ public :
     int64u  tmcd_Duration_TimeScale;
     const std::vector<stts_struct>* DurationsPerFrame;
     int64u  LastUsedOffset;
+    bool    AllFramesParsed;
 
     //Out
     int64s  Pos;

--- a/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_TimeCode.h
@@ -16,6 +16,8 @@
 namespace MediaInfoLib
 {
 
+struct stts_struct;
+
 //***************************************************************************
 // Class File_Mpeg4_TimeCode
 //***************************************************************************
@@ -36,6 +38,8 @@ public :
     int64u  mdhd_Duration_TimeScale;
     int64u  tmcd_Duration;
     int64u  tmcd_Duration_TimeScale;
+    const std::vector<stts_struct>* DurationsPerFrame;
+    int64u  LastUsedOffset;
 
     //Out
     int64s  Pos;


### PR DESCRIPTION
In case of multiple stripped timecodes.
Fix https://github.com/MediaArea/MediaInfoLib/issues/1878.

Also show discontinuities for complex stripped timecodes also without full parsing, as it does not hurt much performance if it is only a couple of timecode samples.