### PR TITLE
WAV: support of big (1+ GB) axml chunks

### DIFF
--- a/Source/MediaInfo/Audio/File_Adm.h
+++ b/Source/MediaInfo/Audio/File_Adm.h
@@ -50,8 +50,9 @@ private :
     bool FileHeader_Begin();
 
     //Buffer - Global
+    void Read_Buffer_Init();
     void Read_Buffer_Continue();
-
+ 
     //Temp
     file_adm_private* File_Adm_Private;
 };

--- a/Source/MediaInfo/Multiple/File_Riff.h
+++ b/Source/MediaInfo/Multiple/File_Riff.h
@@ -142,6 +142,7 @@ private :
     File_DolbyAudioMetadata* DolbyAudioMetadata;
     #if defined(MEDIAINFO_ADM_YES)
     File_Adm* Adm;
+    File_Adm* Adm_chna;
     #endif
     int64u WAVE_data_Size;  //RF64 WAVE_data real chunk size
     int64u WAVE_fact_samplesCount;  //RF64 WAVE_fact real samplesCount
@@ -181,6 +182,7 @@ private :
         Kind_Wave,
         Kind_Aiff,
         Kind_Rmp3,
+        Kind_Axml,
     };
     kind Kind;
     #if defined(MEDIAINFO_GXF_YES)
@@ -318,6 +320,7 @@ private :
     void WAVE_adtl_ltxt();
     void WAVE_adtl_note();
     void WAVE_axml ();
+    void WAVE_axml_Continue ();
     void WAVE_bext ();
     void WAVE_bxml () {WAVE_axml();}
     void WAVE_chna();

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -3655,22 +3655,33 @@ struct profile_info
 
 void File_Riff::WAVE_axml()
 {
-    int64u Element_TotalSize=Element_TotalSize_Get();
-    if (Element_Size!=Element_TotalSize-Alignement_ExtraByte)
+    //Preparing
+    delete Adm;
+    Adm=new File_Adm;
+    Open_Buffer_Init(Adm);
+    if (Adm_chna)
     {
-        if (Buffer_MaximumSize<Element_TotalSize)
-            Buffer_MaximumSize+=Element_TotalSize;
-        size_t* File_Buffer_Size_Hint_Pointer=Config->File_Buffer_Size_Hint_Pointer_Get();
-        if (File_Buffer_Size_Hint_Pointer)
-            (*File_Buffer_Size_Hint_Pointer)=(size_t)(Element_TotalSize-Element_Size);
-        Element_WaitForMoreData();
-        return; //Must wait for more data
+        Adm->chna_Move(Adm_chna);
+        delete Adm_chna; Adm_chna=NULL;
     }
+    Adm->MuxingMode=(Element_Code==Elements::WAVE_bxml)?'b':'a';
+    Adm->MuxingMode+="xml";
+    Kind=Kind_Axml;
 
-    int8u* UncompressedData;
-    size_t UncompressedData_Size;
     if (Element_Code==Elements::WAVE_bxml)
     {
+        int64u Element_TotalSize=Element_TotalSize_Get();
+        if (Element_Size!=Element_TotalSize-Alignement_ExtraByte)
+        {
+            if (Buffer_MaximumSize<Element_TotalSize)
+                Buffer_MaximumSize+=Element_TotalSize;
+            size_t* File_Buffer_Size_Hint_Pointer=Config->File_Buffer_Size_Hint_Pointer_Get();
+            if (File_Buffer_Size_Hint_Pointer)
+                (*File_Buffer_Size_Hint_Pointer)=(size_t)(Element_TotalSize-Element_Size);
+            Element_WaitForMoreData();
+            return; //Must wait for more data
+        }
+
         Element_Name("Compressed AXML");
 
         //Header
@@ -3717,31 +3728,26 @@ void File_Riff::WAVE_axml()
             strm.next_out=strm.next_out+strm.total_out;
             strm.avail_out=UncompressedData_NewMaxSize-strm.total_out;
         }
-        UncompressedData=strm.next_out-strm.total_out;
-        UncompressedData_Size=strm.total_out;
+        int8u* UncompressedData=strm.next_out-strm.total_out;
+        size_t UncompressedData_Size=strm.total_out;
+
+        //Parsing
+        Open_Buffer_Continue(Adm, UncompressedData, UncompressedData_Size);
+        Skip_UTF8(Element_Size, "XML data");
     }
     else
     {
         Element_Name("AXML");
 
-        UncompressedData=(int8u*)Buffer+Buffer_Offset;
-        UncompressedData_Size=(size_t)Element_Size;
+        //Parsing
+        WAVE_axml_Continue();
     }
+}
 
+void File_Riff::WAVE_axml_Continue()
+{
     //Parsing
-    File_Adm* Adm_New=new File_Adm;
-    Adm_New->MuxingMode=(Element_Code==Elements::WAVE_bxml)?'b':'a';
-    Adm_New->MuxingMode+="xml";
-    Open_Buffer_Init(Adm_New);
-    Open_Buffer_Continue(Adm_New, UncompressedData, UncompressedData_Size);
-    if (Adm_New->Status[IsAccepted])
-    {
-        Adm_New->chna_Move(Adm);
-        delete Adm;
-        Adm=Adm_New;
-    }
-
-    //Parsing
+    Open_Buffer_Continue(Adm, Buffer+Buffer_Offset, (size_t)Element_Size);
     Skip_UTF8(Element_Size, "XML data");
 }
 
@@ -3913,11 +3919,8 @@ void File_Riff::WAVE_chna()
 
     //Parsing
     int16u numUIDs;
-    if (!Adm)
-    {
-        Adm=new File_Adm;
-        Open_Buffer_Init(Adm);
-    }
+    auto Adm_Current = new File_Adm;
+    Open_Buffer_Init(Adm_chna);
     Skip_L2(                                                    "numTracks");
     Get_L2 (numUIDs,                                            "numUIDs");
     for (int32u Pos=0; Pos<numUIDs; Pos++)
@@ -3930,11 +3933,21 @@ void File_Riff::WAVE_chna()
         Skip_String(14,                                         "trackRef");
         Skip_String(11,                                         "packRef");
         Skip_L1(                                                "pad");
-        Adm->chna_Add(trackIndex, UID);
+        Adm_Current->chna_Add(trackIndex, UID);
         Element_End0();
         if (Element_Offset>=Element_Size)
             break;
     }
+
+    FILLING_BEGIN()
+        if (Adm)
+        {
+            Adm->chna_Move(Adm_Current);
+            delete Adm_Current; //Adm_Current=NULL
+        }
+        else
+            Adm_chna=Adm_Current;
+    FILLING_END();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/ThirdParty/tfsxml/tfsxml.c
+++ b/Source/ThirdParty/tfsxml/tfsxml.c
@@ -1,22 +1,24 @@
-/* Copyright (c) MediaArea.net SARL. All Rights Reserved.
+/* Copyright (c) MediaArea.net SARL
 
-This software is provided 'as-is', without any express or implied
-warranty. In no event will the authors be held liable for any damages
-arising from the use of this software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Permission is granted to anyone to use this software for any purpose,
-including commercial applications, and to alter it and redistribute it
-freely, subject to the following restrictions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-1. The origin of this software must not be misrepresented; you must not
-   claim that you wrote the original software. If you use this software
-   in a product, an acknowledgment in the product documentation would be
-   appreciated but is not required.
-2. Altered source versions must be plainly marked as such, and must not be
-   misrepresented as being the original software.
-3. This notice may not be removed or altered from any source distribution.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
-(zlib license)
+(MIT License)
 
 */
 
@@ -35,7 +37,7 @@ freely, subject to the following restrictions:
 /*
  * priv flags :
  * 0: is inside an element header
- * 1: previous element is closed
+ * 1: previous element is open (potentially with sub elements)
  */
 
 /*
@@ -43,68 +45,68 @@ freely, subject to the following restrictions:
  * 0: must be decoded
  */
 
-static inline void set_flag(tfsxml_string* priv, int offset)
-{
+static inline void set_flag(tfsxml_string* priv, int offset) {
     priv->flags |= (1 << offset);
 }
 
-static inline int get_flag(tfsxml_string* priv, int offset)
-{
+static inline int get_flag(tfsxml_string* priv, int offset) {
     return priv->flags & (1 << offset);
 }
 
-static inline void unset_flag(tfsxml_string* priv, int offset)
-{
+static inline void unset_flag(tfsxml_string* priv, int offset) {
     priv->flags &= ~(1 << offset);
 }
 
-static inline void next_char(tfsxml_string* priv)
+#define set_is_in_element_header() set_flag(priv, 0)
+#define get_is_in_element_header() get_flag(priv, 0)
+#define unset_is_in_element_header() unset_flag(priv, 0)
+#define set_previous_element_is_open() set_flag(priv, 1)
+#define get_previous_element_is_open() get_flag(priv, 1)
+#define unset_previous_element_is_open() unset_flag(priv, 1)
+
+#define set_must_be_decoded() set_flag(v, 0)
+
+static inline void set_level(tfsxml_string* priv, int level)
 {
+    const int offset = (sizeof(priv->flags) - 1) * 8;
+    priv->flags <<= 8;
+    priv->flags >>= 8;
+    priv->flags |= level << offset;
+}
+
+static inline void get_level(tfsxml_string* priv, int* level)
+{
+    const int offset = (sizeof(priv->flags) - 1) * 8;
+    *level = priv->flags >> offset;
+}
+
+static inline void next_char(tfsxml_string* priv) {
     priv->buf++;
     priv->len--;
 }
 
-static inline int tfsxml_leave_element_header(tfsxml_string* priv)
-{
+static int tfsxml_leave_element_header(tfsxml_string* priv) {
     /* Skip attributes */
     tfsxml_string n, v;
-    while (!tfsxml_attr(priv, &n, &v));
-
-    return 0;
-}
-
-
-static inline int tfsxml_has_value(tfsxml_string* v)
-{
-    int is_end = 0;
-    const char* buf = v->buf;
-    int len = v->len;
-    while (len && !is_end)
-    {
-        switch (*buf)
-        {
-        case '\n':
-        case '\t':
-        case '\r':
-        case ' ':
-            buf++;
-            len--;
-            break;
-        default:
-            is_end = 1;
+    for (;;) {
+        int result = tfsxml_attr(priv, &n, &v);
+        switch (result) {
+            case -1: {
+                return 0;
+            }
+            case 1: {
+                return 1;
+            }
+            default: {
+            }
         }
     }
-    if (is_end)
-        return 0;
-    return -1;
 }
 
-int tfsxml_strcmp_charp(tfsxml_string a, const char* b)
-{
-    /* Compare char per charand return the difference if chars are no equal */
-    for (; a.len && *b; a.buf++, a.len--, b++)
-    {
-        char c = *a.buf - *b;
+int tfsxml_strcmp_charp(tfsxml_string a, const char* b) {
+    /* Compare char per char and return the difference if chars are no equal */
+    for (; a.len && *b; a.buf++, a.len--, b++) {
+        int c = *a.buf - *b;
         if (c)
             return c;
     }
@@ -117,23 +119,19 @@ int tfsxml_strcmp_charp(tfsxml_string a, const char* b)
         return *a.buf; /* a is longer than b */
 }
 
-tfsxml_string tfsxml_strstr_charp(tfsxml_string a, const char* b)
-{
+tfsxml_string tfsxml_strstr_charp(tfsxml_string a, const char* b) {
     /* Iterate string to be scanned */
-    for (; a.len; a.buf++, a.len--)
-    {
+    for (; a.len; a.buf++, a.len--) {
         const char* buf = a.buf;
         int len = a.len;
         const char* bb = b;
         /* Compare char per char */
-        for (; len && *bb; buf++, len--, bb++)
-        {
+        for (; len && *bb; buf++, len--, bb++) {
             char c = *buf - *bb;
             if (c)
                 break;
         }
-        if (!len || *bb)
-        {
+        if (!len || *bb) {
             return a;
         }
     }
@@ -142,16 +140,18 @@ tfsxml_string tfsxml_strstr_charp(tfsxml_string a, const char* b)
     return a;
 }
 
-int tfsxml_init(tfsxml_string* priv, const void* buf, int len)
-{
+int tfsxml_init(tfsxml_string* priv, const void* buf, unsigned len, unsigned version) {
     const char* buf_8 = (const char*)buf;
+
+    if (version != 0) {
+        return -1;
+    }
 
     /* BOM detection */
     if (len > 3
         && (unsigned char)buf_8[0] == 0xEF
         && (unsigned char)buf_8[1] == 0xBB
-        && (unsigned char)buf_8[2] == 0xBF)
-    {
+        && (unsigned char)buf_8[2] == 0xBF) {
         buf_8 += 3;
         len -= 3;
     }
@@ -166,522 +166,574 @@ int tfsxml_init(tfsxml_string* priv, const void* buf, int len)
     priv->buf = (const char*)buf;
     priv->len = len;
     priv->flags = 0;
-    set_flag(priv, 1);
 
     return 0;
 }
 
-int tfsxml_next(tfsxml_string* priv, tfsxml_string* n)
-{
+int tfsxml_next(tfsxml_string* priv, tfsxml_string* n) {
+    tfsxml_string priv_bak;
     int level;
 
+    get_level(priv, &level);
+
     /* Exiting previous element header analysis if needed */
-    if (get_flag(priv, 0) && tfsxml_leave_element_header(priv))
-        return -1;
+    if (!level && get_is_in_element_header()) {
+        int result = tfsxml_leave_element_header(priv);
+        if (result) {
+            return result;
+        }
+    }
 
     /* Leaving previous element content if needed */
-    if (!get_flag(priv, 1) && tfsxml_leave(priv))
-        return -1;
+    if (level || get_previous_element_is_open()) {
+        if (!level && get_previous_element_is_open()) {
+            level++;
+            set_level(priv, level);
+        }
+        int result = tfsxml_leave(priv);
+        if (result) {
+            return result;
+        }
+        get_level(priv, &level);
+    }
 
-    level = 0;
-    while (priv->len)
-    {
-        switch (*priv->buf)
-        {
-        case '<':
-            next_char(priv);
-            if (priv->len && *priv->buf == '?')
-            {
-                n->buf = priv->buf;
-                while (priv->len && *priv->buf != '>')
-                {
-                    next_char(priv);
+    priv_bak = *priv;
+    while (priv->len) {
+        switch (*priv->buf) {
+            case '<': {
+                if (priv->len == 1) {
+                    *priv = priv_bak;
+                    set_level(priv, level);
+                    return 1;
                 }
-                n->len = priv->buf - n->buf;
-                if (priv->len)
-                    next_char(priv);
-                set_flag(priv, 1);
-                return 0;
-            }
-            if (priv->len && *priv->buf == '!')
-            {
-                unsigned long long probe = 0;
-                int i;
-                for (i = 1; i < 8; i++)
-                {
-                    probe <<= 8;
-                    probe |= priv->buf[i];
-                }
-                if (probe == 0x5B43444154415BULL) /* "[CDATA[" */
-                {
-                    probe = 0;
-                    priv->buf += 9;
-                    priv->len -= 9;
-                    while (priv->len)
-                    {
-                        probe &= 0xFFFF;
-                        probe <<= 8;
-                        probe |= *priv->buf;
-                        if (probe == 0x5D5D3EULL) /* "]]>" */
-                            break;
-                        priv->buf++;
-                        priv->len--;
+                if (priv->buf[1] == '/') {
+                    while (priv->len && *priv->buf != '>') {
+                        next_char(priv);
                     }
+                    if (!priv->len) {
+                        *priv = priv_bak;
+                        set_level(priv, level);
+                        return 1;
+                    }
+                    if (!level) {
+                        next_char(priv);
+                        unset_previous_element_is_open();
+                        set_level(priv, level);
+                        return -1;
+                    }
+                    level--;
                     break;
                 }
-                n->buf = priv->buf;
-                if (priv->len >= 3 && priv->buf[1] == '-' && priv->buf[2] == '-')
-                {
-                    int len_sav = priv->len;
-                    const char* buf = priv->buf + 3;
-                    int len = priv->len - 3;
-                    probe = 0;
-                    while (len)
-                    {
-                        probe &= 0xFFFF;
-                        probe <<= 8;
-                        probe |= *buf;
-                        if (probe == 0x2D2D3EULL) /* "-->" */
-                            break;
-                        buf++;
-                        len--;
-                    }
+                if (priv->buf[1] == '?') {
+                    next_char(priv);
                     n->buf = priv->buf;
-                    n->len = len_sav - len;
-                    priv->buf += n->len;
-                    priv->len -= n->len;
-                    if (priv->len)
+                    while (priv->len && *priv->buf != '>') {
                         next_char(priv);
+                    }
+                    if (!priv->len) {
+                        *priv = priv_bak;
+                        set_level(priv, level);
+                        return 1;
+                    }
+                    n->len = priv->buf - n->buf;
+                    next_char(priv);
+                    unset_previous_element_is_open();
+                    set_level(priv, 0);
                     return 0;
                 }
-                while (priv->len && *priv->buf != '>')
+                if (priv->buf[1] == '!') {
+                    unsigned long long probe = 0;
+                    int i;
+                    if (priv->len <= 8) {
+                        *priv = priv_bak;
+                        set_level(priv, level);
+                        return 1;
+                    }
+                    for (i = 2; i <= 8; i++) {
+                        probe <<= 8;
+                        probe |= priv->buf[i];
+                    }
+                    if (probe == 0x5B43444154415BULL) { /* "<![CDATA[" */
+                        probe = 0;
+                        priv->buf += 9;
+                        priv->len -= 9;
+                        while (priv->len) {
+                            probe &= 0xFFFF;
+                            probe <<= 8;
+                            probe |= *priv->buf;
+                            if (probe == 0x5D5D3EULL) { /* "]]>" */
+                                break;
+                            }
+                            next_char(priv);
+                        }
+                        if (!priv->len) {
+                            *priv = priv_bak;
+                            set_level(priv, level);
+                            return 1;
+                        }
+                        break;
+                    }
+                    if ((probe >> 40) == 0x2D2D) { /* "<!--" */
+                        n->buf = priv->buf;
+                        probe = 0;
+                        priv->buf += 4;
+                        priv->len -= 4;
+                        while (priv->len) {
+                            probe &= 0xFFFF;
+                            probe <<= 8;
+                            probe |= *priv->buf;
+                            if (probe == 0x2D2D3EULL) /* "-->" */
+                                break;
+                            next_char(priv);
+                        }
+                        if (!priv->len) {
+                            *priv = priv_bak;
+                            set_level(priv, level);
+                            return 1;
+                        }
+                        n->len = priv->buf - n->buf;
+                        next_char(priv);
+                        unset_previous_element_is_open();
+                        set_level(priv, 0);
+                        return 0;
+                    }
+                    while (priv->len && *priv->buf != '>') {
+                        next_char(priv);
+                    }
+                    if (!priv->len) {
+                        *priv = priv_bak;
+                        set_level(priv, level);
+                        return 1;
+                    }
+                    n->buf = priv_bak.buf;
+                    n->len = priv->buf - n->buf;
                     next_char(priv);
-                n->len = priv->buf - n->buf;
-                if (priv->len)
-                    next_char(priv);
-                set_flag(priv, 1);
-                return 0;
-            }
-            if (*priv->buf == '/')
-            {
-                while (priv->len && *priv->buf != '>')
-                    next_char(priv);
-                next_char(priv);
-                if (!level)
-                {
-                    n->buf = NULL;
-                    n->len = 0;
-                    set_flag(priv, 1);
-                    return -1;
+                    unset_previous_element_is_open();
+                    set_level(priv, 0);
+                    return 0;
                 }
-                level--;
+                if (!level) {
+                    next_char(priv);
+                    n->buf = priv->buf;
+                    for (;;) {
+                        if (!priv->len) {
+                            *priv = priv_bak;
+                            set_level(priv, level);
+                            return 1;
+                        }
+
+                        switch (*priv->buf) {
+                            case '\n':
+                            case '\t':
+                            case '\r':
+                            case ' ':
+                            case '/':
+                            case '>':
+                                n->len = priv->buf - n->buf;
+                                set_is_in_element_header();
+                                set_previous_element_is_open();
+                                set_level(priv, 0);
+                                return 0;
+                            default: {
+                            }
+                        }
+                        next_char(priv);
+                    }
+                }
+                level++;
                 break;
             }
-            if (!level)
-            {
-                n->buf = priv->buf;
-                for (;;)
-                {
-                    if (!priv->len)
-                        return -1;
+            default: {
+            }
+        }
+        next_char(priv);
+    }
+    set_level(priv, level);
+    return 1;
+}
 
-                    switch (*priv->buf)
-                    {
-                    case '\n':
-                    case '\t':
-                    case '\r':
-                    case ' ':
-                    case '/':
-                    case '>':
-                        n->len = priv->buf - n->buf;
-                        set_flag(priv, 0);
-                        unset_flag(priv, 1);
-                        return 0;
-                    default:;
+int tfsxml_attr(tfsxml_string* priv, tfsxml_string* n, tfsxml_string* v) {
+    if (!get_is_in_element_header()) {
+        return -1;
+    }
+
+    v->flags = 0;
+    tfsxml_string priv_bak = *priv;
+    while (priv->len) {
+        switch (*priv->buf) {
+            case '/': {
+                unset_previous_element_is_open();
+                //fall through
+            }
+            case '\n':
+            case '\t':
+            case '\r':
+            case ' ': {
+                break;
+            }
+            case '>': {
+                next_char(priv);
+                unset_is_in_element_header();
+                return -1;
+            }
+            default: {
+                if (!get_previous_element_is_open()) {
+                    break; // Junk after "/", ignoring
+                }
+
+                /* Attribute */
+                n->buf = priv->buf;
+                while (priv->len && *priv->buf != '=') {
+                    next_char(priv);
+                }
+                if (!priv->len) {
+                    *priv = priv_bak;
+                    return 1;
+                }
+                n->len = priv->buf - n->buf;
+                next_char(priv);
+
+                /* Value */
+                const char quote = *priv->buf;
+                if (!priv->len) {
+                    *priv = priv_bak;
+                    return 1;
+                }
+                next_char(priv);
+                v->buf = priv->buf;
+                while (priv->len && *priv->buf != quote) {
+                    if (*priv->buf == '&') {
+                        set_flag(v, 0);
                     }
                     next_char(priv);
                 }
+                v->len = priv->buf - v->buf;
+                if (!priv->len) {
+                    *priv = priv_bak;
+                    return 1;
+                }
+                next_char(priv);
+                return 0;
             }
-            level++;
-            break;
-        default:;
         }
         next_char(priv);
     }
-    n->buf = NULL;
-    n->len = 0;
-    unset_flag(priv, 0);
-    unset_flag(priv, 1);
-    return -1;
+    *priv = priv_bak;
+    return 1;
 }
 
-int tfsxml_attr(tfsxml_string* priv, tfsxml_string* n, tfsxml_string* v)
-{
-    if (!get_flag(priv, 0))
-        return -1;
-
-    v->flags = 0;
-    while (priv->len)
-    {
-        switch (*priv->buf)
-        {
-        case '\n':
-        case '\t':
-        case '\r':
-        case ' ':
-            break;
-        case '/':
-            set_flag(priv, 1);
-            break;
-        case '>':
-            next_char(priv);
-            n->buf = NULL;
-            n->len = 0;
-            v->buf = NULL;
-            v->len = 0;
-            v->flags = 0;
-            unset_flag(priv, 0);
-            return -1;
-        default:
-        {
-            /* Attribute */
-            n->buf = priv->buf;
-            while (priv->len && *priv->buf != '=')
-            {
-                next_char(priv);
-            }
-            n->len = priv->buf - n->buf;
-            if (!priv->len)
-                return -1;
-            next_char(priv);
-        }
-        {
-            /* Value */
-            const char quote = *priv->buf;
-            if (!priv->len)
-                return -1;
-            next_char(priv);
-            v->buf = priv->buf;
-            while (priv->len && *priv->buf != quote)
-            {
-                if (*priv->buf == '&')
-                    set_flag(v, 0);
-                next_char(priv);
-            }
-            v->len = priv->buf - v->buf;
-            if (!priv->len)
-                return -1;
-            next_char(priv);
-            return 0;
-        }
-        }
-        next_char(priv);
-    }
-    n->buf = NULL;
-    n->len = 0;
-    n->flags = 0;
-    v->buf = NULL;
-    v->len = 0;
-    v->flags = 0;
-    unset_flag(priv, 0);
-    return -1;
-}
-
-
-int tfsxml_value(tfsxml_string* priv, tfsxml_string* v)
-{
-    tfsxml_string priv_bak = *priv;
-    int len_sav;
+int tfsxml_value(tfsxml_string* priv, tfsxml_string* v) {
+    tfsxml_string priv_bak;
+    unsigned len_sav;
 
     /* Exiting previous element header analysis if needed */
-    int is_first = 0;
-    if (get_flag(priv, 0))
-    {
-        if (tfsxml_leave_element_header(priv))
-            return -1;
-        is_first = 1;
+    if (get_is_in_element_header()) {
+        int result = tfsxml_leave_element_header(priv);
+        if (result) {
+            return result;
+        }
 
         /* Previous element must not be finished */
-        if (get_flag(priv, 1))
+        if (!get_previous_element_is_open()) {
             return -1;
+        }
     }
 
+    priv_bak = *priv;
     len_sav = priv->len;
     v->flags = 0;
-    while (priv->len)
-    {
-        switch (*priv->buf)
-        {
-        case '&':
-            set_flag(v, 0);
-            break;
-        case '<':
-            if (priv->len == len_sav && priv->len > 8)
-            {
-                unsigned long long probe = 0;
-                int i;
-                for (i = 1; i <= 8; i++)
-                {
-                    probe <<= 8;
-                    probe |= priv->buf[i];
+    while (priv->len) {
+        switch (*priv->buf) {
+            case '&': {
+                set_must_be_decoded();
+                break;
+            }
+            case '<': {
+                if (priv->len == 1) {
+                    *priv = priv_bak;
+                    return 1;
                 }
-                if (probe == 0x215B43444154415BULL) /* "![CDATA[" */
-                {
-                    const char* buf = priv->buf + 9;
-                    int len = priv->len - 9;
-                    probe = 0;
-                    while (len)
-                    {
-                        probe &= 0xFFFF;
-                        probe <<= 8;
-                        probe |= *buf;
-                        if (probe == 0x5D5D3EULL) /* "]]>" */
-                            break;
-                        buf++;
-                        len--;
+                if (priv->buf[1] == '!') {
+                    if (priv->len <= 8) {
+                        *priv = priv_bak;
+                        return 1;
                     }
-                    v->buf = priv->buf;
-                    v->len = len_sav - len;
-                    if (v->len < priv->len)
-                        v->len++;
-                    priv->buf += v->len;
-                    priv->len -= v->len;
-                    v->buf += 9;
-                    v->len -= 12;
-                    return 0;
+                    unsigned long long probe = 0;
+                    int i;
+                    for (i = 2; i <= 8; i++) {
+                        probe <<= 8;
+                        probe |= priv->buf[i];
+                    }
+                    if (probe == 0x5B43444154415BULL) { /* "<![CDATA[" */
+                        set_must_be_decoded();
+                        probe = 0;
+                        priv->buf += 9;
+                        priv->len -= 9;
+                        while (priv->len) {
+                            probe &= 0xFFFF;
+                            probe <<= 8;
+                            probe |= *priv->buf;
+                            if (probe == 0x5D5D3EULL) { /* "]]>" */
+                                break;
+                            }
+                            next_char(priv);
+                        }
+                        if (!priv->len) {
+                            *priv = priv_bak;
+                            return 1;
+                        }
+                        break;
+                    }
                 }
+                v->len = len_sav - priv->len;
+                v->buf = priv->buf - v->len;
+                set_previous_element_is_open();
+                set_level(priv, 1);
+                int result = tfsxml_leave(priv);
+                if (result) {
+                    *priv = priv_bak;
+                    return result;
+                }
+                return 0;
             }
-            v->len = len_sav - priv->len;
-            v->buf = priv->buf - v->len;
-            if (tfsxml_has_value(v))
-            {
-                *priv = priv_bak;
-                return -1;
+            default: {
             }
-            if (is_first)
-            {
-                unset_flag(priv, 1);
-                tfsxml_leave(priv);
-            }
-            return 0;
-        default:;
         }
         next_char(priv);
     }
-
-    v->len = len_sav;
-    v->buf = priv->buf - v->len;
-    v->flags = 0;
-    if (tfsxml_has_value(v))
-    {
-        *priv = priv_bak;
-        return -1;
-    }
-    return 0;
+    *priv = priv_bak;
+    return 1;
 }
 
-int tfsxml_enter(tfsxml_string* priv)
-{
-    /* Exiting previous element header analysis if needed */
-    if (get_flag(priv, 0) && tfsxml_leave_element_header(priv))
-        return -1;
-
-    /* Previous element must not be finished */
-    if (get_flag(priv, 1))
-        return -1;
-
-    set_flag(priv, 1);
-    return 0;
-}
-
-int tfsxml_leave(tfsxml_string* priv)
-{
-    int level;
-
-    /* Exiting previous element header analysis if needed */
-    if (get_flag(priv, 0) && tfsxml_leave_element_header(priv))
-        return -1;
-
-    level = get_flag(priv, 1) ? 1 : 0;
-    while (priv->len)
-    {
-        switch (*priv->buf)
-        {
-        case '<':
-            next_char(priv);
-            if (priv->len && *priv->buf == '/')
-            {
-                if (!level)
-                {
-                    while (priv->len && *priv->buf != '>')
-                        next_char(priv);
-                    if (priv->len)
-                        next_char(priv);
-                    set_flag(priv, 1);
-                    return 0;
-                }
-                level--;
-                if (priv->len)
-                    next_char(priv);
-                break;
-            }
-            if (priv->len && *priv->buf == '?')
-            {
-                while (priv->len && *priv->buf != '>')
-                {
-                    next_char(priv);
-                }
-                if (priv->len)
-                    next_char(priv);
-                set_flag(priv, 1);
-                break;
-            }
-            if (priv->len && *priv->buf == '!')
-            {
-                unsigned long long probe = 0;
-                int i;
-                for (i = 1; i < 8; i++)
-                {
-                    probe <<= 8;
-                    probe |= priv->buf[i];
-                }
-                if (probe == 0x5B43444154415BULL) /* "[CDATA[" */
-                {
-                    probe = 0;
-                    priv->buf += 9;
-                    priv->len -= 9;
-                    while (priv->len)
-                    {
-                        probe &= 0xFFFF;
-                        probe <<= 8;
-                        probe |= *priv->buf;
-                        if (probe == 0x5D5D3EULL) /* "]]>" */
-                            break;
-                        priv->buf++;
-                        priv->len--;
-                    }
-                    break;
-                }
-                if (priv->len >= 3 && priv->buf[1] == '-' && priv->buf[2] == '-')
-                {
-                    const char* buf = priv->buf + 3;
-                    int len_sav = priv->len;
-                    int len = priv->len - 3;
-                    probe = 0;
-                    while (len)
-                    {
-                        probe &= 0xFFFF;
-                        probe <<= 8;
-                        probe |= *buf;
-                        if (probe == 0x2D2D3EULL) /* "-->" */
-                            break;
-                        buf++;
-                        len--;
-                    }
-                    len = len_sav - len;
-                    priv->buf += len;
-                    priv->len -= len;
-                    if (priv->len)
-                        next_char(priv);
-                    break;
-                }
-                while (priv->len && *priv->buf != '>')
-                    next_char(priv);
-                if (priv->len)
-                    next_char(priv);
-                break;
-            }
-            for (;;)
-            {
-                int split;
-
-                if (!priv->len)
-                    return -1;
-
-                split = 0;
-                switch (*priv->buf)
-                {
-                case '\n':
-                case '\t':
-                case '\r':
-                case ' ':
-                case '/':
-                case '>':
-                    set_flag(priv, 0);
-                    unset_flag(priv, 1);
-                    split = 1;
-                    break;
-                default:;
-                }
-                if (split)
-                    break;
-                next_char(priv);
-            }
-            if (tfsxml_leave_element_header(priv))
-                return -1;
-            if (!get_flag(priv, 1))
-                level++;
-            break;
-        default:;
-            next_char(priv);
+int tfsxml_enter(tfsxml_string* priv) {
+    /* Exiting previous element header if needed */
+    if (get_is_in_element_header()) {
+        int result = tfsxml_leave_element_header(priv);
+        if (result) {
+            return result;
         }
     }
 
-    set_flag(priv, 1);
-    set_flag(priv, 3);
+    /* Previous element must not be finished */
+    if (!get_previous_element_is_open()) {
+        return -1;
+    }
+
+    unset_previous_element_is_open();
     return 0;
 }
 
-static const char* const tfsxml_decode_markup[2] =
-{
+int tfsxml_leave(tfsxml_string* priv) {
+    tfsxml_string priv_bak;
+    unsigned level;
+
+    get_level(priv, &level);
+
+    /* Exiting previous element header analysis if needed */
+    if (get_is_in_element_header()) {
+        int result = tfsxml_leave_element_header(priv);
+        if (result) {
+            return result;
+        }
+        if (get_previous_element_is_open()) {
+            level++;
+        }
+    }
+
+    set_previous_element_is_open();
+    priv_bak = *priv;
+    while (priv->len) {
+        switch (*priv->buf) {
+            case '<': {
+                priv_bak = *priv;
+                if (priv->len == 1) {
+                    *priv = priv_bak;
+                    set_level(priv, level);
+                    return 1;
+                }
+                if (priv->buf[1] == '/') {
+                    while (priv->len && *priv->buf != '>') {
+                        next_char(priv);
+                    }
+                    if (!priv->len) {
+                        *priv = priv_bak;
+                        set_level(priv, level);
+                        return 1;
+                    }
+                    level--;
+                    if (!level) {
+                        next_char(priv);
+                        unset_previous_element_is_open();
+                        set_level(priv, 0);
+                        return 0;
+                    }
+                    priv_bak = *priv;
+                    break;
+                }
+                if (priv->buf[1] == '?') {
+                    while (priv->len && *priv->buf != '>') {
+                        next_char(priv);
+                    }
+                    if (!priv->len) {
+                        *priv = priv_bak;
+                        set_level(priv, level);
+                        return 1;
+                    }
+                    unset_previous_element_is_open();
+                    break;
+                }
+                if (priv->buf[1] == '!') {
+                    unsigned long long probe = 0;
+                    int i;
+                    if (priv->len <= 8) {
+                        *priv = priv_bak;
+                        set_level(priv, level);
+                        return 1;
+                    }
+                    for (i = 2; i <= 8; i++) {
+                        probe <<= 8;
+                        probe |= priv->buf[i];
+                    }
+                    if (probe == 0x5B43444154415BULL) { /* "<![CDATA[" */
+                        probe = 0;
+                        priv->buf += 9;
+                        priv->len -= 9;
+                        while (priv->len) {
+                            probe &= 0xFFFF;
+                            probe <<= 8;
+                            probe |= *priv->buf;
+                            if (probe == 0x5D5D3EULL) { /* "]]>" */
+                                break;
+                            }
+                            next_char(priv);
+                        }
+                        if (!priv->len) {
+                            *priv = priv_bak;
+                            set_level(priv, level);
+                            return 1;
+                        }
+                        break;
+                    }
+                    if ((probe >> 40) == 0x2D2D) { /* "<!--" */
+                        probe = 0;
+                        priv->buf += 4;
+                        priv->len -= 4;
+                        while (priv->len) {
+                            probe &= 0xFFFF;
+                            probe <<= 8;
+                            probe |= *priv->buf;
+                            if (probe == 0x2D2D3EULL) /* "-->" */
+                                break;
+                            next_char(priv);
+                        }
+                        if (!priv->len) {
+                            *priv = priv_bak;
+                            set_level(priv, level);
+                            return 1;
+                        }
+                        break;
+                    }
+                    while (priv->len && *priv->buf != '>') {
+                        next_char(priv);
+                    }
+                    if (!priv->len) {
+                        *priv = priv_bak;
+                        set_level(priv, level);
+                        return 1;
+                    }
+                    next_char(priv);
+                    break;
+                }
+                for (;;) {
+                    int split;
+
+                    if (!priv->len) {
+                        *priv = priv_bak;
+                        set_level(priv, level);
+                        return 1;
+                    }
+
+                    split = 0;
+                    switch (*priv->buf) {
+                        case '\n':
+                        case '\t':
+                        case '\r':
+                        case ' ':
+                        case '/':
+                        case '>': {
+                            set_is_in_element_header();
+                            set_previous_element_is_open();
+                            split = 1;
+                            break;
+                        }
+                        default: {
+                        }
+                    }
+                    if (split)
+                        break;
+                    next_char(priv);
+                }
+                int result = tfsxml_leave_element_header(priv);
+                if (result) {
+                    set_is_in_element_header();
+                    set_previous_element_is_open();
+                    set_level(priv, level);
+                    return result;
+                }
+                if (get_previous_element_is_open()) {
+                    level++;
+                    set_previous_element_is_open();
+                }
+                continue;
+            }
+            default: {
+            }
+        }
+        next_char(priv);
+    }
+    set_level(priv, level);
+    return 1;
+}
+
+static const char* const tfsxml_decode_markup[2] = {
     "amp\0apos\0gt\0lt\0quot",
     "&'><\"",
 };
 
-void tfsxml_decode(void* s, const tfsxml_string* v, void (*func)(void*, const char*, int))
-{
+void tfsxml_decode(void* s, const tfsxml_string* v, void (*func)(void*, const char*, unsigned)) {
     const char* buf_begin;
     const char* buf = v->buf;
-    int len = v->len;
+    unsigned len = v->len;
 
-    if (!(v->flags & 1))
-    {
+    if (!(v->flags & 1)) {
         func(s, buf, len);
         return;
     }
 
     buf_begin = buf;
-    while (len)
-    {
-        if (*buf == '&')
-        {
+    while (len) {
+        if (*buf == '&') {
             const char* buf_end = buf;
             int len_end = len;
-            while (len_end && *buf_end != ';')
-            {
+            while (len_end && *buf_end != ';') {
                 buf_end++;
                 len_end--;
             }
-            if (len_end)
-            {
+            if (len_end) {
                 const char* buf_beg = buf + 1;
-                int len_beg = buf_end - buf_beg;
-                if (len_beg && *buf_beg == '#')
-                {
+                unsigned len_beg = buf_end - buf_beg;
+                if (len_beg && *buf_beg == '#') {
                     unsigned long value = 0;
                     buf_beg++;
                     len_beg--;
-                    if (*buf_beg == 'x' || *buf_beg == 'X')
-                    {
+                    if (*buf_beg == 'x' || *buf_beg == 'X') {
                         buf_beg++;
                         len_beg--;
-                        while (len_beg)
-                        {
+                        while (len_beg) {
                             char c = *buf_beg++;
                             len_beg--;
                             value <<= 4;
-                            if (value >= 0x110000)
-                            {
+                            if (value >= 0x110000) {
                                 value = -1;
                                 break;
                             }
@@ -691,58 +743,48 @@ void tfsxml_decode(void* s, const tfsxml_string* v, void (*func)(void*, const ch
                                 value |= c - ('A' - 10);
                             else if (c >= 'a' && c <= 'f')
                                 value |= c - ('a' - 10);
-                            else
-                            {
+                            else {
                                 value = -1;
                                 break;
                             }
                         }
                     }
-                    else
-                    {
-                        while (len_beg)
-                        {
+                    else {
+                        while (len_beg) {
                             char c = *buf_beg++;
                             len_beg--;
-                            if (c < '0' || c > '9')
-                            {
+                            if (c < '0' || c > '9') {
                                 value = -1;
                                 break;
                             }
                             value *= 10;
                             value += c - '0';
-                            if (value >= 0x110000)
-                            {
+                            if (value >= 0x110000) {
                                 value = -1;
                                 break;
                             }
                         }
                     }
 
-                    if (value != (unsigned long)-1)
-                    {
+                    if (value != (unsigned long)-1) {
                         char utf8[4];
                         func(s, buf_begin, buf - buf_begin);
-                        if (value < 0x0080)
-                        {
+                        if (value < 0x0080) {
                             utf8[0] = (char)value;
                             func(s, utf8, 1);
                         }
-                        else if (value < 0x0800)
-                        {
+                        else if (value < 0x0800) {
                             utf8[0] = 0xC0 | (char)(value >> 6);
                             utf8[1] = 0x80 | (char)(value & 0x3F);
                             func(s, utf8, 2);
                         }
-                        else if (value < 0x10000)
-                        {
+                        else if (value < 0x10000) {
                             utf8[0] = 0xE0 | (char)((value >> 12));
                             utf8[1] = 0x80 | (char)((value >> 6) & 0x3F);
                             utf8[2] = 0x80 | (char)((value & 0x3F));
                             func(s, utf8, 3);
                         }
-                        else if (value < 0x110000)
-                        {
+                        else if (value < 0x110000) {
                             utf8[0] = 0xF0 | (char)((value >> 18));
                             utf8[1] = 0x80 | (char)((value >> 12) & 0x3F);
                             utf8[2] = 0x80 | (char)((value >> 6) & 0x3F);
@@ -755,26 +797,23 @@ void tfsxml_decode(void* s, const tfsxml_string* v, void (*func)(void*, const ch
                         buf_begin = buf_end + 1;
                     }
                 }
-                else
-                {
+                else {
                     const char* const buf_beg_sav = buf_beg;
                     const char* replaced = tfsxml_decode_markup[0];
                     const char* replace_bys = tfsxml_decode_markup[1];
-                    for (;;)
-                    {
+                    for (;;) {
                         char replace_by = *replace_bys++;
-                        if (!replace_by)
+                        if (!replace_by) {
                             break;
+                        }
 
-                        while (*replaced)
-                        {
+                        while (*replaced) {
                             if (buf_beg == buf_end || !*replaced || *replaced != *buf_beg)
                                 break;
                             replaced++;
                             buf_beg++;
                         }
-                        if (buf_beg == buf_end && !*replaced)
-                        {
+                        if (buf_beg == buf_end && !*replaced) {
                             func(s, buf_begin, buf - buf_begin);
                             func(s, &replace_by, 1);
                             len -= buf_end - buf;
@@ -783,11 +822,39 @@ void tfsxml_decode(void* s, const tfsxml_string* v, void (*func)(void*, const ch
                             break;
                         }
                         buf_beg = buf_beg_sav;
-                        while (*replaced)
+                        while (*replaced) {
                             replaced++;
+                        }
                         replaced++;
                     }
                 }
+            }
+        }
+        if (*buf == '<' && len > 8) {
+            unsigned long long probe = 0;
+            int i;
+            for (i = 1; i <= 8; i++) {
+                probe <<= 8;
+                probe |= buf[i];
+            }
+            if (probe == 0x215B43444154415BULL) { /* "<![CDATA[" */
+                func(s, buf_begin, buf - buf_begin);
+                probe = 0;
+                buf += 9;
+                len -= 9;
+                buf_begin = buf;
+                while (len) {
+                    probe &= 0xFFFF;
+                    probe <<= 8;
+                    probe |= *buf;
+                    if (probe == 0x5D5D3EULL) { /* "]]>" */
+                        break;
+                    }
+                    buf++;
+                    len--;
+                }
+                func(s, buf_begin, buf - 2 - buf_begin);
+                buf_begin = buf + 1;
             }
         }
         buf++;

--- a/Source/ThirdParty/tfsxml/tfsxml.h
+++ b/Source/ThirdParty/tfsxml/tfsxml.h
@@ -1,3 +1,27 @@
+/* Copyright (c) MediaArea.net SARL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+(MIT License)
+
+*/
+
 /*
  * Tiny Fast Streamable XML parser
  */
@@ -22,22 +46,22 @@ extern "C"
  *
  * @note after init, priv should not be directly used (data may be something else than a buf/len pair)
  */
-    typedef struct tfsxml_string
-{
+typedef struct tfsxml_string {
     const char* buf;
-    int         len;
-    int         flags;
+    unsigned    len;
+    unsigned    flags;
 } tfsxml_string;
 
 /** Initialize the parser
  *
- * @param priv  pointer to a tfsxml_string dedicated instance, private use by the parser
- * @param buf  pointer to start of the buffer
- * @param len  length of the buffer
+ * @param priv      pointer to a tfsxml_string dedicated instance, private use by the parser
+ * @param buf       pointer to start of the buffer
+ * @param len       length of the buffer
+ * @param version   API version supported by the client
  *
  * @note after init, priv should not be directly used (data may be something else than a buf/len pair)
  */
-int tfsxml_init(tfsxml_string* priv, const void* buf, int len);
+int tfsxml_init(tfsxml_string* priv, const void* buf, unsigned len, unsigned version);
 
 /** Get next element or other content except an element value
  *
@@ -46,6 +70,7 @@ int tfsxml_init(tfsxml_string* priv, const void* buf, int len);
  *
  * @return  0 if an element is available at the current level
  *          -1 if no element is available at the current level
+ *          1 if need of more data
  */
 int tfsxml_next(tfsxml_string* priv, tfsxml_string* n);
 
@@ -57,6 +82,7 @@ int tfsxml_next(tfsxml_string* priv, tfsxml_string* n);
  *
  * @return  0 if an attribute is available for the current element
  *          -1 if no more attribute is available for the current element
+ *          1 if need of more data
  */
 int tfsxml_attr(tfsxml_string* priv, tfsxml_string* n, tfsxml_string* v);
 
@@ -67,6 +93,7 @@ int tfsxml_attr(tfsxml_string* priv, tfsxml_string* n, tfsxml_string* v);
  *
  * @return  0 if a value is available for the current element
  *          -1 if no value is available for the current element
+ *          1 if need of more data
  *
  * @note if this element has sub-elements, the whole content (all sub-elements) are provided
  */
@@ -78,6 +105,7 @@ int tfsxml_value(tfsxml_string* priv, tfsxml_string* v);
  *
  * @return  0 if it is possible to enter in an element
  *          -1 if it is not possible to enter in an element
+ *          1 if need of more data
  */
 int tfsxml_enter(tfsxml_string* priv);
 
@@ -87,6 +115,7 @@ int tfsxml_enter(tfsxml_string* priv);
  *
  * @return  0 if it is possible to leave an element
  *          -1 if it is not possible to leave an element
+ *          1 if need of more data
  */
 int tfsxml_leave(tfsxml_string* priv);
 
@@ -96,17 +125,17 @@ int tfsxml_leave(tfsxml_string* priv);
 
 /** Convert encoded XML block (attribute or value) to real content (encoded in UTF-8)
  *
- * @param s  opaque data transmitted to func
- * @param b  XML content to decode
- * @param func  function that will receive blocks of decoded content
+ * @param s         opaque data transmitted to func
+ * @param v         XML content to decode
+ * @param func      append function that will receive blocks of decoded content
  *
- * @param func_s  s
- * @param buf  decoded content
- * @param len  length of the decoded content
+ * @param func_s    string to append to
+ * @param func_buf  decoded content
+ * @param func_len  length of the decoded content
  *
  * @note see tfsxml_decode_string C++ function for an example of usage
  */
-void tfsxml_decode(void* s, const tfsxml_string* v, void (*func)(void* func_s, const char* func_buf, int func_len));
+void tfsxml_decode(void* s, const tfsxml_string* v, void (*func)(void* func_s, const char* func_buf, unsigned func_len));
 
 /** -------------------------------------------------------------------------
         Helper functions related to tfsxml_string
@@ -137,7 +166,7 @@ tfsxml_string tfsxml_strstr_charp(tfsxml_string a, const char* b);
 #ifdef __cplusplus
 #include <string>
 
-static void tfsxml_decode_string(void* d, const char* buf, int len) { ((std::string*)d)->append(buf, len); }
+static void tfsxml_decode_string(void* d, const char* buf, unsigned len) { ((std::string*)d)->append(buf, len); }
 
 /** Convert encoded XML block (attribute or value) to real content (encoded in UTF-8)
  *


### PR DESCRIPTION
Some ADM content are really big and loading the complete XML file in RAM was too much for 32-bit systems (but also too much RAM consuming on low memory 64-bit systems)