### PR TITLE
ADM: rounding of FFoA to 0 decimal and Start/End time codes to 2 decimals

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -196,7 +196,14 @@ void Merge_FillTimeCode(File__Analyze& In, const string& Prefix, const TimeCode&
     
     In.Fill(Stream_Audio, 0, Prefix.c_str(), TC_Time.ToString(), true, true);
     In.Fill_SetOptions(Stream_Audio, 0, Prefix.c_str(), "N NTY");
-    In.Fill(Stream_Audio, 0, (Prefix+"/String").c_str(), TC_Time.ToString()+(TC_WithExtraSamples_String.empty()?string():(" ("+TC_WithExtraSamples_String+')')), true, true);
+    string ForDisplay;
+    if (Prefix=="Dolby_Atmos_Metadata FirstFrameOfAction")
+        ForDisplay=TC_Frames.ToString();
+    else if (Prefix.find(" Start")+6==Prefix.size() || Prefix.find(" End")+4==Prefix.size())
+        ForDisplay=TC_WithExtraSubFrames_String;
+    else
+        ForDisplay=TC_WithExtraSamples_String;
+    In.Fill(Stream_Audio, 0, (Prefix+"/String").c_str(), TC_Time.ToString()+(ForDisplay.empty()?string():(" ("+ForDisplay+')')), true, true);
     In.Fill_SetOptions(Stream_Audio, 0, (Prefix+"/String").c_str(), "Y NTN");
     In.Fill(Stream_Audio, 0, (Prefix+"/TimeCode").c_str(), TC_Frames.ToString(), true, true);
     if (TC_Frames.IsValid())


### PR DESCRIPTION
Only for default display (advance view still shows 2 decimals and sample offset).
Change is made in order to match (future) Dolby tools.