### PR TITLE
Matroska: show ST-12 timecode of first frame

### DIFF
--- a/Source/MediaInfo/Multiple/File_Gxf_TimeCode.cpp
+++ b/Source/MediaInfo/Multiple/File_Gxf_TimeCode.cpp
@@ -88,6 +88,7 @@ File_Gxf_TimeCode::File_Gxf_TimeCode()
     FieldsPerFrame_Code=(int32u)-1;
     IsAtc=false;
     IsBigEndian=false;
+    IsTimeCodeTrack=false;
 
     //Out
     TimeCode_FirstFrame_ms=(int64u)-1;
@@ -105,6 +106,12 @@ File_Gxf_TimeCode::~File_Gxf_TimeCode()
 //---------------------------------------------------------------------------
 void File_Gxf_TimeCode::Streams_Fill()
 {
+    Stream_Prepare(Stream_Other);
+    Fill(Stream_Other, 0, Other_TimeCode_FirstFrame, TimeCode_FirstFrame);
+    if (IsTimeCodeTrack)
+        return;
+
+
     Stream_Prepare(Stream_Video);
     Fill(Stream_Video, 0, Video_Delay, TimeCode_FirstFrame_ms);
     if (TimeCode_FirstFrame.size()==11)

--- a/Source/MediaInfo/Multiple/File_Gxf_TimeCode.h
+++ b/Source/MediaInfo/Multiple/File_Gxf_TimeCode.h
@@ -40,6 +40,7 @@ public :
     int32u FieldsPerFrame_Code;
     bool   IsAtc; // SMPTE ST 12-2
     bool   IsBigEndian;
+    bool   IsTimeCodeTrack;
 
     //Out
     int64u TimeCode_FirstFrame_ms;

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -1287,6 +1287,17 @@ void File_Mk::Streams_Finish()
             if (Temp->second.StreamKind==Stream_Video && !Codec_Temp.empty())
                 Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Codec), Codec_Temp, true);
 
+            //BlockAdditions
+            for (auto Add=Temp->second.BlockAdditions.begin(); Add!=Temp->second.BlockAdditions.end(); ++Add)
+            {
+                auto StreamKind_Last_Sav=StreamKind_Last;
+                auto StreamPos_Last_Sav=StreamPos_Last;
+                Merge(*Add->second);
+                Fill(StreamKind_Last, StreamPos_Last, Other_ID, to_string(Temp->first)+"-Add-"+to_string(Add->first));
+                Fill(StreamKind_Last, StreamPos_Last, Other_MuxingMode, "BlockAddition");
+                StreamKind_Last=StreamKind_Last_Sav;
+                StreamPos_Last=StreamPos_Last_Sav;
+            }
 
             //Format specific
             #if defined(MEDIAINFO_DVDIF_YES)
@@ -3571,6 +3582,7 @@ void File_Mk::Segment_Tracks_TrackEntry_BlockAdditionMapping_Manage()
             {
             auto Temp=new File_Gxf_TimeCode();
             Temp->IsBigEndian=true;
+            Temp->IsTimeCodeTrack=true;
             Parser=Temp;
             }
             #endif


### PR DESCRIPTION
Parsing (so MediaTrace) is already there, so just showing a timecode track

```
Other
ID                                       : 1-Add-121
Muxing mode                              : BlockAddition
Time code of first frame                 : 00:00:00:00
```

ID need some review about how to manage block addition IDs.
Time code is not yet checked about discontinuities.