### PR TITLE
Duration: timecode output does not use drop frame for 23.976fps, fix

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -3012,7 +3012,7 @@ void File__Analyze::Duration_Duration123(stream_t StreamKind, size_t StreamPos, 
                 if (!DropFrame_IsValid)
                 {
                     int32s  FrameRateI=float32_int32s(FrameRateS.To_float32());
-                    if (FrameRateI%30)
+                    if (!(FrameRateI%30))
                     {
                         float32 FrameRateF=FrameRateS.To_float32();
                         float FrameRateF_Min=((float32)FrameRateI)/((float32)1.002);


### PR DESCRIPTION
Small typo in https://github.com/MediaArea/MediaInfoLib/pull/1905 and the opposite of was what wanted was implemented :(.