### PR TITLE
DAR: do the difference between 2.40 (1920x800) and 2.39 (1920x804)

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -3465,7 +3465,8 @@ void File__Analyze::DisplayAspectRatio_Fill(const Ztring &Value, stream_t Stream
     else if (DAR>=(float)2.15 && DAR<(float)2.22)   DARS=__T("2.2:1");
     else if (DAR>=(float)2.23 && DAR<(float)2.30)   DARS=__T("2.25:1");
     else if (DAR>=(float)2.30 && DAR<(float)2.37)   DARS=__T("2.35:1");
-    else if (DAR>=(float)2.37 && DAR<(float)2.45)   DARS=__T("2.40:1");
+    else if (DAR>=(float)2.37 && DAR<(float)2.395)  DARS=__T("2.39:1");
+    else if (DAR>=(float)2.395 && DAR<(float)2.45)  DARS=__T("2.40:1");
     else                                            DARS.From_Number(DAR);
       DARS.FindAndReplace(__T("."), MediaInfoLib::Config.Language_Get(__T("  Config_Text_FloatSeparator")));
     if (MediaInfoLib::Config.Language_Get(__T("  Language_ISO639"))==__T("fr") &&   DARS.find(__T(":1"))==string::npos)


### PR DESCRIPTION
804 is not a multiple of 8 so 800 is often preferred but source content us a bit cut, we want to do the difference between the full source content at 2.39:1 and some missing lines at 2.40:1.

https://en.wikipedia.org/wiki/Aspect_ratio_(image)#Previous_and_currently_used_aspect_ratios

> 2.4:1 = 12:5
> Rounded notation of 2.39:1, also as 2.40:1. [Blu-ray Disc](https://en.wikipedia.org/wiki/Blu-ray_Disc) film releases may use only         800 instead of 803 or 804 lines of the 1920×1080 resolution, resulting in an even 2.4:1 aspect ratio."
