### PR TITLE
PNG: support of color description chunks (CCIP CLLI MDCV), update

### DIFF
--- a/Source/MediaInfo/File__Analyze.h
+++ b/Source/MediaInfo/File__Analyze.h
@@ -885,9 +885,9 @@ public :
     // Others, specialized
     //***************************************************************************
 
-    #if defined(MEDIAINFO_AV1_YES) || defined(MEDIAINFO_AVC_YES) || defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MPEGTS_YES)
+    #if defined(MEDIAINFO_AV1_YES) || defined(MEDIAINFO_AVC_YES) || defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MPEGTS_YES) || defined(MEDIAINFO_PNG_YES)
     void Get_MasteringDisplayColorVolume(Ztring& MasteringDisplay_ColorPrimaries, Ztring& MasteringDisplay_Luminance, bool FromAV1=false);
-    void Get_LightLevel(Ztring &MaxCLL, Ztring &MaxFALL);
+    void Get_LightLevel(Ztring &MaxCLL, Ztring &MaxFALL, int32u Divisor=1);
     #endif
     #if defined(MEDIAINFO_AV1_YES) || defined(MEDIAINFO_AVC_YES) || defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MATROSKA_YES) || defined(MEDIAINFO_MXF_YES) || defined(MEDIAINFO_MPEGTS_YES)
     struct mastering_metadata_2086

--- a/Source/MediaInfo/File__Analyze_MinimizeSize.h
+++ b/Source/MediaInfo/File__Analyze_MinimizeSize.h
@@ -775,9 +775,9 @@ public :
     // Others, specialized
     //***************************************************************************
 
-    #if defined(MEDIAINFO_AV1_YES) || defined(MEDIAINFO_AVC_YES) || defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MPEGTS_YES)
+    #if defined(MEDIAINFO_AV1_YES) || defined(MEDIAINFO_AVC_YES) || defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MPEGTS_YES) || defined(MEDIAINFO_PNG_YES)
     void Get_MasteringDisplayColorVolume(Ztring& MasteringDisplay_ColorPrimaries, Ztring& MasteringDisplay_Luminance, bool FromAV1=false);
-    void Get_LightLevel(Ztring &MaxCLL, Ztring &MaxFALL);
+    void Get_LightLevel(Ztring &MaxCLL, Ztring &MaxFALL, int32u Divisor=1);
     #endif
     #if defined(MEDIAINFO_AV1_YES) || defined(MEDIAINFO_AVC_YES) || defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MATROSKA_YES) || defined(MEDIAINFO_MXF_YES) || defined(MEDIAINFO_MPEGTS_YES)
     struct mastering_metadata_2086

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -620,17 +620,32 @@ void File__Analyze::dvcC(bool has_dependency_pid, std::map<std::string, Ztring>*
 
 //---------------------------------------------------------------------------
 #if defined(MEDIAINFO_AV1_YES) || defined(MEDIAINFO_AVC_YES) || defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES)
-void File__Analyze::Get_LightLevel(Ztring &MaxCLL, Ztring &MaxFALL)
+void File__Analyze::Get_LightLevel(Ztring &MaxCLL, Ztring &MaxFALL, int32u Divisor)
 {
     //Parsing
-    int16u maximum_content_light_level, maximum_frame_average_light_level;
-    Get_B2(maximum_content_light_level,                         "maximum_content_light_level");
-    Get_B2(maximum_frame_average_light_level,                   "maximum_frame_average_light_level");
+    if (Divisor-1)
+    {
+        int32u maximum_content_light_level, maximum_frame_average_light_level;
+        Get_B4 (maximum_content_light_level,                    "maximum_content_light_level");
+        Get_B4 (maximum_frame_average_light_level,              "maximum_frame_average_light_level");
 
-    if (maximum_content_light_level)
-        MaxCLL=Ztring::ToZtring(maximum_content_light_level)+__T(" cd/m2");
-    if (maximum_frame_average_light_level)
-        MaxFALL=Ztring::ToZtring(maximum_frame_average_light_level)+__T(" cd/m2");
+        auto Decimals=to_string(Divisor).size()-1;
+        if (maximum_content_light_level)
+            MaxCLL=Ztring::ToZtring(((float32)maximum_content_light_level)/Divisor, Decimals)+__T(" cd/m2");
+        if (maximum_frame_average_light_level)
+            MaxFALL=Ztring::ToZtring(((float32)maximum_frame_average_light_level)/Divisor, Decimals)+__T(" cd/m2");
+    }
+    else
+    {
+        int16u maximum_content_light_level, maximum_frame_average_light_level;
+        Get_B2 (maximum_content_light_level,                    "maximum_content_light_level");
+        Get_B2 (maximum_frame_average_light_level,              "maximum_frame_average_light_level");
+
+        if (maximum_content_light_level)
+            MaxCLL=Ztring::ToZtring(maximum_content_light_level)+__T(" cd/m2");
+        if (maximum_frame_average_light_level)
+            MaxFALL=Ztring::ToZtring(maximum_frame_average_light_level)+__T(" cd/m2");
+    }
 }
 #endif
 

--- a/Source/MediaInfo/Image/File_Png.cpp
+++ b/Source/MediaInfo/Image/File_Png.cpp
@@ -346,7 +346,7 @@ void File_Png::cLLi()
 {
     //Parsing
     Ztring MaxCLL, MaxFALL;
-    Get_LightLevel(MaxCLL, MaxFALL);
+    Get_LightLevel(MaxCLL, MaxFALL, 10000);
 
     FILLING_BEGIN();
         Fill(StreamKind_Last, StreamPos_Last, "MaxCLL", MaxCLL);


### PR DESCRIPTION
Update of https://github.com/MediaArea/MediaInfoLib/pull/1924

CLLI in PNG is not like others (0.0001 step)