### PR TITLE
I1940, MOV/MP4: fix slowness with some unrecognized metadata atoms

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -361,6 +361,7 @@ private :
     void moov_udta_meta_uuid();
     void moov_udta_ndrm();
     void moov_udta_nsav();
+    void moov_udta_PANA();
     void moov_udta_rtng();
     void moov_udta_ptv ();
     void moov_udta_Sel0();


### PR DESCRIPTION
General fix + specifically skip `PANA` atom (todo: parse it... As well as the XML atom)

Fix https://github.com/MediaArea/MediaInfoLib/issues/1940