### PR TITLE
Add Atmos channel layouts from CoreAudioTypes.h.

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -467,6 +467,16 @@ static string Mpeg4_chan_ChannelDescription_Layout (int32u ChannelLabel)
         case  43 : return "DialogCentricMix";
         case  44 : return "CenterSurroundDirect";
         case  45 : return "Haptic";
+        case  46 : return "Ltf";
+        case  47 : return "Ctf";
+        case  48 : return "Rtf";
+        case  49 : return "Ltm";
+        case  50 : return "Ctm";
+        case  51 : return "Rtm";
+        case  52 : return "Ltr";
+        case  53 : return "Ctr";
+        case  54 : return "Rtr";
+
         case 200 : return "W";
         case 201 : return "X";
         case 202 : return "Y";


### PR DESCRIPTION
As seen at the following locations:

- https://developer.apple.com/documentation/coreaudiotypes/1572103-audio_channel_labels
- https://github.com/xybp888/iOS-SDKs/blob/master/iPhoneOS13.0.sdk/System/Library/Frameworks/CoreAudioTypes.framework/Headers/CoreAudioBaseTypes.h

Before:

```
Audio
ID                                       : 1
Format                                   : ALAC
Codec ID                                 : alac
Codec ID/Info                            : Apple Lossless Audio Codec
Duration                                 : 28 s 96 ms
Bit rate                                 : 349 kb/s
Channel(s)                               : 12 channels
Channel layout                           : L R C LFE Lb Rb Ls Rs 46 48 52 54
Sampling rate                            : 48.0 kHz
Bit depth                                : 16 bits
Stream size                              : 1.17 MiB (98%)

```

After:

```
Audio
ID                                       : 1
Format                                   : ALAC
Codec ID                                 : alac
Codec ID/Info                            : Apple Lossless Audio Codec
Duration                                 : 28 s 96 ms
Bit rate                                 : 349 kb/s
Channel(s)                               : 12 channels
Channel layout                           : L R C LFE Lb Rb Ls Rs Ltf Rtf Ltr Rtr
Sampling rate                            : 48.0 kHz
Bit depth                                : 16 bits
Stream size                              : 1.17 MiB (98%)

```