### PR TITLE
By buffer API: accept blu-ray files

### DIFF
--- a/Source/MediaInfo/File__MultipleParsing.cpp
+++ b/Source/MediaInfo/File__MultipleParsing.cpp
@@ -432,10 +432,9 @@ File__MultipleParsing::File__MultipleParsing()
         {File_MpegTs* Temp=new File_MpegTs(); Temp->BDAV_Size=4; Parser.push_back(Temp);}
         {File_MpegTs* Temp=new File_MpegTs(); Temp->BDAV_Size=4; Temp->NoPatPmt=true; Parser.push_back(Temp);}
     #endif
-//    Only with directories, no By Buffer interface
-//    #if defined(MEDIAINFO_BDMV_YES)
-//        Parser.push_back(new File_Bdmv());
-//    #endif
+    #if defined(MEDIAINFO_BDMV_YES)
+        Parser.push_back(new File_Bdmv());
+    #endif
     #if defined(MEDIAINFO_CDXA_YES)
         Parser.push_back(new File_Cdxa());
     #endif


### PR DESCRIPTION
We still don't support referencing other files inside an ISO, but at least there are some info from a single file

fix https://github.com/MediaArea/MediaInfoLib/issues/1964#issuecomment-1962325965