### PR TITLE
WAV: more precise sampling count

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -883,7 +883,7 @@ void File__Analyze::Streams_Finish_StreamOnly(stream_t StreamKind, size_t Pos)
     }
 
     //Duration from Bitrate and StreamSize
-    if (StreamKind!=Stream_Other && Retrieve(StreamKind, Pos, Fill_Parameter(StreamKind, Generic_Duration)).empty() && !Retrieve(StreamKind, Pos, Fill_Parameter(StreamKind, Generic_StreamSize)).empty() && !Retrieve(StreamKind, Pos, "BitRate").empty() && Count_Get(Stream_Video)+Count_Get(Stream_Audio)>1) //If only one stream, duration will be copied later, useful for exact bitrate calculation //TODO: enable it aslo for 1 stream, after handling of incoherencies found during tests
+    if (StreamKind!=Stream_Other && Retrieve(StreamKind, Pos, Fill_Parameter(StreamKind, Generic_Duration)).empty() && !Retrieve(StreamKind, Pos, Fill_Parameter(StreamKind, Generic_StreamSize)).empty() && !Retrieve(StreamKind, Pos, "BitRate").empty())
     {
         int64u BitRate=Retrieve(StreamKind, Pos, "BitRate").To_int64u();
         int64u StreamSize=Retrieve(StreamKind, Pos, Fill_Parameter(StreamKind, Generic_StreamSize)).To_int64u();

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -4095,7 +4095,6 @@ void File_Riff::WAVE_fact()
     Get_L4 (SamplesCount,                                       "SamplesCount");
 
     FILLING_BEGIN();
-        if (!Retrieve(Stream_Audio, StreamPos_Last, Audio_SamplingCount).empty()) // Not the priority
         {
         int64u SamplesCount64=SamplesCount==(int32u)-1?WAVE_fact_samplesCount:SamplesCount;
         float64 SamplingRate=Retrieve(Stream_Audio, StreamPos_Last, Audio_SamplingRate).To_float64();
@@ -4113,7 +4112,12 @@ void File_Riff::WAVE_fact()
                 {
                     int64u Duration_FromBitRate = File_Size * 8 * 1000 / BitRate;
                     if (Duration_FromBitRate > Duration*1.02 || Duration_FromBitRate < Duration*0.98)
-                        IsOK = false;
+                    {
+                        if (Retrieve(Stream_Audio, StreamPos_Last, Audio_Format) == __T("PCM"))
+                            IsOK = false;
+                        else
+                            Clear(Stream_Audio, StreamPos_Last, Audio_BitRate); // Bit rate is often not precise or wrong for non PCM
+                    }
                 }
             }
 


### PR DESCRIPTION
by using sampling count metadata or block align info when available, update from a previous PR a long time ago, in order to catch more corner case e.g. buggy average bit rate tip in the WAV header.