### PR TITLE
CEA-608/708: options for ignoring command only streams

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -243,6 +243,7 @@ MediaInfo_Config_MediaInfo::MediaInfo_Config_MediaInfo()
     #endif //defined(MEDIAINFO_LIBMMS_YES)
     File_Eia608_DisplayEmptyStream=false;
     File_Eia708_DisplayEmptyStream=false;
+    File_CommandOnlyMeansEmpty=false;
     State=0;
     #if defined(MEDIAINFO_AC3_YES)
     File_Ac3_IgnoreCrc=false;
@@ -1253,6 +1254,15 @@ Ztring MediaInfo_Config_MediaInfo::Option (const String &Option, const String &V
     else if (Option_Lower==__T("file_eia608_displayemptystream_get"))
     {
         return File_Eia608_DisplayEmptyStream_Get()?"1":"0";
+    }
+    else if (Option_Lower==__T("file_commandonlymeansempty"))
+    {
+        File_CommandOnlyMeansEmpty_Set(!(Value==__T("0") || Value.empty()));
+        return __T("");
+    }
+    else if (Option_Lower==__T("file_commandonlymeansempty_get"))
+    {
+        return File_CommandOnlyMeansEmpty_Get()?"1":"0";
     }
     else if (Option_Lower==__T("file_ac3_ignorecrc"))
     {
@@ -3571,6 +3581,19 @@ bool MediaInfo_Config_MediaInfo::File_Eia708_DisplayEmptyStream_Get ()
 {
     CriticalSectionLocker CSL(CS);
     return File_Eia708_DisplayEmptyStream;
+}
+
+//---------------------------------------------------------------------------
+void MediaInfo_Config_MediaInfo::File_CommandOnlyMeansEmpty_Set (bool NewValue)
+{
+    CriticalSectionLocker CSL(CS);
+    File_CommandOnlyMeansEmpty=NewValue;
+}
+
+bool MediaInfo_Config_MediaInfo::File_CommandOnlyMeansEmpty_Get ()
+{
+    CriticalSectionLocker CSL(CS);
+    return File_CommandOnlyMeansEmpty;
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
@@ -375,6 +375,8 @@ public :
     bool          File_Eia608_DisplayEmptyStream_Get ();
     void          File_Eia708_DisplayEmptyStream_Set (bool NewValue);
     bool          File_Eia708_DisplayEmptyStream_Get ();
+    void          File_CommandOnlyMeansEmpty_Set(bool NewValue);
+    bool          File_CommandOnlyMeansEmpty_Get();
     #if defined(MEDIAINFO_AC3_YES)
     void          File_Ac3_IgnoreCrc_Set (bool NewValue);
     bool          File_Ac3_IgnoreCrc_Get ();
@@ -609,6 +611,7 @@ private :
     #endif //defined(MEDIAINFO_LIBMMS_YES)
     bool                    File_Eia608_DisplayEmptyStream;
     bool                    File_Eia708_DisplayEmptyStream;
+    bool                    File_CommandOnlyMeansEmpty;
     #if defined(MEDIAINFO_AC3_YES)
     bool                    File_Ac3_IgnoreCrc;
     #endif //defined(MEDIAINFO_AC3_YES)

--- a/Source/MediaInfo/Text/File_Eia608.cpp
+++ b/Source/MediaInfo/Text/File_Eia608.cpp
@@ -114,7 +114,7 @@ void File_Eia608::Streams_Fill()
     }
 
     for (size_t Pos=0; Pos<Streams.size(); Pos++)
-        if (Streams[Pos] || (Pos<2 && Config->File_Eia608_DisplayEmptyStream_Get()))
+        if ((Streams[Pos] && (DataDetected[1+Pos] || !Config->File_CommandOnlyMeansEmpty_Get())) || (Pos<2 && Config->File_Eia608_DisplayEmptyStream_Get()))
         {
             Stream_Prepare(Stream_Text);
             Fill(Stream_Text, StreamPos_Last, Text_Format, "EIA-608");

--- a/Source/MediaInfo/Text/File_Eia708.cpp
+++ b/Source/MediaInfo/Text/File_Eia708.cpp
@@ -90,7 +90,7 @@ void File_Eia708::Streams_Fill()
     }
 
     for (size_t Pos=0; Pos<Streams.size(); Pos++)
-        if (Streams[Pos] || (Pos && Pos<2 && Config->File_Eia708_DisplayEmptyStream_Get()))
+        if ((Streams[Pos] && ((DataDetected&((int64u)1)<<Pos) || !Config->File_CommandOnlyMeansEmpty_Get())) || (Pos && Pos<2 && Config->File_Eia708_DisplayEmptyStream_Get()))
         {
             Stream_Prepare(Stream_Text);
             Fill(Stream_Text, StreamPos_Last, Text_ID, Pos);


### PR DESCRIPTION
Close https://github.com/MediaArea/MediaInfoLib/issues/1882 (CLI only, GUI will command with other options).

```
mediainfo UXKV-A_01_D01.scc.txt "--Inform=Text;%ID%,"
CC1,T1,
mediainfo UXKV-A_01_D01.scc.txt "--Inform=Text;%ID%,"  --File_CommandOnlyMeansEmpty=1
CC1,
```
