### PR TITLE
Avoid infinite loop with distant files

### DIFF
--- a/Source/MediaInfo/Audio/File_Ac3.cpp
+++ b/Source/MediaInfo/Audio/File_Ac3.cpp
@@ -1026,7 +1026,7 @@ File_Ac3::File_Ac3()
         Trace_Layers_Update(8); //Stream
     #endif //MEDIAINFO_TRACE
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=32*1024;
+    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     Buffer_TotalBytes_Fill_Max=1024*1024;
     PTS_DTS_Needed=true;
     StreamSource=IsStream;

--- a/Source/MediaInfo/Audio/File_Ac4.cpp
+++ b/Source/MediaInfo/Audio/File_Ac4.cpp
@@ -1116,7 +1116,7 @@ File_Ac4::File_Ac4()
         Trace_Layers_Update(8); //Stream
     #endif //MEDIAINFO_TRACE
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=32*1024;
+    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     Buffer_TotalBytes_Fill_Max=1024*1024;
     PTS_DTS_Needed=true;
     StreamSource=IsStream;

--- a/Source/MediaInfo/Audio/File_DolbyE.cpp
+++ b/Source/MediaInfo/Audio/File_DolbyE.cpp
@@ -975,7 +975,7 @@ File_DolbyE::File_DolbyE()
 
     //Configuration
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=32*1024;
+    Buffer_TotalBytes_FirstSynched_Max=64*1024;
 
     //In
     GuardBand_Before=0;

--- a/Source/MediaInfo/Audio/File_Dts.cpp
+++ b/Source/MediaInfo/Audio/File_Dts.cpp
@@ -542,7 +542,7 @@ File_Dts::File_Dts()
         Trace_Layers_Update(8); //Stream
     #endif //MEDIAINFO_TRACE
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=32*1024;
+    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     PTS_DTS_Needed=true;
     StreamSource=IsStream;
 

--- a/Source/MediaInfo/Audio/File_DtsUhd.cpp
+++ b/Source/MediaInfo/Audio/File_DtsUhd.cpp
@@ -1368,7 +1368,7 @@ File_DtsUhd::File_DtsUhd()
     IsType1CertifiedContent=false;
     LongTermLoudnessIndex=(int8u)-1;
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=32*1024;
+    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     PTS_DTS_Needed=true;
     StreamSource=IsStream;
 }

--- a/Source/MediaInfo/Audio/File_Wvpk.cpp
+++ b/Source/MediaInfo/Audio/File_Wvpk.cpp
@@ -110,7 +110,7 @@ File_Wvpk::File_Wvpk()
 
     //Configuration
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=32*1024;
+    Buffer_TotalBytes_FirstSynched_Max=64*1024;
 
     //In
     Frame_Count_Valid=2;

--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -472,7 +472,7 @@ File__Analyze::File__Analyze ()
     if (MediaInfoLib::Config.FormatDetection_MaximumOffset_Get())
         Buffer_TotalBytes_FirstSynched_Max=MediaInfoLib::Config.FormatDetection_MaximumOffset_Get();
     else
-        Buffer_TotalBytes_FirstSynched_Max=1024*1024;
+        Buffer_TotalBytes_FirstSynched_Max=16*1024*1024;
     if (Buffer_TotalBytes_FirstSynched_Max<(int64u)-1-64*1024*1024)
         Buffer_TotalBytes_Fill_Max=Buffer_TotalBytes_FirstSynched_Max+64*1024*1024;
     else
@@ -2244,7 +2244,7 @@ bool File__Analyze::Synchro_Manage()
         {
             if (Status[IsFinished])
                 Finish(); //Finish
-            if (!IsSub && File_Offset_FirstSynched==(int64u)-1 && Buffer_TotalBytes+Buffer_Offset>=Buffer_TotalBytes_FirstSynched_Max)
+            if (!IsSub && !Status[IsAccepted] && Buffer_TotalBytes+Buffer_Offset>=Buffer_TotalBytes_FirstSynched_Max)
                 Reject();
             return false; //Wait for more data
         }

--- a/Source/MediaInfo/File__MultipleParsing.h
+++ b/Source/MediaInfo/File__MultipleParsing.h
@@ -37,9 +37,6 @@ public :
     ~File__MultipleParsing();
 
 private :
-    //Streams management
-    void Streams_Finish();
-
     //Buffer - Global
     void Read_Buffer_Init();
     void Read_Buffer_Unsynched();

--- a/Source/MediaInfo/Image/File_Tga.h
+++ b/Source/MediaInfo/Image/File_Tga.h
@@ -35,6 +35,7 @@ public :
 private :
     //Streams management
     void Streams_Fill();
+    void Streams_Finish();
 
     //Buffer - File header
     bool FileHeader_Begin();

--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -233,7 +233,6 @@ File_DvDif::File_DvDif()
         Demux_Level=3; //Container and Stream
     #endif //MEDIAINFO_DEMUX
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
 
     //In
     Frame_Count_Valid=IsSub?1:2;

--- a/Source/MediaInfo/Multiple/File_Gxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Gxf.cpp
@@ -217,7 +217,6 @@ File_Gxf::File_Gxf()
         Demux_Level=2; //Container
     #endif //MEDIAINFO_DEMUX
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     Buffer_TotalBytes_Fill_Max=(int64u)-1; //Disabling this feature for this format, this is done in the parser
     #if MEDIAINFO_DEMUX
         Demux_EventWasSent_Accept_Specific=true;

--- a/Source/MediaInfo/Multiple/File_MpegPs.cpp
+++ b/Source/MediaInfo/Multiple/File_MpegPs.cpp
@@ -200,7 +200,6 @@ File_MpegPs::File_MpegPs()
         Trace_Layers_Update(0); //Container1
     #endif //MEDIAINFO_TRACE
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     Buffer_TotalBytes_Fill_Max=(int64u)-1; //Disabling this feature for this format, this is done in the parser
     Trusted_Multiplier=2;
 

--- a/Source/MediaInfo/Multiple/File_MpegTs.cpp
+++ b/Source/MediaInfo/Multiple/File_MpegTs.cpp
@@ -259,7 +259,6 @@ File_MpegTs::File_MpegTs()
         Demux_Level=4; //Intermediate
     #endif //MEDIAINFO_DEMUX
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     Buffer_TotalBytes_Fill_Max=(int64u)-1; //Disabling this feature for this format, this is done in the parser
     Trusted_Multiplier=2;
     #if MEDIAINFO_DEMUX

--- a/Source/MediaInfo/Multiple/File_Ogg.cpp
+++ b/Source/MediaInfo/Multiple/File_Ogg.cpp
@@ -38,7 +38,6 @@ File_Ogg::File_Ogg()
 {
     //Configuration
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
 
     //In
     SizedBlocks=false;

--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -657,7 +657,6 @@ File_Avc::File_Avc()
         Trace_Layers_Update(8); //Stream
     #endif //MEDIAINFO_TRACE
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     PTS_DTS_Needed=true;
     StreamSource=IsStream;
     Frame_Count_NotParsedIncluded=0;

--- a/Source/MediaInfo/Video/File_AvsV.cpp
+++ b/Source/MediaInfo/Video/File_AvsV.cpp
@@ -170,7 +170,6 @@ File_AvsV::File_AvsV()
 {
     //Config
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
 
     //In
     Frame_Count_Valid=30;

--- a/Source/MediaInfo/Video/File_Dirac.cpp
+++ b/Source/MediaInfo/Video/File_Dirac.cpp
@@ -407,7 +407,6 @@ File_Dirac::File_Dirac()
 {
     //Configuration
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
 
     //In
     Frame_Count_Valid=1;

--- a/Source/MediaInfo/Video/File_Hevc.cpp
+++ b/Source/MediaInfo/Video/File_Hevc.cpp
@@ -189,7 +189,6 @@ File_Hevc::File_Hevc()
         Trace_Layers_Update(8); //Stream
     #endif //MEDIAINFO_TRACE
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     PTS_DTS_Needed=true;
     StreamSource=IsStream;
     Frame_Count_NotParsedIncluded=0;

--- a/Source/MediaInfo/Video/File_Mpeg4v.cpp
+++ b/Source/MediaInfo/Video/File_Mpeg4v.cpp
@@ -244,7 +244,6 @@ File_Mpeg4v::File_Mpeg4v()
     #endif //MEDIAINFO_TRACE
     Trusted_Multiplier=2;
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     PTS_DTS_Needed=true;
     StreamSource=IsStream;
 

--- a/Source/MediaInfo/Video/File_Mpegv.cpp
+++ b/Source/MediaInfo/Video/File_Mpegv.cpp
@@ -1085,7 +1085,6 @@ File_Mpegv::File_Mpegv()
     #endif //MEDIAINFO_TRACE
     Trusted_Multiplier=2;
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     PTS_DTS_Needed=true;
     StreamSource=IsStream;
     Frame_Count_NotParsedIncluded=0;

--- a/Source/MediaInfo/Video/File_Vc1.cpp
+++ b/Source/MediaInfo/Video/File_Vc1.cpp
@@ -224,7 +224,6 @@ File_Vc1::File_Vc1()
         Trace_Layers_Update(8); //Stream
     #endif //MEDIAINFO_TRACE
     MustSynchronize=true;
-    Buffer_TotalBytes_FirstSynched_Max=64*1024;
     PTS_DTS_Needed=true;
     StreamSource=IsStream;
     Frame_Count_NotParsedIncluded=0;


### PR DESCRIPTION
Also avoid some false positive detection as H.263 and tweak amount of bytes read with distant files.

Fix https://github.com/MediaArea/MediaInfoLib/issues/2015