### PR TITLE
MXF: Support of SMPTE ST 422-2019 I2

### DIFF
--- a/Source/MediaInfo/Image/File_Jpeg.h
+++ b/Source/MediaInfo/Image/File_Jpeg.h
@@ -32,6 +32,7 @@ public :
     //In
     stream_t StreamKind;
     bool     Interlaced;
+    int8u    MxfContentKind;
     #if MEDIAINFO_DEMUX
     float64  FrameRate;
     #endif //MEDIAINFO_DEMUX

--- a/Source/MediaInfo/Multiple/File_Mxf.h
+++ b/Source/MediaInfo/Multiple/File_Mxf.h
@@ -885,6 +885,7 @@ protected :
         int16u BlockAlign;
         int32u QuantizationBits;
         int64u Duration;
+        int8u  Jp2kContentKind;
         int8u  ActiveFormat;
         int8u  FieldTopness;
         int8u  FieldDominance;
@@ -962,6 +963,7 @@ protected :
             QuantizationBits=(int32u)-1;
             Duration=(int64u)-1;
             ActiveFormat=(int8u)-1;
+            Jp2kContentKind=(int8u)-1;
             FieldTopness=(int8u)-1; //Field x is upper field
             FieldDominance=1; //Default is field 1 temporaly first
             Type=Type_Unknown;


### PR DESCRIPTION
I2 mode is interlaced but with FrameLayout FULL_FRAME, despite what is for interlaced content for all other formats.
All the I2 files I received up to https://github.com/MediaArea/MediaInfoLib/issues/2037 violates this part of the spec but well, we need to at least support correctly when theoretically a file is conforming to specs.
In order to not break the support of I2 files in the wild, both FrameLayout FULL_FRAME and FrameLayout SEPARATE_FIELDS are supported and there is a probe in the JP2k frame in case of former UL with essence container label Content Kind of 0.

Mainly fix https://github.com/MediaArea/MediaInfoLib/issues/2037 but also fix some incoherent issues about frame rate with other files.