### PR TITLE
ID3v2: fix crash with some malformed files

### DIFF
--- a/Source/MediaInfo/Tag/File_Id3v2.h
+++ b/Source/MediaInfo/Tag/File_Id3v2.h
@@ -226,6 +226,7 @@ private :
     bool   Unsynchronisation_Global;
     bool   Unsynchronisation_Frame;
     bool   DataLengthIndicator;
+    std::vector<size_t> Unsynch_List;
 
     //Helpers
     void Fill_Name();


### PR DESCRIPTION
Also correctly handle ID3v2.4 unsynchronization.

fix https://github.com/MediaArea/MediaInfoLib/issues/2054.