### PR TITLE
WavPack: various fixes for multichannel & DSD files

### DIFF
--- a/Source/MediaInfo/Audio/File_Wvpk.h
+++ b/Source/MediaInfo/Audio/File_Wvpk.h
@@ -78,7 +78,7 @@ private :
     bool   dsf;
     int8u  SamplingRate_Index;
     int8u  SamplingRate_Shift;
-    int8u  num_channels;
+    int16u num_channels;
     int32u SamplingRate;
     int32u channel_mask;
     int32u Size;


### PR DESCRIPTION
- fix parsing of multichannel files with greater than 8 streams
- fix compression ratio calculation for all multichannel files
- fix DSD file parsing