### PR TITLE
Conformance checker: an element is indicated bigger than its upper element, fix

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.cpp
@@ -2998,10 +2998,13 @@ string File_Mpeg4::CreateElementName()
     string Result;
     for (size_t i = 1; i < Element_Level; i++) {
         Result += Ztring().From_CC4(Element[i].Code).Trim().To_UTF8();
-        if (Result.back() >= '0' && Result.back() <= '9') {
+        if (Result.empty()) {
+            Result = "0x20202020"; // Full of spaces
+        }
+        else if (Result.back() >= '0' && Result.back() <= '9') {
             Result += '_';
         }
-        Result += __T(' ');
+        Result += ' ';
     }
     if (!Result.empty())
         Result.pop_back();


### PR DESCRIPTION
Fix potential crash after https://github.com/MediaArea/MediaInfoLib/pull/2051.