### PR TITLE
HTML Improvements

### DIFF
--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -436,7 +436,7 @@ Ztring MediaInfo_Internal::Inform()
     #endif //defined(MEDIAINFO_CSV_YES)
 
     if (HTML)
-        Retour+=__T("<html>\n\n<head>\n<META http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" /></head>\n<body>\n");
+        Retour+=__T("<!DOCTYPE html>\n<html>\n<head>\n    <meta charset=\"utf-8\">\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n    <title>MediaInfo</title>\n</head>\n<body>\n");
     #if defined(MEDIAINFO_XML_YES) || defined(MEDIAINFO_JSON_YES)
     if (XML_0_7_78_MA || XML_0_7_78_MI || JSON)
     {
@@ -469,7 +469,7 @@ Ztring MediaInfo_Internal::Inform()
         for (size_t StreamPos=0; StreamPos<(size_t)Count_Get((stream_t)StreamKind); StreamPos++)
         {
             //Pour chaque stream
-            if (HTML) Retour+=__T("<table width=\"100%\" border=\"0\" cellpadding=\"1\" cellspacing=\"2\" style=\"border:1px solid Navy\">\n<tr>\n    <td width=\"150\"><h2>");
+            if (HTML) Retour+=__T("<table width=\"100%\" style=\"width: 100%; table-layout: fixed; padding: 1px; border-spacing: 2px; border:1px solid Navy\">\n  <tr>\n    <td width=\"150\" style=\"width: 20vw; min-width: 150px; max-width: 250px\"><h2 style=\"margin-top: 0px\">");
             #if defined(MEDIAINFO_XML_YES) || defined(MEDIAINFO_JSON_YES)
             Node* Node_Current=NULL;
             if (XML || XML_0_7_78_MA || XML_0_7_78_MI || JSON) Node_Current=Node_MI?Node_MI->Add_Child("track", true):Node_Main->Add_Child("track", true);
@@ -489,7 +489,7 @@ Ztring MediaInfo_Internal::Inform()
                 }
                 Retour+=A;
             }
-            if (HTML) Retour+=__T("</h2></td>\n  </tr>");
+            if (HTML) Retour+=__T("</h2></td>\n    <td colspan=\"3\"></td>\n  </tr>");
             #if defined(MEDIAINFO_XML_YES) || defined(MEDIAINFO_JSON_YES)
             if (XML || XML_0_7_78_MA || XML_0_7_78_MI || JSON)
             {
@@ -511,12 +511,12 @@ Ztring MediaInfo_Internal::Inform()
                 Retour+=Inform((stream_t)StreamKind, StreamPos, false);
             }
 
-            if (HTML) Retour+=__T("</table>\n<br />");
+            if (HTML) Retour+=__T("</table>\n<br>");
             if (!XML && !XML_0_7_78_MA && !XML_0_7_78_MI && !JSON) Retour+=MediaInfoLib::Config.LineSeparator_Get();
         }
     }
 
-    if (HTML) Retour+=__T("\n</body>\n</html>\n");
+    if (HTML) Retour+=__T("</body>\n</html>\n");
 
     if (!CSV && !HTML && !XML && !XML_0_7_78_MA && !XML_0_7_78_MI && !JSON)
     {


### PR DESCRIPTION
Improve and modernize the HTML that is generated. Tested on Firefox (including Responsive Design Mode), Edge, VCL GUI (with IE and WebView2 engine) and Qt GUI. The display is considered consistent across all with the exception that the Qt GUI displays borders differently.

`width="100%"` and `width="150"` should be removed but is kept there to maintain compatibility with Qt GUI and possibly older browser engines.

**HTML Validator now:**
![Screenshot 2024-06-20 175513](https://github.com/MediaArea/MediaInfoLib/assets/77721854/b38e34fb-30be-4d9e-9009-70672d2cbe83)

```
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":9.1-9.119: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":10.7-11.76: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tdÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":11.122-12.20: error: Table columns in range 3ÔÇª4 established by element ÔÇ£tdÔÇØ have no cells beginning in them.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":56.1-56.119: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":57.7-58.76: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tdÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":58.120-59.20: error: Table columns in range 3ÔÇª4 established by element ÔÇ£tdÔÇØ have no cells beginning in them.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":179.1-179.119: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":180.7-181.76: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tdÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":181.123-182.20: error: Table columns in range 3ÔÇª4 established by element ÔÇ£tdÔÇØ have no cells beginning in them.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":318.1-318.119: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":319.7-320.76: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tdÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":320.123-321.20: error: Table columns in range 3ÔÇª4 established by element ÔÇ£tdÔÇØ have no cells beginning in them.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo%20(2).html":1.16-2.6: info warning: Consider adding a ÔÇ£langÔÇØ attribute to the ÔÇ£htmlÔÇØ start tag to declare the language of this document.
```

**HTML Validator previous:**
![Screenshot 2024-06-20 175424](https://github.com/MediaArea/MediaInfoLib/assets/77721854/b29916ba-e544-4660-b718-7d23260d9ce0)
<details>
<summary>Click to show (very long)</summary>

```
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":1.1-1.6: error: Start tag seen without seeing a doctype first. Expected ÔÇ£<!DOCTYPE html>ÔÇØ.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":4.1-4.69: info: Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":4.70-4.76: error: Element ÔÇ£headÔÇØ is missing a required instance of child element ÔÇ£titleÔÇØ.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":6.1-6.93: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":6.1-6.93: error: The ÔÇ£cellpaddingÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":6.1-6.93: error: The ÔÇ£cellspacingÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":6.1-6.93: error: The ÔÇ£borderÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":7.5-8.20: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tdÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":12.33-13.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":16.100-17.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":20.30-21.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":24.39-25.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":28.33-29.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":32.35-33.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":36.34-37.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":40.35-41.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":44.35-45.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":48.36-49.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":11.25-12.20: error: Table columns in range 3ÔÇª4 established by element ÔÇ£tdÔÇØ have no cells beginning in them.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":51.1-51.6: info: Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":52.1-52.93: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":52.1-52.93: error: The ÔÇ£cellpaddingÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":52.1-52.93: error: The ÔÇ£cellspacingÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":52.1-52.93: error: The ÔÇ£borderÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":53.5-54.20: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tdÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":58.39-59.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":62.33-63.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":66.29-67.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":70.46-71.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":74.35-75.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":78.46-79.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":82.29-83.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":86.34-87.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":90.44-91.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":94.28-95.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":98.35-99.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":102.34-103.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":106.35-107.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":110.35-111.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":114.38-115.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":118.38-119.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":122.30-123.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":126.36-127.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":130.30-131.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":134.29-135.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":138.31-139.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":142.32-143.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":146.37-147.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":150.31-151.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":154.39-155.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":158.33-159.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":162.32-163.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":166.32-167.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":170.32-171.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":57.25-58.20: error: Table columns in range 3ÔÇª4 established by element ÔÇ£tdÔÇØ have no cells beginning in them.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":173.1-173.6: info: Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":174.1-174.93: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":174.1-174.93: error: The ÔÇ£cellpaddingÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":174.1-174.93: error: The ÔÇ£cellspacingÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":174.1-174.93: error: The ÔÇ£borderÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":175.5-176.20: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tdÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":180.39-181.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":184.33-185.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":188.44-189.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":192.84-193.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":196.55-197.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":200.42-201.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":204.29-205.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":208.35-209.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":212.34-213.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":216.34-217.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":220.36-221.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":224.36-225.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":228.47-229.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":232.34-233.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":236.47-237.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":240.34-241.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":244.39-245.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":248.39-249.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":252.28-253.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":256.35-257.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":260.29-261.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":264.32-265.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":268.34-269.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":272.33-273.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":276.31-277.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":280.31-281.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":284.33-285.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":288.33-289.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":292.33-293.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":296.33-297.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":300.32-301.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":304.32-305.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":308.32-309.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":179.25-180.20: error: Table columns in range 3ÔÇª4 established by element ÔÇ£tdÔÇØ have no cells beginning in them.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":311.1-311.6: info: Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":312.1-312.93: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":312.1-312.93: error: The ÔÇ£cellpaddingÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":312.1-312.93: error: The ÔÇ£cellspacingÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":312.1-312.93: error: The ÔÇ£borderÔÇØ attribute on the ÔÇ£tableÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":313.5-314.20: error: The ÔÇ£widthÔÇØ attribute on the ÔÇ£tdÔÇØ element is obsolete. Use CSS instead.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":318.39-319.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":322.33-323.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":326.36-327.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":330.64-331.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":334.61-335.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":338.38-339.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":342.42-343.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":346.29-347.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":350.35-351.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":354.34-355.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":358.36-359.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":362.36-363.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":366.47-367.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":370.34-371.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":374.47-375.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":378.31-379.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":382.39-383.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":386.39-387.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":390.28-391.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":394.28-395.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":398.35-399.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":402.29-403.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":406.32-407.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":410.33-411.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":414.33-415.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":418.31-419.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":422.31-423.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":426.33-427.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":430.33-431.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":434.33-435.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":438.33-439.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":442.32-443.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":446.32-447.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":450.32-451.7: info warning: A table row was 4 columns wide and exceeded the column count established by the first row (1).
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":317.25-318.20: error: Table columns in range 3ÔÇª4 established by element ÔÇ£tdÔÇØ have no cells beginning in them.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":453.1-453.6: info: Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.
"file:/D:/%5BTHD%20DDP%20Atmos%5D%20Dolby%20Atmos%20Amaze.m2ts.MediaInfo.html":1.1-1.6: info warning: Consider adding a ÔÇ£langÔÇØ attribute to the ÔÇ£htmlÔÇØ start tag to declare the language of this document.
```

</details>