### PR TITLE
CEA-608/708: option for forcing all CC1-CC4/T1 if stream is detected

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -134,6 +134,18 @@ const size_t Buffer_NormalSize=/*188*7;//*/64*1024;
 // Info
 //***************************************************************************
 
+const char* DisplayCaptions_Strings[] =
+{
+    "Command",
+    "Content",
+    "Stream",
+};
+static_assert(sizeof(DisplayCaptions_Strings) / sizeof(*DisplayCaptions_Strings) == DisplayCaptions_Max, "");
+
+//***************************************************************************
+// Class
+//***************************************************************************
+
 MediaInfo_Config_MediaInfo::MediaInfo_Config_MediaInfo()
 {
     MediaInfoLib::Config.Init(); //Initialize Configuration
@@ -242,9 +254,7 @@ MediaInfo_Config_MediaInfo::MediaInfo_Config_MediaInfo()
     #if defined(MEDIAINFO_LIBMMS_YES)
         File_Mmsh_Describe_Only=false;
     #endif //defined(MEDIAINFO_LIBMMS_YES)
-    File_Eia608_DisplayEmptyStream=false;
-    File_Eia708_DisplayEmptyStream=false;
-    File_CommandOnlyMeansEmpty=false;
+    DisplayCaptions=DisplayCaptions_Command;
     File_ProbeCaption_Set({});
     State=0;
     #if defined(MEDIAINFO_AC3_YES)
@@ -1239,32 +1249,22 @@ Ztring MediaInfo_Config_MediaInfo::Option (const String &Option, const String &V
             return __T("Libmms support is disabled due to compilation options");
         #endif //defined(MEDIAINFO_LIBMMS_YES)
     }
+    else if (Option_Lower==__T("file_displaycaptions"))
+    {
+        return File_DisplayCaptions_Set(Value);
+    }
     else if (Option_Lower==__T("file_eia708_displayemptystream"))
     {
-        File_Eia708_DisplayEmptyStream_Set(!(Value==__T("0") || Value.empty()));
-        return __T("");
-    }
-    else if (Option_Lower==__T("file_eia708_displayemptystream_get"))
-    {
-        return File_Eia708_DisplayEmptyStream_Get()?"1":"0";
+        return File_DisplayCaptions_Set(Ztring().From_UTF8(DisplayCaptions_Strings[Value==__T("0")?DisplayCaptions_Command:DisplayCaptions_Stream]));
     }
     else if (Option_Lower==__T("file_eia608_displayemptystream"))
     {
-        File_Eia608_DisplayEmptyStream_Set(!(Value==__T("0") || Value.empty()));
-        return __T("");
-    }
-    else if (Option_Lower==__T("file_eia608_displayemptystream_get"))
-    {
-        return File_Eia608_DisplayEmptyStream_Get()?"1":"0";
+        return File_DisplayCaptions_Set(Ztring().From_UTF8(DisplayCaptions_Strings[Value==__T("0")?DisplayCaptions_Command:DisplayCaptions_Stream]));
     }
     else if (Option_Lower==__T("file_commandonlymeansempty"))
     {
-        File_CommandOnlyMeansEmpty_Set(!(Value==__T("0") || Value.empty()));
+        return File_DisplayCaptions_Set(Ztring().From_UTF8(DisplayCaptions_Strings[Value==__T("0")?DisplayCaptions_Command:DisplayCaptions_Content]));
         return __T("");
-    }
-    else if (Option_Lower==__T("file_commandonlymeansempty_get"))
-    {
-        return File_CommandOnlyMeansEmpty_Get()?"1":"0";
     }
     else if (Option_Lower==__T("file_probecaption"))
     {
@@ -3577,42 +3577,28 @@ bool MediaInfo_Config_MediaInfo::File_Mmsh_Describe_Only_Get ()
 #endif //defined(MEDIAINFO_LIBMMS_YES)
 
 //---------------------------------------------------------------------------
-void MediaInfo_Config_MediaInfo::File_Eia608_DisplayEmptyStream_Set (bool NewValue)
+Ztring MediaInfo_Config_MediaInfo::File_DisplayCaptions_Set (const Ztring& NewValue)
 {
+    auto NewValueS = NewValue.To_UTF8();
+    size_t i = 0;
+    for (; i < DisplayCaptions_Max; i++) {
+        if (NewValueS == DisplayCaptions_Strings[i]) {
+            break;
+        }
+    }
+    if (i >= DisplayCaptions_Max)
+        return __T("Unknown value");
+
     CriticalSectionLocker CSL(CS);
-    File_Eia608_DisplayEmptyStream=NewValue;
+    DisplayCaptions = (display_captions)i;
+
+    return {};
 }
 
-bool MediaInfo_Config_MediaInfo::File_Eia608_DisplayEmptyStream_Get ()
+display_captions MediaInfo_Config_MediaInfo::File_DisplayCaptions_Get ()
 {
     CriticalSectionLocker CSL(CS);
-    return File_Eia608_DisplayEmptyStream;
-}
-
-//---------------------------------------------------------------------------
-void MediaInfo_Config_MediaInfo::File_Eia708_DisplayEmptyStream_Set (bool NewValue)
-{
-    CriticalSectionLocker CSL(CS);
-    File_Eia708_DisplayEmptyStream=NewValue;
-}
-
-bool MediaInfo_Config_MediaInfo::File_Eia708_DisplayEmptyStream_Get ()
-{
-    CriticalSectionLocker CSL(CS);
-    return File_Eia708_DisplayEmptyStream;
-}
-
-//---------------------------------------------------------------------------
-void MediaInfo_Config_MediaInfo::File_CommandOnlyMeansEmpty_Set (bool NewValue)
-{
-    CriticalSectionLocker CSL(CS);
-    File_CommandOnlyMeansEmpty=NewValue;
-}
-
-bool MediaInfo_Config_MediaInfo::File_CommandOnlyMeansEmpty_Get ()
-{
-    CriticalSectionLocker CSL(CS);
-    return File_CommandOnlyMeansEmpty;
+    return DisplayCaptions;
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
@@ -84,6 +84,14 @@ struct config_probe
     string              Parser;
 };
 
+enum display_captions
+{
+    DisplayCaptions_Command,
+    DisplayCaptions_Content,
+    DisplayCaptions_Stream,
+    DisplayCaptions_Max
+};
+
 //***************************************************************************
 // Class MediaInfo_Config_MediaInfo
 //***************************************************************************
@@ -387,12 +395,8 @@ public :
     void          File_Mmsh_Describe_Only_Set (bool NewValue);
     bool          File_Mmsh_Describe_Only_Get ();
     #endif //defined(MEDIAINFO_LIBMMS_YES)
-    void          File_Eia608_DisplayEmptyStream_Set (bool NewValue);
-    bool          File_Eia608_DisplayEmptyStream_Get ();
-    void          File_Eia708_DisplayEmptyStream_Set (bool NewValue);
-    bool          File_Eia708_DisplayEmptyStream_Get ();
-    void          File_CommandOnlyMeansEmpty_Set(bool NewValue);
-    bool          File_CommandOnlyMeansEmpty_Get();
+    Ztring        File_DisplayCaptions_Set (const Ztring& NewValue);
+    display_captions File_DisplayCaptions_Get ();
     Ztring        File_ProbeCaption_Set(const Ztring& NewValue);
     config_probe  File_ProbeCaption_Get(const string& Parser);
     #if defined(MEDIAINFO_AC3_YES)
@@ -627,9 +631,7 @@ private :
     #if defined(MEDIAINFO_LIBMMS_YES)
     bool                    File_Mmsh_Describe_Only;
     #endif //defined(MEDIAINFO_LIBMMS_YES)
-    bool                    File_Eia608_DisplayEmptyStream;
-    bool                    File_Eia708_DisplayEmptyStream;
-    bool                    File_CommandOnlyMeansEmpty;
+    display_captions        DisplayCaptions;
     std::vector<config_probe> File_ProbeCaption;
     size_t                  File_ProbeCaption_Pos;
     #if defined(MEDIAINFO_AC3_YES)

--- a/Source/MediaInfo/Text/File_Cdp.cpp
+++ b/Source/MediaInfo/Text/File_Cdp.cpp
@@ -472,7 +472,7 @@ void File_Cdp::ccdata_section()
         BS_End();
 
         #if MEDIAINFO_ADVANCED
-            if (cc_type>=2 && !Streams[2] && Config->File_Eia708_DisplayEmptyStream_Get())
+            if (cc_type>=2 && !Streams[2] && Config->File_DisplayCaptions_Get()==DisplayCaptions_Stream)
                 CreateStream(2);
         #endif //MEDIAINFO_ADVANCED
 

--- a/Source/MediaInfo/Text/File_DtvccTransport.cpp
+++ b/Source/MediaInfo/Text/File_DtvccTransport.cpp
@@ -241,7 +241,7 @@ void File_DtvccTransport::Read_Buffer_Continue()
             BS_End();
 
             #if MEDIAINFO_ADVANCED
-                if (cc_type>=2 && !Streams[2] && Config->File_Eia708_DisplayEmptyStream_Get())
+                if (cc_type>=2 && !Streams[2] && Config->File_DisplayCaptions_Get()==DisplayCaptions_Stream)
                     CreateStream(2);
             #endif //MEDIAINFO_ADVANCED
 

--- a/Source/MediaInfo/Text/File_Eia608.h
+++ b/Source/MediaInfo/Text/File_Eia608.h
@@ -163,15 +163,15 @@ private :
             Duration_End_Command=FLT_MAX;
             Duration_End_Command_WasJustUpdated=false;
         }
+
+        int64u HasContent() { return Count_PopOn + Count_RollUp + Count_PaintOn; }
     };
     std::vector<stream*> Streams;
 
     int8u cc_data_1_Old;
     int8u cc_data_2_Old;
     bool   HasContent;
-    bool   HasContent_Displayed;
     bool   HasJumped;
-    std::bitset<8> DataDetected; //1=CC1, 2=CC2, 3=T1, 4=T2, 5=XDS
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Text/File_Eia708.h
+++ b/Source/MediaInfo/Text/File_Eia708.h
@@ -140,12 +140,13 @@ private :
             for (size_t Pos=0; Pos<Windows.size(); Pos++)
                 delete Windows[Pos]; //Windows[Pos]=NULL;
         }
+
+        bool HasContent() { return !Windows.empty(); }
     };
     std::vector<stream*> Streams;
     int8u service_number;
     int8u block_size;
     bool   HasContent;
-    int64u DataDetected; //1 service per bit
 
     //Elements
     void NUL();                 //NUL

--- a/Source/MediaInfo/Text/File_Scte20.cpp
+++ b/Source/MediaInfo/Text/File_Scte20.cpp
@@ -157,7 +157,7 @@ void File_Scte20::Read_Buffer_Init()
     #endif //defined(MEDIAINFO_EIA608_YES)
 
     //Configuration
-    Eia608_DisplayEmptyStream=Config->File_Eia608_DisplayEmptyStream_Get();
+    Eia608_DisplayEmptyStream=Config->File_DisplayCaptions_Get()==DisplayCaptions_Stream;
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Common option for https://github.com/MediaArea/MediaInfo/issues/674 and https://github.com/MediaArea/MediaInfoLib/issues/1882, now `File_DisplayCaptions` with `Content`, `Command`, `Stream`.