### PR TITLE
HEVC: add missing parsing of some multilayer SPS elements

### DIFF
--- a/Source/MediaInfo/Video/File_Hevc.h
+++ b/Source/MediaInfo/Video/File_Hevc.h
@@ -418,7 +418,7 @@ private :
     void slice_segment_header();
     void profile_tier_level(profile_tier_level_struct& p, bool profilePresentFlag, int8u maxNumSubLayersMinus1);
     void short_term_ref_pic_sets(int8u num_short_term_ref_pic_sets);
-    void vui_parameters(std::vector<video_parameter_set_struct*>::iterator video_parameter_set_Item, seq_parameter_set_struct::vui_parameters_struct* &vui_parameters_Item);
+    void vui_parameters(seq_parameter_set_struct::vui_parameters_struct* &vui_parameters_Item, int8u maxNumSubLayersMinus1);
     void hrd_parameters(bool commonInfPresentFlag, int8u maxNumSubLayersMinus1, seq_parameter_set_struct::vui_parameters_struct::xxl_common* &xxL_Common, seq_parameter_set_struct::vui_parameters_struct::xxl* &NAL, seq_parameter_set_struct::vui_parameters_struct::xxl* &VCL);
     void sub_layer_hrd_parameters(seq_parameter_set_struct::vui_parameters_struct::xxl_common* xxL_Common, int8u bit_rate_scale, int8u cpb_size_scale, int32u cpb_cnt_minus1, seq_parameter_set_struct::vui_parameters_struct::xxl* &hrd_parameters_Item);
     void scaling_list_data();


### PR DESCRIPTION
I have a few multiview samples generated by either iPhone or Apple's authoring tools, and for all of them i get the following:

```
Conformance errors                       : 1
 HEVC                                    : Yes
  General compliance                     : Bitstream parsing ran out of data to read before the end of the syntax was reached, most probably the bitstream is malformed  (offset 0xDEADBEEF)
Codec configuration box                  : hvcC+lhvC
```

In both cases, the offset reported is the start of whatever box follows the lhvC one, so it was clear there were LHEVCDecoderConfigurationRecord parsing related issues.

Looking into it i found one problem parsing SPS when nuh_layer_id > 0 and one when MultiLayerExtSpsFlag is true (nuh_layer_id > 0 && sps_ext_or_max_sub_layers_minus1 == 7), both of which i'm fixing in this PR, as the LHEVCDecoderConfigurationRecord itself seems to be ok.
Only the latter is enough to fix parsing the samples i have, but i'm including the other as well to ensure correct parsing for all files. You can check the syntax i'm fixing in section F.7.3.2.2.1 of ITU-T H.265