### PR TITLE
Escape HTML strings

### DIFF
--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -877,6 +877,10 @@ Ztring MediaInfo_Internal::Inform (stream_t StreamKind, size_t StreamPos, bool I
                     Retour+=__T("      <tr>\n        <td class=\"Prefix\">");
                     Retour+=Prefix+Nom.TrimLeft();
                     Retour+=__T(" :</td>\n        <td>");
+                    Valeur.FindAndReplace(__T("&"), __T("&amp;"), 0, Ztring_Recursive);
+                    Valeur.FindAndReplace(__T("<"), __T("&lt;"), 0, Ztring_Recursive);
+                    Valeur.FindAndReplace(__T(">"), __T("&gt;"), 0, Ztring_Recursive);
+                    Valeur.FindAndReplace(__T("  "), __T(" &nbsp;"), 0, Ztring_Recursive);
                     Retour+=Valeur;
                     Retour+=__T("</td>\n      </tr>");
                 }


### PR DESCRIPTION
Escape HTML strings to ensure they display exactly what is in the file and not trigger unwanted results.

Fixes #1975 

Test file:
https://github.com/user-attachments/assets/fcebf2f9-532c-4a25-b810-5a389f55d44b

Before:
![Screenshot 2024-09-30 154319](https://github.com/user-attachments/assets/a4fe63ad-1ceb-4193-a42b-f9022fc93054)
![Screenshot 2024-09-30 154326](https://github.com/user-attachments/assets/a1cda83a-5181-42d4-8ece-dba579d3ab8d)

After:
![Screenshot 2024-09-30 154405](https://github.com/user-attachments/assets/3e29da4a-f70f-45af-b146-4d547025c090)
