### PR TITLE
MXF: fix wrong Delay field with NDF timecodes

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -864,7 +864,7 @@ Ztring MediaInfo_Config_MediaInfo::Option (const String &Option, const String &V
     }
     else if (Option_Lower==__T("file_demux_rate"))
     {
-        #if MEDIAINFO_DEMUX
+        #if 1 //MEDIAINFO_DEMUX
             Demux_Rate_Set(Ztring(Value).To_float64());
             return Ztring();
         #else //MEDIAINFO_DEMUX
@@ -2455,7 +2455,7 @@ bool MediaInfo_Config_MediaInfo::Demux_SplitAudioBlocks_Get()
 #endif //MEDIAINFO_DEMUX
 
 //---------------------------------------------------------------------------
-#if MEDIAINFO_DEMUX
+#if 1 //MEDIAINFO_DEMUX
 void MediaInfo_Config_MediaInfo::Demux_Rate_Set (float64 NewValue)
 {
     CriticalSectionLocker CSL(CS);

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.h
@@ -312,6 +312,8 @@ public :
     void          Event_SubFile_Missing_Absolute(const Ztring &FileName_Absolute);
     #endif //MEDIAINFO_EVENTS
 
+    void          Demux_Rate_Set (float64 NewValue);
+    float64       Demux_Rate_Get ();
     #if MEDIAINFO_DEMUX
     void          Demux_ForceIds_Set (bool NewValue);
     bool          Demux_ForceIds_Get ();
@@ -325,8 +327,6 @@ public :
     bool          Demux_Hevc_Transcode_Iso14496_15_to_AnnexB_Get ();
     void          Demux_Unpacketize_Set (bool NewValue);
     bool          Demux_Unpacketize_Get ();
-    void          Demux_Rate_Set (float64 NewValue);
-    float64       Demux_Rate_Get ();
     void          Demux_FirstDts_Set (int64u NewValue);
     int64u        Demux_FirstDts_Get ();
     void          Demux_FirstFrameNumber_Set (int64u NewValue);
@@ -583,6 +583,7 @@ private :
     std::vector<event_delayed*> Events_TimestampShift_Delayed;
     #endif //MEDIAINFO_EVENTS
 
+    float64                 Demux_Rate;
     #if MEDIAINFO_DEMUX
     bool                    Demux_ForceIds;
     bool                    Demux_PCM_20bitTo16bit;
@@ -591,7 +592,6 @@ private :
     bool                    Demux_Hevc_Transcode_Iso14496_15_to_AnnexB;
     bool                    Demux_Unpacketize;
     bool                    Demux_SplitAudioBlocks;
-    float64                 Demux_Rate;
     int64u                  Demux_FirstDts;
     int64u                  Demux_FirstFrameNumber;
     int8u                   Demux_InitData;

--- a/Source/MediaInfo/Multiple/File_Mxf.h
+++ b/Source/MediaInfo/Multiple/File_Mxf.h
@@ -646,6 +646,7 @@ protected :
     //TimeCode
     struct mxftimecode
     {
+        int128u InstanceUID;
         int64u  StartTimecode;
         int16u  RoundedTimecodeBase;
         bool    DropFrame;
@@ -660,17 +661,12 @@ protected :
         {
             return RoundedTimecodeBase && StartTimecode != (int64u)-1;
         }
-        float64 Get_TimeCode_StartTimecode_Temp(const int64u& File_IgnoreEditsBefore) const
+        float64 Get_TimeCode_StartTimecode_Temp(const int64u& File_IgnoreEditsBefore, bool Is1001=false) const
         {
             if (RoundedTimecodeBase)
             {
-                float64 TimeCode_StartTimecode_Temp = ((float64)(StartTimecode + File_IgnoreEditsBefore)) / RoundedTimecodeBase;
-                if (DropFrame)
-                {
-                    TimeCode_StartTimecode_Temp *= 1001;
-                    TimeCode_StartTimecode_Temp /= 1000;
-                }
-                return TimeCode_StartTimecode_Temp;
+                TimeCode TimeCode_StartTimecode_Temp((uint64_t)(StartTimecode + File_IgnoreEditsBefore), RoundedTimecodeBase - 1, TimeCode::flags().DropFrame(DropFrame).FPS1001(Is1001));
+                return TimeCode_StartTimecode_Temp.ToSeconds();
             }
             else
                 return 0.0;
@@ -1426,9 +1422,9 @@ protected :
         essences::iterator Demux_CurrentEssence;
     #endif //MEDIAINFO_DEMUX
 
+    float64 Demux_Rate;
     #if MEDIAINFO_DEMUX || MEDIAINFO_SEEK
         size_t CountOfLocatorsToParse;
-        float64 Demux_Rate;
 
         //IndexTable
         struct indextable

--- a/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
+++ b/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
@@ -567,6 +567,8 @@ void File__ReferenceFilesHelper::ParseReferences()
                         EditRate_Count++;
                     }
                 }
+        /*
+        //It was used for demux with seek, not used in practice in the open source version, and it has bad side effects so currently disabled, we should find a better way to do that
         if (EditRate_Count>1)
             //Multiple rates, using only one rate
             for (Sequences_Current=0; Sequences_Current<Sequences.size(); Sequences_Current++)
@@ -596,6 +598,7 @@ void File__ReferenceFilesHelper::ParseReferences()
                         }
                         Sequences[Sequences_Current]->Resources[Pos]->EditRate=EditRate;
                     }
+        */
 
         //Testing IDs
         std::set<int64u> StreamList;
@@ -1438,6 +1441,10 @@ void File__ReferenceFilesHelper::ParseReference_Finalize_PerStream ()
                 MI2.Config.File_IgnoreEditsAfter=Sequences[Sequences_Current]->Resources[Pos]->IgnoreEditsAfter;
             MI2.Config.File_EditRate=Sequences[Sequences_Current]->Resources[Pos]->EditRate;
             Sequences[Sequences_Current]->Resources[Pos]->FileNames.Separator_Set(0, ",");
+            if (FrameRate)
+                MI2.Option(__T("File_Demux_Rate"), Ztring::ToZtring(FrameRate));
+            else if (!Sequences[Sequences_Current]->Resources.empty() && Sequences[Sequences_Current]->Resources[0]->EditRate) //TODO: per Pos
+                MI2.Option(__T("File_Demux_Rate"), Ztring::ToZtring(Sequences[Sequences_Current]->Resources[0]->EditRate));
             size_t MiOpenResult=MI2.Open(Sequences[Sequences_Current]->Resources[Pos]->FileNames.Read());
             MI2.Option(__T("ParseSpeed"), ParseSpeed_Save); //This is a global value, need to reset it. TODO: local value
             MI2.Option(__T("Demux"), Demux_Save); //This is a global value, need to reset it. TODO: local value
@@ -1848,6 +1855,10 @@ MediaInfo_Internal* File__ReferenceFilesHelper::MI_Create()
             MI_Temp->Option(__T("File_SubFile_IDs_Set"), SubFile_IDs.Read());
         }
     #endif //MEDIAINFO_EVENTS
+    if (FrameRate)
+        MI_Temp->Option(__T("File_Demux_Rate"), Ztring::ToZtring(FrameRate));
+    else if (!Sequences[Sequences_Current]->Resources.empty() && Sequences[Sequences_Current]->Resources[0]->EditRate) //TODO: per Pos
+        MI_Temp->Option(__T("File_Demux_Rate"), Ztring::ToZtring(Sequences[Sequences_Current]->Resources[0]->EditRate));
     #if MEDIAINFO_DEMUX
         if (Config->Demux_Unpacketize_Get())
             MI_Temp->Option(__T("File_Demux_Unpacketize"), __T("1"));
@@ -1855,10 +1866,6 @@ MediaInfo_Internal* File__ReferenceFilesHelper::MI_Create()
             MI_Temp->Option(__T("File_Demux_Avc_Transcode_Iso14496_15_to_Iso14496_10"), __T("1"));
         if (Config->Demux_Hevc_Transcode_Iso14496_15_to_AnnexB_Get())
             MI_Temp->Option(__T("File_Demux_Hevc_Transcode_Iso14496_15_to_AnnexB"), __T("1"));
-        if (FrameRate)
-            MI_Temp->Option(__T("File_Demux_Rate"), Ztring::ToZtring(FrameRate));
-        else if (!Sequences[Sequences_Current]->Resources.empty() && Sequences[Sequences_Current]->Resources[0]->EditRate) //TODO: per Pos
-            MI_Temp->Option(__T("File_Demux_Rate"), Ztring::ToZtring(Sequences[Sequences_Current]->Resources[0]->EditRate));
         switch (Config->Demux_InitData_Get())
         {
             case 0 : MI_Temp->Option(__T("File_Demux_InitData"), __T("Event")); break;


### PR DESCRIPTION
Fix https://github.com/MediaArea/MediaInfoLib/issues/2110