### PR TITLE
Removed buffer leak in PNG file parsing and when using inflate

### DIFF
--- a/Source/MediaInfo/Audio/File_Mga.cpp
+++ b/Source/MediaInfo/Audio/File_Mga.cpp
@@ -241,12 +241,13 @@ void File_Mga::SerialAudioDefinitionModelMetadataPayload(int64u Length)
             size_t UncompressedData_NewMaxSize=strm.total_out*4;
             int8u* UncompressedData_New=new int8u[UncompressedData_NewMaxSize];
             memcpy(UncompressedData_New, strm.next_out-strm.total_out, strm.total_out);
-            delete[] strm.next_out; strm.next_out=UncompressedData_New;
+            delete[](strm.next_out - strm.total_out); strm.next_out=UncompressedData_New;
             strm.next_out=strm.next_out+strm.total_out;
             strm.avail_out=UncompressedData_NewMaxSize-strm.total_out;
         }
         UncompressedData=strm.next_out-strm.total_out;
         UncompressedData_Size=strm.total_out;
+        inflateEnd(&strm);
     }
 
     #if defined(MEDIAINFO_ADM_YES)

--- a/Source/MediaInfo/Audio/File_SmpteSt0337.cpp
+++ b/Source/MediaInfo/Audio/File_SmpteSt0337.cpp
@@ -1368,13 +1368,13 @@ void File_SmpteSt0337::Data_Parse()
                         size_t UncompressedData_NewMaxSize=strm.total_out*4;
                         int8u* UncompressedData_New=new int8u[UncompressedData_NewMaxSize];
                         memcpy(UncompressedData_New, strm.next_out-strm.total_out, strm.total_out);
-                        delete[] strm.next_out; strm.next_out=UncompressedData_New;
+                        delete[](strm.next_out - strm.total_out); strm.next_out=UncompressedData_New;
                         strm.next_out=strm.next_out+strm.total_out;
                         strm.avail_out=UncompressedData_NewMaxSize-strm.total_out;
                     }
                     UncompressedData=strm.next_out-strm.total_out;
                     UncompressedData_Size=strm.total_out;
-
+                    inflateEnd(&strm);
                     // Adapting
                     Buffer=Save_Buffer;
                     Buffer_Offset=Save_Buffer_Offset;

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -3731,9 +3731,10 @@ void File_Riff::WAVE_axml()
         }
         int8u* UncompressedData=strm.next_out-strm.total_out;
         size_t UncompressedData_Size=strm.total_out;
-
+        inflateEnd(&strm);
         //Parsing
         Open_Buffer_Continue(Adm, UncompressedData, UncompressedData_Size);
+        delete[] UncompressedData;
         Skip_UTF8(Element_Size, "XML data");
     }
     else


### PR DESCRIPTION
Solves recently opened issue at #2120 