### PR TITLE
MPEG-TS: increase probing at end of FileHeader_Begin

### DIFF
--- a/Source/MediaInfo/Multiple/File_MpegTs.cpp
+++ b/Source/MediaInfo/Multiple/File_MpegTs.cpp
@@ -279,7 +279,7 @@ File_MpegTs::File_MpegTs()
 
     //Data
     MpegTs_JumpTo_Begin=MediaInfoLib::Config.MpegTs_MaximumOffset_Get();
-    MpegTs_JumpTo_End=MediaInfoLib::Config.MpegTs_MaximumOffset_Get()/4;
+    MpegTs_JumpTo_End=MediaInfoLib::Config.MpegTs_MaximumOffset_Get();
     MpegTs_ScanUpTo=(int64u)-1;
     Searching_TimeStamp_Start=true;
     Complete_Stream=NULL;
@@ -330,7 +330,7 @@ void File_MpegTs::Streams_Accept()
 
     //Temp
     MpegTs_JumpTo_Begin=(File_Offset_FirstSynched==(int64u)-1?0:Buffer_TotalBytes_LastSynched)+MediaInfoLib::Config.MpegTs_MaximumOffset_Get();
-    MpegTs_JumpTo_End=MediaInfoLib::Config.MpegTs_MaximumOffset_Get()/4;
+    MpegTs_JumpTo_End=MediaInfoLib::Config.MpegTs_MaximumOffset_Get();
     if (MpegTs_JumpTo_Begin==(int64u)-1 || MpegTs_JumpTo_Begin+MpegTs_JumpTo_End>=File_Size)
     {
         if (MpegTs_JumpTo_Begin+MpegTs_JumpTo_End>File_Size)
@@ -2100,8 +2100,8 @@ void File_MpegTs::Read_Buffer_AfterParsing()
                                 if (Duration) 
                                     Ratio = (27000000 * 2) / Duration; 
                                 MpegTs_JumpTo_End*=Ratio;
-                                if (MpegTs_JumpTo_End>MediaInfoLib::Config.MpegTs_MaximumOffset_Get()/4)
-                                    MpegTs_JumpTo_End=MediaInfoLib::Config.MpegTs_MaximumOffset_Get()/4;
+                                if (MpegTs_JumpTo_End>MediaInfoLib::Config.MpegTs_MaximumOffset_Get())
+                                    MpegTs_JumpTo_End=MediaInfoLib::Config.MpegTs_MaximumOffset_Get();
                                 break; //Using the first PES found
                             }
                         }


### PR DESCRIPTION
It reads more content from the disk but this is the only way to get the real end time of each stream. A smarter way could be to keep the previous behavior but seek earlier if not all found, on the todo-list