### PR TITLE
DvDif: Avoid to call Synchro_Manage() twice

### DIFF
--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -56,15 +56,14 @@ void File_DvDif::Read_Buffer_Continue()
         return;
 
     if (!Synchro_Manage()) // TODO: Synchro_Manage() should be called before Read_Buffer_Continue() in File__Analyze
-        return; //Wait for more data
-
-    #if MEDIAINFO_DEMUX
-        if (Demux_UnpacketizeContainer && !Synchro_Manage()) // We need to manage manually synchronization in case of demux
-        {
+    {
+        #if MEDIAINFO_DEMUX
+        if (Demux_UnpacketizeContainer) // We need to manage manually synchronization in case of demux
             Element_WaitForMoreData();
-            return; //Wait for more data
-        }
-    #endif // MEDIAINFO_DEMUX
+        #endif // MEDIAINFO_DEMUX
+
+        return; //Wait for more data
+    }
 
     //Errors stats
     while (Buffer_Offset+80<=Buffer_Size)


### PR DESCRIPTION
Fixes mipops/DVrescue#944