### PR TITLE
Also set ChannelLayout to Stereo when HEAAC v2 is detected

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac_GeneralAudio.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_GeneralAudio.cpp
@@ -4269,6 +4269,7 @@ void File_Aac::FillInfosHEAACv2(const Ztring& Format_Settings)
     const Ztring ChannelPositions = Infos["ChannelPositions"];
     Infos["Channel(s)"] = __T("2");
     Infos["ChannelPositions"] = __T("Front: L R");
+    Infos["ChannelLayout"] = __T("L R");
     if (MediaInfoLib::Config.LegacyStreamDisplay_Get())
     {
         const Ztring SamplingRate_Previous = Infos["SamplingRate"];


### PR DESCRIPTION
Currently, if HEAAC v2 is detected, the number of channels is updated to 2, the `ChannelPositions` are updated to `Front: L R` but the `ChannelLayout` is not updated to 'L R' but shows the previously set layout of 'M'. 

Before Fix:
```
Audio
Format                                   : AAC LC SBR PS
Format/Info                              : Advanced Audio Codec Low Complexity with Spectral Band Replication and Parametric Stereo
Commercial name                          : HE-AACv2
Format version                           : Version 4
Format settings                          : Implicit
Codec ID                                 : 2
Bit rate mode                            : Variable
Channel(s)                               : 2 channels
Channel layout                           : M
Sampling rate                            : 44.1 kHz
Frame rate                               : 21.533 FPS (2048 SPF)
Compression mode                         : Lossy
Stream size                              : 11.1 MiB (100%)
```

After fix:
```
Audio
Format                                   : AAC LC SBR PS
Format/Info                              : Advanced Audio Codec Low Complexity with Spectral Band Replication and Parametric Stereo
Commercial name                          : HE-AACv2
Format version                           : Version 4
Format settings                          : Implicit
Codec ID                                 : 2
Bit rate mode                            : Variable
Channel(s)                               : 2 channels
Channel layout                           : L R
Sampling rate                            : 44.1 kHz
Frame rate                               : 21.533 FPS (2048 SPF)
Compression mode                         : Lossy
Stream size                              : 11.1 MiB (100%)
```