### PR TITLE
FFV1: MaxSliceCount not in XML report

### DIFF
--- a/Source/MediaInfo/Video/File_Ffv1.cpp
+++ b/Source/MediaInfo/Video/File_Ffv1.cpp
@@ -1210,7 +1210,7 @@ void File_Ffv1::Parameters()
             if (version>1)
             {
                 Fill(Stream_Video, 0, "MaxSlicesCount", num_h_slices*num_v_slices);
-                Fill_SetOptions(Stream_Video, 0, "MaxSlicesCount", "N NTN");
+                Fill_SetOptions(Stream_Video, 0, "MaxSlicesCount", "N NTY");
                 Fill(Stream_Video, 0, Video_Format_Settings_SliceCount, num_h_slices*num_v_slices);
                 if (version>=3)
                 {


### PR DESCRIPTION
Fix https://github.com/MediaArea/MediaConch_SourceCode/issues/790.