### PR TITLE
Matroska tag: Detection for VVC

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -1630,6 +1630,7 @@ void MediaInfo_Config_CodecID_Video_Matroska (InfoMap &Info)
     "V_MPEG4/ISO/AP;MPEG-4 Visual;;Advanced Profile;http://ffdshow-tryout.sourceforge.net/\n"
     "V_MPEG4/ISO/AVC;AVC;;;http://ffdshow-tryout.sourceforge.net/\n"
     "V_MPEGH/ISO/HEVC;HEVC\n"
+    "V_MPEGI/ISO/VVC;VVC\n"
     "V_MPEG4/MS/V2;MPEG-4 Visual;MS MPEG-4 v2;MS MPEG-4 v2;http://ffdshow-tryout.sourceforge.net/\n"
     "V_MPEG4/MS/V3;MPEG-4 Visual;MS MPEG-4 v3;MS MPEG-4 v3;http://ffdshow-tryout.sourceforge.net/\n"
     "V_MPEG1;MPEG Video;;MPEG 1 or 2 Video;http://ffdshow-tryout.sourceforge.net/\n"

--- a/Source/Resource/Text/DataBase/CodecID_Video_Matroska.csv
+++ b/Source/Resource/Text/DataBase/CodecID_Video_Matroska.csv
@@ -11,6 +11,7 @@ V_MPEG4/ISO/ASP;MPEG-4 Visual;;Advanced Simple Profile;http://www.xvid.org/Downl
 V_MPEG4/ISO/AP;MPEG-4 Visual;;Advanced Profile;http://ffdshow-tryout.sourceforge.net/
 V_MPEG4/ISO/AVC;AVC;;;http://ffdshow-tryout.sourceforge.net/
 V_MPEGH/ISO/HEVC;HEVC;;;
+V_MPEGI/ISO/VVC;VVC;;;
 V_MPEG4/MS/V2;MPEG-4 Visual;MS MPEG-4 v2;MS MPEG-4 v2;http://ffdshow-tryout.sourceforge.net/
 V_MPEG4/MS/V3;MPEG-4 Visual;MS MPEG-4 v3;MS MPEG-4 v3;http://ffdshow-tryout.sourceforge.net/
 V_MPEG1;MPEG Video;;MPEG 1 or 2 Video;http://ffdshow-tryout.sourceforge.net/


### PR DESCRIPTION
This will detect VVC Matroska video tag official from Matroska format.

You can have look a commit of matroska-specification, that VVC defines Matroska video tag:
https://github.com/ietf-wg-cellar/matroska-specification/commit/c9fbd31e94156eaed04c91a000a1562d5aa792b3

But, official matroska page doesn't have VVC information of codec mapping written on it.

Also I'm leaving examples here, if you need it just in case.
[matroska-vvcsamples.zip](https://github.com/user-attachments/files/17926351/matroska-vvcsamples.zip)

If you have question, feedback or issue, feel free to let me know. Thanks! :)

Regards,
Martin Eesmaa