### PR TITLE
PNG: adapt cLLi/mdCv letter case, update

### DIFF
--- a/Source/MediaInfo/Image/File_Png.h
+++ b/Source/MediaInfo/Image/File_Png.h
@@ -66,7 +66,7 @@ private :
     void PLTE() {Skip_XX(Element_Size, "Data");}
     void cICP();
     void cLLI();
-    void cLLi() { cLLi(); }
+    void cLLi() { cLLI(); }
     void iCCP();
     void iTXt() {Textual(bitset8().set(IsCompressed).set(IsUTF8));}
     void gAMA();


### PR DESCRIPTION
Fix after https://github.com/MediaArea/MediaInfoLib/pull/2148, thanks @cjee21 for catching that before the release, and always dangerous to patch quickly without crafting a test file...