### PR TITLE
AVC&HEVC: PAR is unspecified if not indicated

### DIFF
--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -323,27 +323,32 @@ namespace MediaInfoLib
 const size_t Avc_Errors_MaxCount=32;
 
 //---------------------------------------------------------------------------
-extern const int8u Avc_PixelAspectRatio_Size=17;
-extern const float32 Avc_PixelAspectRatio[Avc_PixelAspectRatio_Size]=
+struct par
 {
-    (float32)1, //Reserved
-    (float32)1,
-    (float32)12/(float32)11,
-    (float32)10/(float32)11,
-    (float32)16/(float32)11,
-    (float32)40/(float32)33,
-    (float32)24/(float32)11,
-    (float32)20/(float32)11,
-    (float32)32/(float32)11,
-    (float32)80/(float32)33,
-    (float32)18/(float32)11,
-    (float32)15/(float32)11,
-    (float32)64/(float32)33,
-    (float32)160/(float32)99,
-    (float32)4/(float32)3,
-    (float32)3/(float32)2,
-    (float32)2,
+    int8u w;
+    int8u h;
 };
+extern const par Avc_PixelAspectRatio[] =
+{
+    {   1,   1 }, //Reserved
+    {   1,   1 },
+    {  12,  11 },
+    {  10,  11 },
+    {  16,  11 },
+    {  40,  33 },
+    {  24,  11 },
+    {  20,  11 },
+    {  32,  11 },
+    {  80,  33 },
+    {  18,  11 },
+    {  15,  11 },
+    {  64,  33 },
+    { 160,  99 },
+    {   4,   3 },
+    {   3,   2 },
+    {   2,   1 },
+};
+extern const auto Avc_PixelAspectRatio_Size = sizeof(Avc_PixelAspectRatio) / sizeof(*Avc_PixelAspectRatio);
 
 //---------------------------------------------------------------------------
 const char* Avc_video_format[]=
@@ -889,8 +894,10 @@ void File_Avc::Streams_Fill()
 }
 
 //---------------------------------------------------------------------------
-void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq_parameter_set_Item)
+void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq_parameter_set_Item_)
 {
+    auto seq_parameter_set_Item = *seq_parameter_set_Item_;
+
     if (Count_Get(Stream_Video) && !Retrieve_Const(Stream_Video, 0, Video_Format).empty())
         return;
     if (!Count_Get(Stream_Video))
@@ -899,54 +906,55 @@ void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq
     Fill(Stream_Video, 0, Video_Codec, "AVC");
 
     //Calculating - Pixels
-    int32u Width =((*seq_parameter_set_Item)->pic_width_in_mbs_minus1       +1)*16;
-    int32u Height=((*seq_parameter_set_Item)->pic_height_in_map_units_minus1+1)*16*(2-(*seq_parameter_set_Item)->frame_mbs_only_flag);
-    int8u chromaArrayType = (*seq_parameter_set_Item)->ChromaArrayType();
+    int32u Width =(seq_parameter_set_Item->pic_width_in_mbs_minus1       +1)*16;
+    int32u Height=(seq_parameter_set_Item->pic_height_in_map_units_minus1+1)*16*(2-seq_parameter_set_Item->frame_mbs_only_flag);
+    int8u chromaArrayType = seq_parameter_set_Item->ChromaArrayType();
     if (chromaArrayType >= 4)
         chromaArrayType = 0;
     int32u CropUnitX=Avc_SubWidthC [chromaArrayType];
-    int32u CropUnitY=Avc_SubHeightC[chromaArrayType]*(2-(*seq_parameter_set_Item)->frame_mbs_only_flag);
-    Width -=((*seq_parameter_set_Item)->frame_crop_left_offset+(*seq_parameter_set_Item)->frame_crop_right_offset )*CropUnitX;
-    Height-=((*seq_parameter_set_Item)->frame_crop_top_offset +(*seq_parameter_set_Item)->frame_crop_bottom_offset)*CropUnitY;
+    int32u CropUnitY=Avc_SubHeightC[chromaArrayType]*(2-seq_parameter_set_Item->frame_mbs_only_flag);
+    Width -=(seq_parameter_set_Item->frame_crop_left_offset+seq_parameter_set_Item->frame_crop_right_offset )*CropUnitX;
+    Height-=(seq_parameter_set_Item->frame_crop_top_offset +seq_parameter_set_Item->frame_crop_bottom_offset)*CropUnitY;
 
     //From vui_parameters
-    float64 PixelAspectRatio=1;
     float64 FrameRate=0;
-    if ((*seq_parameter_set_Item)->vui_parameters)
+    const auto vui_parameters = seq_parameter_set_Item->vui_parameters;
+    if (vui_parameters)
     {
-        if ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_info_present_flag)
+        if (vui_parameters->flags[timing_info_present_flag])
         {
-            if ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc<Avc_PixelAspectRatio_Size)
-                PixelAspectRatio=Avc_PixelAspectRatio[(*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc];
-            else if ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc==0xFF && (*seq_parameter_set_Item)->vui_parameters->sar_height)
-                PixelAspectRatio=((float64)(*seq_parameter_set_Item)->vui_parameters->sar_width)/(*seq_parameter_set_Item)->vui_parameters->sar_height;
-        }
-        if ((*seq_parameter_set_Item)->vui_parameters->timing_info_present_flag)
-        {
-            if (!(*seq_parameter_set_Item)->vui_parameters->fixed_frame_rate_flag)
+            if (!vui_parameters->flags[fixed_frame_rate_flag])
                 Fill(Stream_Video, StreamPos_Last, Video_FrameRate_Mode, "VFR");
-            else if ((*seq_parameter_set_Item)->vui_parameters->timing_info_present_flag && (*seq_parameter_set_Item)->vui_parameters->time_scale && (*seq_parameter_set_Item)->vui_parameters->num_units_in_tick)
+            else if (vui_parameters->time_scale && vui_parameters->num_units_in_tick)
             {
-                FrameRate=(float64)(*seq_parameter_set_Item)->vui_parameters->time_scale/(*seq_parameter_set_Item)->vui_parameters->num_units_in_tick/((*seq_parameter_set_Item)->frame_mbs_only_flag?2:(((*seq_parameter_set_Item)->pic_order_cnt_type==2 && Structure_Frame/2>Structure_Field)?1:2))/FrameRate_Divider;
+                FrameRate = (float32)vui_parameters->time_scale / vui_parameters->num_units_in_tick / (seq_parameter_set_Item->frame_mbs_only_flag ? 2 : ((seq_parameter_set_Item->pic_order_cnt_type == 2 && Structure_Frame / 2 > Structure_Field) ? 1 : 2)) / FrameRate_Divider;
                 Fill(Stream_Video, StreamPos_Last, Video_FrameRate, FrameRate);
             }
+        }
+
+        if (vui_parameters->sar_width && vui_parameters->sar_height)
+        {
+            auto PixelAspectRatio = ((float32)vui_parameters->sar_width) / vui_parameters->sar_height;
+            Fill(Stream_Video, 0, Video_PixelAspectRatio, PixelAspectRatio, 3, true);
+            if (Width && Height)
+                Fill(Stream_Video, 0, Video_DisplayAspectRatio, Width*PixelAspectRatio/Height, 3, true); //More precise
         }
 
         //Colour description
         if (preferred_transfer_characteristics!=2)
             Fill(Stream_Video, 0, Video_transfer_characteristics, Mpegv_transfer_characteristics(preferred_transfer_characteristics));
-        if ((*seq_parameter_set_Item)->vui_parameters->video_signal_type_present_flag)
+        if (vui_parameters->flags[video_signal_type_present_flag])
         {
-            Fill(Stream_Video, 0, Video_Standard, Avc_video_format[(*seq_parameter_set_Item)->vui_parameters->video_format]);
-            Fill(Stream_Video, 0, Video_colour_range, Avc_video_full_range[(*seq_parameter_set_Item)->vui_parameters->video_full_range_flag]);
-            if ((*seq_parameter_set_Item)->vui_parameters->colour_description_present_flag)
+            Fill(Stream_Video, 0, Video_Standard, Avc_video_format[vui_parameters->video_format]);
+            Fill(Stream_Video, 0, Video_colour_range, Avc_video_full_range[vui_parameters->flags[video_full_range_flag]]);
+            if (vui_parameters->flags[colour_description_present_flag])
             {
                 Fill(Stream_Video, 0, Video_colour_description_present, "Yes");
-                Fill(Stream_Video, 0, Video_colour_primaries, Mpegv_colour_primaries((*seq_parameter_set_Item)->vui_parameters->colour_primaries));
-                Fill(Stream_Video, 0, Video_transfer_characteristics, Mpegv_transfer_characteristics((*seq_parameter_set_Item)->vui_parameters->transfer_characteristics));
-                Fill(Stream_Video, 0, Video_matrix_coefficients, Mpegv_matrix_coefficients((*seq_parameter_set_Item)->vui_parameters->matrix_coefficients));
-                if ((*seq_parameter_set_Item)->vui_parameters->matrix_coefficients!=2)
-                    Fill(Stream_Video, 0, Video_ColorSpace, Mpegv_matrix_coefficients_ColorSpace((*seq_parameter_set_Item)->vui_parameters->matrix_coefficients), Unlimited, true, true);
+                Fill(Stream_Video, 0, Video_colour_primaries, Mpegv_colour_primaries(vui_parameters->colour_primaries));
+                Fill(Stream_Video, 0, Video_transfer_characteristics, Mpegv_transfer_characteristics(vui_parameters->transfer_characteristics));
+                Fill(Stream_Video, 0, Video_matrix_coefficients, Mpegv_matrix_coefficients(vui_parameters->matrix_coefficients));
+                if (vui_parameters->matrix_coefficients!=2)
+                    Fill(Stream_Video, 0, Video_ColorSpace, Mpegv_matrix_coefficients_ColorSpace(vui_parameters->matrix_coefficients), Unlimited, true, true);
             }
         }
 
@@ -956,7 +964,7 @@ void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq
         bool   cbr_flag=false;
         bool   cbr_flag_IsSet=false;
         bool   cbr_flag_IsValid=true;
-        seq_parameter_set_struct::vui_parameters_struct::xxl* NAL=(*seq_parameter_set_Item)->vui_parameters->NAL;
+        seq_parameter_set_struct::vui_parameters_struct::xxl* NAL=vui_parameters->NAL;
         if (NAL)
             for (size_t Pos=0; Pos<NAL->SchedSel.size(); Pos++)
             {
@@ -974,7 +982,7 @@ void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq
                     cbr_flag_IsSet=true;
                 }
             }
-        seq_parameter_set_struct::vui_parameters_struct::xxl* VCL=(*seq_parameter_set_Item)->vui_parameters->VCL;
+        seq_parameter_set_struct::vui_parameters_struct::xxl* VCL=vui_parameters->VCL;
         if (VCL)
             for (size_t Pos=0; Pos<VCL->SchedSel.size(); Pos++)
             {
@@ -999,18 +1007,15 @@ void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq
         }
     }
 
-    auto Profile=Avc_profile_level_string((*seq_parameter_set_Item)->profile_idc, (*seq_parameter_set_Item)->level_idc, (*seq_parameter_set_Item)->constraint_set_flags);
+    auto Profile=Avc_profile_level_string(seq_parameter_set_Item->profile_idc, seq_parameter_set_Item->level_idc, seq_parameter_set_Item->constraint_set_flags);
     Fill(Stream_Video, 0, Video_Format_Profile, Profile);
     Fill(Stream_Video, 0, Video_Codec_Profile, Profile);
     Fill(Stream_Video, StreamPos_Last, Video_Width, Width);
     Fill(Stream_Video, StreamPos_Last, Video_Height, Height);
-    if ((*seq_parameter_set_Item)->frame_crop_left_offset || (*seq_parameter_set_Item)->frame_crop_right_offset)
-        Fill(Stream_Video, StreamPos_Last, Video_Stored_Width, ((*seq_parameter_set_Item)->pic_width_in_mbs_minus1       +1)*16);
-    if ((*seq_parameter_set_Item)->frame_crop_top_offset || (*seq_parameter_set_Item)->frame_crop_bottom_offset)
-        Fill(Stream_Video, StreamPos_Last, Video_Stored_Height, ((*seq_parameter_set_Item)->pic_height_in_map_units_minus1+1)*16*(2-(*seq_parameter_set_Item)->frame_mbs_only_flag));
-    Fill(Stream_Video, 0, Video_PixelAspectRatio, PixelAspectRatio, 3, true);
-    if(Height)
-        Fill(Stream_Video, 0, Video_DisplayAspectRatio, Width*PixelAspectRatio/Height, 3, true); //More precise
+    if (seq_parameter_set_Item->frame_crop_left_offset || seq_parameter_set_Item->frame_crop_right_offset)
+        Fill(Stream_Video, StreamPos_Last, Video_Stored_Width, (seq_parameter_set_Item->pic_width_in_mbs_minus1       +1)*16);
+    if (seq_parameter_set_Item->frame_crop_top_offset || seq_parameter_set_Item->frame_crop_bottom_offset)
+        Fill(Stream_Video, StreamPos_Last, Video_Stored_Height, (seq_parameter_set_Item->pic_height_in_map_units_minus1+1)*16*(2-seq_parameter_set_Item->frame_mbs_only_flag));
     if (FrameRate_Divider==2)
     {
         Fill(Stream_Video, StreamPos_Last, Video_Format_Settings_FrameMode, "Frame doubling");
@@ -1023,14 +1028,14 @@ void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq
     }
 
     //Interlacement
-    if ((*seq_parameter_set_Item)->mb_adaptive_frame_field_flag && Structure_Frame>0) //Interlaced macro-block
+    if (seq_parameter_set_Item->mb_adaptive_frame_field_flag && Structure_Frame>0) //Interlaced macro-block
     {
         Fill(Stream_Video, 0, Video_ScanType, "MBAFF");
         Fill(Stream_Video, 0, Video_Interlacement, "MBAFF");
     }
-    else if ((*seq_parameter_set_Item)->frame_mbs_only_flag || (Structure_Frame>0 && Structure_Field==0)) //No interlaced frame
+    else if (seq_parameter_set_Item->frame_mbs_only_flag || (Structure_Frame>0 && Structure_Field==0)) //No interlaced frame
     {
-        switch ((*seq_parameter_set_Item)->pic_struct_FirstDetected)
+        switch (seq_parameter_set_Item->pic_struct_FirstDetected)
         {
             case  3 :
                         Fill(Stream_Video, 0, Video_ScanType, "Interlaced");
@@ -1079,7 +1084,7 @@ void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq
         }
         else
         {
-            switch ((*seq_parameter_set_Item)->pic_struct_FirstDetected)
+            switch (seq_parameter_set_Item->pic_struct_FirstDetected)
             {
                 case  1 :
                             Fill(Stream_Video, 0, Video_ScanOrder, (string) "TFF");
@@ -1120,7 +1125,7 @@ void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq
         Fill(Stream_Video, 0, Video_BitRate_Nominal, BitRate_Nominal);
     Fill(Stream_Video, 0, Video_MuxingMode, MuxingMode);
     for (std::vector<pic_parameter_set_struct*>::iterator pic_parameter_set_Item=pic_parameter_sets.begin(); pic_parameter_set_Item!=pic_parameter_sets.end(); ++pic_parameter_set_Item)
-        if (*pic_parameter_set_Item && (*pic_parameter_set_Item)->seq_parameter_set_id==seq_parameter_set_Item-(seq_parameter_sets.empty()?subset_seq_parameter_sets.begin():seq_parameter_sets.begin()))
+        if (*pic_parameter_set_Item && (*pic_parameter_set_Item)->seq_parameter_set_id==seq_parameter_set_Item_-(seq_parameter_sets.empty()?subset_seq_parameter_sets.begin():seq_parameter_sets.begin()))
         {
             if ((*pic_parameter_set_Item)->entropy_coding_mode_flag)
             {
@@ -1136,18 +1141,18 @@ void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq
             }
             break; //TODO: currently, testing only the first pic_parameter_set
         }
-    if ((*seq_parameter_set_Item)->max_num_ref_frames>0)
+    if (seq_parameter_set_Item->max_num_ref_frames>0)
     {
-        Fill(Stream_Video, 0, Video_Format_Settings, Ztring::ToZtring((*seq_parameter_set_Item)->max_num_ref_frames)+__T(" Ref Frames"));
-        Fill(Stream_Video, 0, Video_Codec_Settings, Ztring::ToZtring((*seq_parameter_set_Item)->max_num_ref_frames)+__T(" Ref Frames"));
-        Fill(Stream_Video, 0, Video_Format_Settings_RefFrames, (*seq_parameter_set_Item)->max_num_ref_frames);
-        Fill(Stream_Video, 0, Video_Codec_Settings_RefFrames, (*seq_parameter_set_Item)->max_num_ref_frames);
+        Fill(Stream_Video, 0, Video_Format_Settings, Ztring::ToZtring(seq_parameter_set_Item->max_num_ref_frames)+__T(" Ref Frames"));
+        Fill(Stream_Video, 0, Video_Codec_Settings, Ztring::ToZtring(seq_parameter_set_Item->max_num_ref_frames)+__T(" Ref Frames"));
+        Fill(Stream_Video, 0, Video_Format_Settings_RefFrames, seq_parameter_set_Item->max_num_ref_frames);
+        Fill(Stream_Video, 0, Video_Codec_Settings_RefFrames, seq_parameter_set_Item->max_num_ref_frames);
     }
     if (Retrieve(Stream_Video, 0, Video_ColorSpace).empty())
-        Fill(Stream_Video, 0, Video_ColorSpace, Avc_ChromaSubsampling_format_idc_ColorSpace((*seq_parameter_set_Item)->chroma_format_idc));
-    Fill(Stream_Video, 0, Video_ChromaSubsampling, Avc_ChromaSubsampling_format_idc((*seq_parameter_set_Item)->chroma_format_idc));
-    if ((*seq_parameter_set_Item)->bit_depth_luma_minus8==(*seq_parameter_set_Item)->bit_depth_chroma_minus8)
-        Fill(Stream_Video, 0, Video_BitDepth, (*seq_parameter_set_Item)->bit_depth_luma_minus8+8);
+        Fill(Stream_Video, 0, Video_ColorSpace, Avc_ChromaSubsampling_format_idc_ColorSpace(seq_parameter_set_Item->chroma_format_idc));
+    Fill(Stream_Video, 0, Video_ChromaSubsampling, Avc_ChromaSubsampling_format_idc(seq_parameter_set_Item->chroma_format_idc));
+    if (seq_parameter_set_Item->bit_depth_luma_minus8==seq_parameter_set_Item->bit_depth_chroma_minus8)
+        Fill(Stream_Video, 0, Video_BitDepth, seq_parameter_set_Item->bit_depth_luma_minus8+8);
     if (MaxSlicesCount>1)
         Fill(Stream_Video, 0, Video_Format_Settings_SliceCount, MaxSlicesCount);
 
@@ -1249,7 +1254,7 @@ void File_Avc::Streams_Finish()
     #endif //defined(MEDIAINFO_DTVCCTRANSPORT_YES)
 
     #if MEDIAINFO_IBIUSAGE
-        if (seq_parameter_sets.size()==1 && (*seq_parameter_sets.begin())->vui_parameters && (*seq_parameter_sets.begin())->vui_parameters->timing_info_present_flag && (*seq_parameter_sets.begin())->vui_parameters->fixed_frame_rate_flag)
+        if (seq_parameter_sets.size()==1 && (*seq_parameter_sets.begin())->vui_parameters && (*seq_parameter_sets.begin())->vui_parameters->time_scale && (*seq_parameter_sets.begin())->vui_parameters->fixed_frame_rate_flag)
             Ibi_Stream_Finish((*seq_parameter_sets.begin())->vui_parameters->time_scale, (*seq_parameter_sets.begin())->vui_parameters->num_units_in_tick);
     #endif //MEDIAINFO_IBIUSAGE
 }
@@ -2393,7 +2398,7 @@ void File_Avc::slice_header()
             (*seq_parameter_set_Item)->pic_struct_FirstDetected=bottom_field_flag?2:1; //2=BFF, 1=TFF
 
         //Saving some info
-        if ((*seq_parameter_set_Item)->vui_parameters && (*seq_parameter_set_Item)->vui_parameters->timing_info_present_flag && (*seq_parameter_set_Item)->vui_parameters->num_units_in_tick)
+        if ((*seq_parameter_set_Item)->vui_parameters && (*seq_parameter_set_Item)->vui_parameters->time_scale && (*seq_parameter_set_Item)->vui_parameters->num_units_in_tick)
             tc=float64_int64s(((float64)1000000000)/((float64)(*seq_parameter_set_Item)->vui_parameters->time_scale/(*seq_parameter_set_Item)->vui_parameters->num_units_in_tick/((*seq_parameter_set_Item)->pic_order_cnt_type==2?1:2)/FrameRate_Divider)/((!(*seq_parameter_set_Item)->frame_mbs_only_flag && field_pic_flag)?2:1));
 
         int32s TemporalReferences_Offset_pic_order_cnt_lsb_Diff=0;
@@ -2743,7 +2748,7 @@ void File_Avc::slice_header()
                 if (slice_type<9)
                     Element_Info1(__T("slice_type ")+Ztring().From_UTF8(Avc_slice_type[slice_type]));
                 Element_Info1(__T("frame_num ")+Ztring::ToZtring(frame_num));
-                if ((*seq_parameter_set_Item)->vui_parameters && (*seq_parameter_set_Item)->vui_parameters->fixed_frame_rate_flag)
+                if ((*seq_parameter_set_Item)->vui_parameters && (*seq_parameter_set_Item)->vui_parameters->flags[fixed_frame_rate_flag])
                 {
                     if (FrameInfo.PCR!=(int64u)-1)
                         Element_Info1(__T("PCR ")+Ztring().Duration_From_Milliseconds(float64_int64s(((float64)FrameInfo.PCR)/1000000)));
@@ -3088,7 +3093,7 @@ void File_Avc::sei_message_pic_timing(int32u /*payloadSize*/, int32u seq_paramet
         Skip_S4(cpb_removal_delay_length_minus1+1,              "cpb_removal_delay");
         Skip_S4(dpb_output_delay_length_minus1+1,               "dpb_output_delay");
     }
-    if ((*seq_parameter_set_Item)->vui_parameters && (*seq_parameter_set_Item)->vui_parameters->pic_struct_present_flag)
+    if ((*seq_parameter_set_Item)->vui_parameters && (*seq_parameter_set_Item)->vui_parameters->flags[pic_struct_present_flag])
     {
         Get_S1 (4, pic_struct,                                  "pic_struct");
         switch (pic_struct)
@@ -3149,7 +3154,7 @@ void File_Avc::sei_message_pic_timing(int32u /*payloadSize*/, int32u seq_paramet
                             n_frames=0;
                             FrameMax=0; //Unsupported type
                         }
-                        else if ((*seq_parameter_set_Item)->vui_parameters->fixed_frame_rate_flag && (*seq_parameter_set_Item)->vui_parameters->timing_info_present_flag && (*seq_parameter_set_Item)->vui_parameters->time_scale && (*seq_parameter_set_Item)->vui_parameters->num_units_in_tick)
+                        else if ((*seq_parameter_set_Item)->vui_parameters->flags[fixed_frame_rate_flag] && (*seq_parameter_set_Item)->vui_parameters->time_scale && (*seq_parameter_set_Item)->vui_parameters->time_scale && (*seq_parameter_set_Item)->vui_parameters->num_units_in_tick)
                             FrameMax=(int32u)(float64_int64s((float64)(*seq_parameter_set_Item)->vui_parameters->time_scale/(*seq_parameter_set_Item)->vui_parameters->num_units_in_tick/((*seq_parameter_set_Item)->frame_mbs_only_flag?2:(((*seq_parameter_set_Item)->pic_order_cnt_type==2 && Structure_Frame/2>Structure_Field)?1:2))/FrameRate_Divider)-1);
                         else if (n_frames>99)
                             FrameMax=n_frames;
@@ -3167,7 +3172,7 @@ void File_Avc::sei_message_pic_timing(int32u /*payloadSize*/, int32u seq_paramet
     BS_End();
 
     FILLING_BEGIN_PRECISE();
-        if ((*seq_parameter_set_Item)->pic_struct_FirstDetected==(int8u)-1 && (*seq_parameter_set_Item)->vui_parameters && (*seq_parameter_set_Item)->vui_parameters->pic_struct_present_flag)
+        if ((*seq_parameter_set_Item)->pic_struct_FirstDetected==(int8u)-1 && (*seq_parameter_set_Item)->vui_parameters && (*seq_parameter_set_Item)->vui_parameters->flags[pic_struct_present_flag])
             (*seq_parameter_set_Item)->pic_struct_FirstDetected=pic_struct;
     FILLING_END();
 }
@@ -3224,7 +3229,7 @@ void File_Avc::sei_message_user_data_registered_itu_t_t35_DTG1()
         File_AfdBarData DTG1_Parser;
         for (auto seq_parameter_set_Item : seq_parameter_sets)
         {
-            if (seq_parameter_set_Item && seq_parameter_set_Item->vui_parameters && seq_parameter_set_Item->vui_parameters->aspect_ratio_info_present_flag)
+            if (seq_parameter_set_Item && seq_parameter_set_Item->vui_parameters && seq_parameter_set_Item->vui_parameters->sar_width && seq_parameter_set_Item->vui_parameters->sar_height)
             {
                 //TODO: avoid duplicated code
                 int32u Width =(seq_parameter_set_Item->pic_width_in_mbs_minus1       +1)*16;
@@ -3238,16 +3243,11 @@ void File_Avc::sei_message_user_data_registered_itu_t_t35_DTG1()
                 Height-=(seq_parameter_set_Item->frame_crop_top_offset +seq_parameter_set_Item->frame_crop_bottom_offset)*CropUnitY;
                 if (Height)
                 {
-                    float64 PixelAspectRatio = 1;
-                    if (seq_parameter_set_Item->vui_parameters->aspect_ratio_idc<Avc_PixelAspectRatio_Size)
-                            PixelAspectRatio = Avc_PixelAspectRatio[seq_parameter_set_Item->vui_parameters->aspect_ratio_idc];
-                    else if (seq_parameter_set_Item->vui_parameters->aspect_ratio_idc == 0xFF && seq_parameter_set_Item->vui_parameters->sar_height)
-                            PixelAspectRatio = ((float64) seq_parameter_set_Item->vui_parameters->sar_width) / seq_parameter_set_Item->vui_parameters->sar_height;
+                    auto PixelAspectRatio=((float32)seq_parameter_set_Item->vui_parameters->sar_width) / seq_parameter_set_Item->vui_parameters->sar_height;
                     auto DAR=Width*PixelAspectRatio/Height;
                     if (DAR>=4.0/3.0*0.95 && DAR<4.0/3.0*1.05) DTG1_Parser.aspect_ratio_FromContainer=0; //4/3
                     if (DAR>=16.0/9.0*0.95 && DAR<16.0/9.0*1.05) DTG1_Parser.aspect_ratio_FromContainer=1; //16/9
                 }
-                break;
             }
         }
         Open_Buffer_Init(&DTG1_Parser);
@@ -3333,24 +3333,24 @@ void File_Avc::sei_message_user_data_registered_itu_t_t35_GA94_03_Delayed(int32u
             }
             if (((File_DtvccTransport*)GA94_03_Parser)->AspectRatio==0)
             {
-                float64 PixelAspectRatio=1;
-                std::vector<seq_parameter_set_struct*>::iterator seq_parameter_set_Item=seq_parameter_sets.begin();
-                for (; seq_parameter_set_Item!=seq_parameter_sets.end(); ++seq_parameter_set_Item)
-                    if ((*seq_parameter_set_Item))
+                std::vector<seq_parameter_set_struct*>::iterator seq_parameter_set_Item_=seq_parameter_sets.begin();
+                for (; seq_parameter_set_Item_!=seq_parameter_sets.end(); ++seq_parameter_set_Item_)
+                    if ((*seq_parameter_set_Item_))
                         break;
-                if (seq_parameter_set_Item!=seq_parameter_sets.end())
+                if (seq_parameter_set_Item_!=seq_parameter_sets.end())
                 {
-                    if (((*seq_parameter_set_Item)->vui_parameters) && ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_info_present_flag))
+                    const auto seq_parameter_set_Item=*seq_parameter_set_Item_;
+                    const auto vui_parameters=seq_parameter_set_Item->vui_parameters;
+                    if (vui_parameters && vui_parameters->sar_width && vui_parameters->sar_height)
                     {
-                        if ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc<Avc_PixelAspectRatio_Size)
-                            PixelAspectRatio=Avc_PixelAspectRatio[(*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc];
-                        else if ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc==0xFF && (*seq_parameter_set_Item)->vui_parameters->sar_height)
-                            PixelAspectRatio=((float64)(*seq_parameter_set_Item)->vui_parameters->sar_width)/(*seq_parameter_set_Item)->vui_parameters->sar_height;
+                        const int32u Width =(seq_parameter_set_Item->pic_width_in_mbs_minus1       +1)*16;
+                        const int32u Height=(seq_parameter_set_Item->pic_height_in_map_units_minus1+1)*16*(2-seq_parameter_set_Item->frame_mbs_only_flag);
+                        if (Height)
+                        {
+                            auto PixelAspectRatio=((float32)vui_parameters->sar_width)/vui_parameters->sar_height;
+                            ((File_DtvccTransport*)GA94_03_Parser)->AspectRatio=Width*PixelAspectRatio/Height;
+                        }
                     }
-                    const int32u Width =((*seq_parameter_set_Item)->pic_width_in_mbs_minus1       +1)*16;
-                    const int32u Height=((*seq_parameter_set_Item)->pic_height_in_map_units_minus1+1)*16*(2-(*seq_parameter_set_Item)->frame_mbs_only_flag);
-                    if(Height)
-                        ((File_DtvccTransport*)GA94_03_Parser)->AspectRatio=Width*PixelAspectRatio/Height;
                 }
             }
             if (GA94_03_Parser->PTS_DTS_Needed)
@@ -4439,25 +4439,36 @@ void File_Avc::vui_parameters(seq_parameter_set_struct::vui_parameters_struct* &
 {
     //Parsing
     seq_parameter_set_struct::vui_parameters_struct::xxl *NAL=NULL, *VCL=NULL;
-    int32u  num_units_in_tick=(int32u)-1, time_scale=(int32u)-1;
-    int16u  sar_width=(int16u)-1, sar_height=(int16u)-1;
-    int8u   aspect_ratio_idc=0, video_format=5, video_full_range_flag = 0, colour_primaries=2, transfer_characteristics=2, matrix_coefficients=2;
-    bool    aspect_ratio_info_present_flag, video_signal_type_present_flag, colour_description_present_flag=false, timing_info_present_flag, fixed_frame_rate_flag=false, nal_hrd_parameters_present_flag, vcl_hrd_parameters_present_flag, pic_struct_present_flag;
-    TEST_SB_GET (aspect_ratio_info_present_flag,                "aspect_ratio_info_present_flag");
-        Get_S1 (8, aspect_ratio_idc,                            "aspect_ratio_idc"); Param_Info1C((aspect_ratio_idc<Avc_PixelAspectRatio_Size), Avc_PixelAspectRatio[aspect_ratio_idc]);
+    bitset<vui_flags_Max> flags;
+    int32u  num_units_in_tick=0, time_scale=0;
+    int16u  sar_width=1, sar_height=1;
+    int8u   video_format=5, colour_primaries=2, transfer_characteristics=2, matrix_coefficients=2;
+    bool    nal_hrd_parameters_present_flag, vcl_hrd_parameters_present_flag;
+    TEST_SB_SKIP(                                               "aspect_ratio_info_present_flag");
+        int8u aspect_ratio_idc;
+        Get_S1 (8, aspect_ratio_idc,                            "aspect_ratio_idc"); Param_Info1C((aspect_ratio_idc<Avc_PixelAspectRatio_Size), ((float32)Avc_PixelAspectRatio[aspect_ratio_idc].w)/Avc_PixelAspectRatio[aspect_ratio_idc].h);
         if (aspect_ratio_idc==0xFF)
         {
             Get_S2 (16, sar_width,                              "sar_width");
             Get_S2 (16, sar_height,                             "sar_height");
         }
+        else if (aspect_ratio_idc < Avc_PixelAspectRatio_Size)
+        {
+            sar_width = Avc_PixelAspectRatio[aspect_ratio_idc].w;
+            sar_height = Avc_PixelAspectRatio[aspect_ratio_idc].h;
+        }
     TEST_SB_END();
     TEST_SB_SKIP(                                               "overscan_info_present_flag");
         Skip_SB(                                                "overscan_appropriate_flag");
     TEST_SB_END();
-    TEST_SB_GET (video_signal_type_present_flag,                "video_signal_type_present_flag");
+    TEST_SB_SKIP(                                               "video_signal_type_present_flag");
+        flags[video_signal_type_present_flag]=true;
+        bool video_full_range_flag_;
         Get_S1 (3, video_format,                                "video_format"); Param_Info1(Avc_video_format[video_format]);
-        Get_S1 (1, video_full_range_flag,                       "video_full_range_flag"); Param_Info1(Avc_video_full_range[video_full_range_flag]);
-        TEST_SB_GET (colour_description_present_flag,           "colour_description_present_flag");
+        Get_SB (   video_full_range_flag_,                      "video_full_range_flag"); Param_Info1(Avc_video_full_range[video_full_range_flag_]);
+        flags[video_full_range_flag]=video_full_range_flag_;
+        TEST_SB_SKIP(                                           "colour_description_present_flag");
+            flags[colour_description_present_flag]=true;
             Get_S1 (8, colour_primaries,                        "colour_primaries"); Param_Info1(Mpegv_colour_primaries(colour_primaries));
             Get_S1 (8, transfer_characteristics,                "transfer_characteristics"); Param_Info1(Mpegv_transfer_characteristics(transfer_characteristics));
             Get_S1 (8, matrix_coefficients,                     "matrix_coefficients"); Param_Info1(Mpegv_matrix_coefficients(matrix_coefficients));
@@ -4467,10 +4478,13 @@ void File_Avc::vui_parameters(seq_parameter_set_struct::vui_parameters_struct* &
         Skip_UE(                                                "chroma_sample_loc_type_top_field");
         Skip_UE(                                                "chroma_sample_loc_type_bottom_field");
     TEST_SB_END();
-    TEST_SB_GET (timing_info_present_flag,                      "timing_info_present_flag");
+    TEST_SB_SKIP(                                               "timing_info_present_flag");
+        flags[timing_info_present_flag]=true;
+        bool fixed_frame_rate_flag_;
         Get_S4 (32, num_units_in_tick,                          "num_units_in_tick");
         Get_S4 (32, time_scale,                                 "time_scale");
-        Get_SB (    fixed_frame_rate_flag,                      "fixed_frame_rate_flag");
+        Get_SB (    fixed_frame_rate_flag_,                     "fixed_frame_rate_flag");
+        flags[fixed_frame_rate_flag]=fixed_frame_rate_flag_;
     TEST_SB_END();
     TEST_SB_GET (nal_hrd_parameters_present_flag,               "nal_hrd_parameters_present_flag");
         hrd_parameters(NAL);
@@ -4480,7 +4494,9 @@ void File_Avc::vui_parameters(seq_parameter_set_struct::vui_parameters_struct* &
     TEST_SB_END();
     if (nal_hrd_parameters_present_flag || vcl_hrd_parameters_present_flag)
         Skip_SB(                                                "low_delay_hrd_flag");
-    Get_SB (   pic_struct_present_flag,                         "pic_struct_present_flag");
+    bool pic_struct_present_flag_;
+    Get_SB (   pic_struct_present_flag_,                        "pic_struct_present_flag");
+    flags[pic_struct_present_flag]=pic_struct_present_flag_;
     TEST_SB_SKIP(                                               "bitstream_restriction_flag");
         int32u  max_num_reorder_frames;
         Skip_SB(                                                "motion_vectors_over_pic_boundaries_flag");
@@ -4500,18 +4516,11 @@ void File_Avc::vui_parameters(seq_parameter_set_struct::vui_parameters_struct* &
                                                                                     time_scale,
                                                                                     sar_width,
                                                                                     sar_height,
-                                                                                    aspect_ratio_idc,
                                                                                     video_format,
-                                                                                    video_full_range_flag,
                                                                                     colour_primaries,
                                                                                     transfer_characteristics,
                                                                                     matrix_coefficients,
-                                                                                    aspect_ratio_info_present_flag,
-                                                                                    video_signal_type_present_flag,
-                                                                                    colour_description_present_flag,
-                                                                                    timing_info_present_flag,
-                                                                                    fixed_frame_rate_flag,
-                                                                                    pic_struct_present_flag
+                                                                                    flags
                                                                                 );
     FILLING_ELSE();
         delete NAL; NAL=NULL;

--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -330,7 +330,6 @@ struct par
 };
 extern const par Avc_PixelAspectRatio[] =
 {
-    {   1,   1 }, //Reserved
     {   1,   1 },
     {  12,  11 },
     {  10,  11 },
@@ -4441,21 +4440,25 @@ void File_Avc::vui_parameters(seq_parameter_set_struct::vui_parameters_struct* &
     seq_parameter_set_struct::vui_parameters_struct::xxl *NAL=NULL, *VCL=NULL;
     bitset<vui_flags_Max> flags;
     int32u  num_units_in_tick=0, time_scale=0;
-    int16u  sar_width=1, sar_height=1;
+    int16u  sar_width=0, sar_height=0;
     int8u   video_format=5, colour_primaries=2, transfer_characteristics=2, matrix_coefficients=2;
     bool    nal_hrd_parameters_present_flag, vcl_hrd_parameters_present_flag;
     TEST_SB_SKIP(                                               "aspect_ratio_info_present_flag");
         int8u aspect_ratio_idc;
-        Get_S1 (8, aspect_ratio_idc,                            "aspect_ratio_idc"); Param_Info1C((aspect_ratio_idc<Avc_PixelAspectRatio_Size), ((float32)Avc_PixelAspectRatio[aspect_ratio_idc].w)/Avc_PixelAspectRatio[aspect_ratio_idc].h);
+        Get_S1 (8, aspect_ratio_idc,                            "aspect_ratio_idc");
         if (aspect_ratio_idc==0xFF)
         {
             Get_S2 (16, sar_width,                              "sar_width");
             Get_S2 (16, sar_height,                             "sar_height");
         }
-        else if (aspect_ratio_idc < Avc_PixelAspectRatio_Size)
+        else if (aspect_ratio_idc && aspect_ratio_idc <= Avc_PixelAspectRatio_Size)
         {
-            sar_width = Avc_PixelAspectRatio[aspect_ratio_idc].w;
-            sar_height = Avc_PixelAspectRatio[aspect_ratio_idc].h;
+            aspect_ratio_idc--;
+            const auto& aspect_ratio = Avc_PixelAspectRatio[aspect_ratio_idc];
+            Param_Info1(aspect_ratio.w);
+            Param_Info1(aspect_ratio.h);
+            sar_width = aspect_ratio.w;
+            sar_height = aspect_ratio.h;
         }
     TEST_SB_END();
     TEST_SB_SKIP(                                               "overscan_info_present_flag");

--- a/Source/MediaInfo/Video/File_Avc.h
+++ b/Source/MediaInfo/Video/File_Avc.h
@@ -13,7 +13,9 @@
 #include "MediaInfo/File__Analyze.h"
 #include "MediaInfo/File__Duplicate.h"
 #include "MediaInfo/TimeCode.h"
+#include <bitset>
 #include <cmath>
+
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
@@ -83,6 +85,17 @@ private :
 #endif //MEDIAINFO_DEMUX
     };
 
+    enum vui_flag
+    {
+        video_signal_type_present_flag,
+        video_full_range_flag,
+        colour_description_present_flag,
+        timing_info_present_flag,
+        fixed_frame_rate_flag,
+        pic_struct_present_flag,
+        vui_flags_Max
+    };
+    typedef std::bitset<vui_flags_Max> vui_flags;
     struct seq_parameter_set_struct : public iso14496_base
     {
         struct vui_parameters_struct
@@ -168,20 +181,13 @@ private :
             int32u  time_scale;
             int16u  sar_width;
             int16u  sar_height;
-            int8u   aspect_ratio_idc;
             int8u   video_format;
-            int8u   video_full_range_flag;
             int8u   colour_primaries;
             int8u   transfer_characteristics;
             int8u   matrix_coefficients;
-            bool    aspect_ratio_info_present_flag;
-            bool    video_signal_type_present_flag;
-            bool    colour_description_present_flag;
-            bool    timing_info_present_flag;
-            bool    fixed_frame_rate_flag;
-            bool    pic_struct_present_flag;
+            vui_flags flags;
 
-            vui_parameters_struct(xxl* NAL_, xxl* VCL_, int32u num_units_in_tick_, int32u time_scale_, int16u  sar_width_, int16u  sar_height_, int8u aspect_ratio_idc_, int8u video_format_, int8u video_full_range_flag_, int8u colour_primaries_, int8u transfer_characteristics_, int8u matrix_coefficients_, bool aspect_ratio_info_present_flag_, bool video_signal_type_present_flag_, bool colour_description_present_flag_, bool timing_info_present_flag_, bool fixed_frame_rate_flag_, bool pic_struct_present_flag_)
+            vui_parameters_struct(xxl* NAL_, xxl* VCL_, int32u num_units_in_tick_, int32u time_scale_, int16u  sar_width_, int16u  sar_height_, int8u video_format_, int8u colour_primaries_, int8u transfer_characteristics_, int8u matrix_coefficients_, vui_flags flags_)
                 :
                 NAL(NAL_),
                 VCL(VCL_),
@@ -189,18 +195,11 @@ private :
                 time_scale(time_scale_),
                 sar_width(sar_width_),
                 sar_height(sar_height_),
-                aspect_ratio_idc(aspect_ratio_idc_),
                 video_format(video_format_),
-                video_full_range_flag(video_full_range_flag_),
                 colour_primaries(colour_primaries_),
                 transfer_characteristics(transfer_characteristics_),
                 matrix_coefficients(matrix_coefficients_),
-                aspect_ratio_info_present_flag(aspect_ratio_info_present_flag_),
-                video_signal_type_present_flag(video_signal_type_present_flag_),
-                colour_description_present_flag(colour_description_present_flag_),
-                timing_info_present_flag(timing_info_present_flag_),
-                fixed_frame_rate_flag(fixed_frame_rate_flag_),
-                pic_struct_present_flag(pic_struct_present_flag_)
+                flags(flags_)
             {
             }
 

--- a/Source/MediaInfo/Video/File_Hevc.cpp
+++ b/Source/MediaInfo/Video/File_Hevc.cpp
@@ -4206,22 +4206,25 @@ void File_Hevc::vui_parameters(seq_parameter_set_struct::vui_parameters_struct* 
     seq_parameter_set_struct::vui_parameters_struct::xxl *NAL = NULL, *VCL = NULL;
     vui_flags flags;
     int32u  num_units_in_tick=0, time_scale=0;
-    int16u  sar_width=1, sar_height=1;
+    int16u  sar_width=0, sar_height=0;
     int8u   video_format=5, colour_primaries=2, transfer_characteristics=2, matrix_coefficients=2;
     bool flag;
     TEST_SB_SKIP(                                               "aspect_ratio_info_present_flag");
         int8u aspect_ratio_idc=0;
-        Get_S1 (8, aspect_ratio_idc,                            "aspect_ratio_idc"); Param_Info1C((aspect_ratio_idc < Avc_PixelAspectRatio_Size), ((float32)Avc_PixelAspectRatio[aspect_ratio_idc].w)/Avc_PixelAspectRatio[aspect_ratio_idc].h);
+        Get_S1 (8, aspect_ratio_idc,                            "aspect_ratio_idc");
         if (aspect_ratio_idc==0xFF)
         {
             Get_S2 (16, sar_width,                              "sar_width");
             Get_S2 (16, sar_height,                             "sar_height");
         }
-        else if (aspect_ratio_idc<Avc_PixelAspectRatio_Size)
+        else if (aspect_ratio_idc && aspect_ratio_idc <= Avc_PixelAspectRatio_Size)
         {
-            const auto& aspect_ratio=Avc_PixelAspectRatio[aspect_ratio_idc];
-            sar_width=aspect_ratio.w;
-            sar_height=aspect_ratio.h;
+            aspect_ratio_idc--;
+            const auto& aspect_ratio = Avc_PixelAspectRatio[aspect_ratio_idc];
+            Param_Info1(aspect_ratio.w);
+            Param_Info1(aspect_ratio.h);
+            sar_width = aspect_ratio.w;
+            sar_height = aspect_ratio.h;
         }
     TEST_SB_END();
     TEST_SB_SKIP(                                               "overscan_info_present_flag");

--- a/Source/MediaInfo/Video/File_Hevc.cpp
+++ b/Source/MediaInfo/Video/File_Hevc.cpp
@@ -168,8 +168,13 @@ extern const char* Mpegv_matrix_coefficients(int8u matrix_coefficients);
 const char* Mpegv_matrix_coefficients_ColorSpace(int8u matrix_coefficients);
 
 //---------------------------------------------------------------------------
-extern const int8u Avc_PixelAspectRatio_Size;
-extern const float32 Avc_PixelAspectRatio[];
+struct par
+{
+    int8u w;
+    int8u h;
+};
+extern const par Avc_PixelAspectRatio[];
+extern const size_t Avc_PixelAspectRatio_Size;
 extern const char* Avc_video_format[];
 extern const char* Avc_video_full_range[];
 
@@ -435,71 +440,64 @@ void File_Hevc::Streams_Fill(std::vector<video_parameter_set_struct*>::iterator 
 }
 
 //---------------------------------------------------------------------------
-void File_Hevc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq_parameter_set_Item)
+void File_Hevc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq_parameter_set_Item_)
 {
-    if ((*seq_parameter_set_Item)->nuh_layer_id)
+    auto seq_parameter_set_Item = *seq_parameter_set_Item_;
+    if (seq_parameter_set_Item->nuh_layer_id)
         return;
 
-    int32u Width = (*seq_parameter_set_Item)->pic_width_in_luma_samples;
-    int32u Height= (*seq_parameter_set_Item)->pic_height_in_luma_samples;
-    int8u chromaArrayType = (*seq_parameter_set_Item)->ChromaArrayType();
+    int32u Width = seq_parameter_set_Item->pic_width_in_luma_samples;
+    int32u Height= seq_parameter_set_Item->pic_height_in_luma_samples;
+    int8u chromaArrayType = seq_parameter_set_Item->ChromaArrayType();
     if (chromaArrayType >= 4)
         chromaArrayType = 0;
     int32u CropUnitX=Hevc_SubWidthC [chromaArrayType];
     int32u CropUnitY=Hevc_SubHeightC[chromaArrayType];
-    Width -=((*seq_parameter_set_Item)->conf_win_left_offset+(*seq_parameter_set_Item)->conf_win_right_offset)*CropUnitX;
-    Height-=((*seq_parameter_set_Item)->conf_win_top_offset +(*seq_parameter_set_Item)->conf_win_bottom_offset)*CropUnitY;
+    Width -=(seq_parameter_set_Item->conf_win_left_offset+seq_parameter_set_Item->conf_win_right_offset)*CropUnitX;
+    Height-=(seq_parameter_set_Item->conf_win_top_offset +seq_parameter_set_Item->conf_win_bottom_offset)*CropUnitY;
 
-    const auto& p=(*seq_parameter_set_Item)->profile_tier_level_info;
+    const auto& p=seq_parameter_set_Item->profile_tier_level_info;
     Streams_Fill_Profile(p);
     Fill(Stream_Video, StreamPos_Last, Video_Width, Width);
     Fill(Stream_Video, StreamPos_Last, Video_Height, Height);
-    if ((*seq_parameter_set_Item)->conf_win_left_offset || (*seq_parameter_set_Item)->conf_win_right_offset)
-        Fill(Stream_Video, StreamPos_Last, Video_Stored_Width, (*seq_parameter_set_Item)->pic_width_in_luma_samples);
-    if ((*seq_parameter_set_Item)->conf_win_top_offset || (*seq_parameter_set_Item)->conf_win_bottom_offset)
-        Fill(Stream_Video, StreamPos_Last, Video_Stored_Height, (*seq_parameter_set_Item)->pic_height_in_luma_samples);
+    if (seq_parameter_set_Item->conf_win_left_offset || seq_parameter_set_Item->conf_win_right_offset)
+        Fill(Stream_Video, StreamPos_Last, Video_Stored_Width, seq_parameter_set_Item->pic_width_in_luma_samples);
+    if (seq_parameter_set_Item->conf_win_top_offset || seq_parameter_set_Item->conf_win_bottom_offset)
+        Fill(Stream_Video, StreamPos_Last, Video_Stored_Height, seq_parameter_set_Item->pic_height_in_luma_samples);
 
-    Fill(Stream_Video, 0, Video_ColorSpace, Hevc_chroma_format_idc_ColorSpace((*seq_parameter_set_Item)->chroma_format_idc));
-    Fill(Stream_Video, 0, Video_ChromaSubsampling, Hevc_chroma_format_idc((*seq_parameter_set_Item)->chroma_format_idc));
-    if ((*seq_parameter_set_Item)->bit_depth_luma_minus8==(*seq_parameter_set_Item)->bit_depth_chroma_minus8)
-        Fill(Stream_Video, 0, Video_BitDepth, (*seq_parameter_set_Item)->bit_depth_luma_minus8+8);
+    Fill(Stream_Video, 0, Video_ColorSpace, Hevc_chroma_format_idc_ColorSpace(seq_parameter_set_Item->chroma_format_idc));
+    Fill(Stream_Video, 0, Video_ChromaSubsampling, Hevc_chroma_format_idc(seq_parameter_set_Item->chroma_format_idc));
+    if (seq_parameter_set_Item->bit_depth_luma_minus8==seq_parameter_set_Item->bit_depth_chroma_minus8)
+        Fill(Stream_Video, 0, Video_BitDepth, seq_parameter_set_Item->bit_depth_luma_minus8+8);
 
     if (preferred_transfer_characteristics!=2)
         Fill(Stream_Video, 0, Video_transfer_characteristics, Mpegv_transfer_characteristics(preferred_transfer_characteristics));
-    if ((*seq_parameter_set_Item)->vui_parameters)
+    const auto vui_parameters = seq_parameter_set_Item->vui_parameters;
+    if (vui_parameters)
     {
-        if ((*seq_parameter_set_Item)->vui_parameters->timing_info_present_flag)
+        if (vui_parameters->time_scale && vui_parameters->num_units_in_tick)
+            Fill(Stream_Video, StreamPos_Last, Video_FrameRate, (float32)vui_parameters->time_scale / vui_parameters->num_units_in_tick);
+
+        if (vui_parameters->sar_width && vui_parameters->sar_height)
         {
-                if ((*seq_parameter_set_Item)->vui_parameters->time_scale && (*seq_parameter_set_Item)->vui_parameters->num_units_in_tick)
-                        Fill(Stream_Video, StreamPos_Last, Video_FrameRate, (float64)(*seq_parameter_set_Item)->vui_parameters->time_scale / (*seq_parameter_set_Item)->vui_parameters->num_units_in_tick);
+            auto PixelAspectRatio = ((float32)vui_parameters->sar_width) / vui_parameters->sar_height;
+            Fill(Stream_Video, 0, Video_PixelAspectRatio, PixelAspectRatio, 3, true);
+            if (Width && Height)
+                Fill(Stream_Video, 0, Video_DisplayAspectRatio, Width*PixelAspectRatio/Height, 3, true); //More precise
         }
 
-        if ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_info_present_flag)
+        if (vui_parameters->flags[video_signal_type_present_flag])
         {
-                float64 PixelAspectRatio = 1;
-                if ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc<Avc_PixelAspectRatio_Size)
-                        PixelAspectRatio = Avc_PixelAspectRatio[(*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc];
-                else if ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc == 0xFF && (*seq_parameter_set_Item)->vui_parameters->sar_height)
-                        PixelAspectRatio = ((float64) (*seq_parameter_set_Item)->vui_parameters->sar_width) / (*seq_parameter_set_Item)->vui_parameters->sar_height;
-
-                Fill(Stream_Video, 0, Video_PixelAspectRatio, PixelAspectRatio, 3, true);
-                if(Height)
-                   Fill(Stream_Video, 0, Video_DisplayAspectRatio, Width*PixelAspectRatio/Height, 3, true); //More precise
-        }
-
-        //Colour description
-        if ((*seq_parameter_set_Item)->vui_parameters->video_signal_type_present_flag)
-        {
-            Fill(Stream_Video, 0, Video_Standard, Avc_video_format[(*seq_parameter_set_Item)->vui_parameters->video_format]);
-            Fill(Stream_Video, 0, Video_colour_range, Avc_video_full_range[(*seq_parameter_set_Item)->vui_parameters->video_full_range_flag]);
-            if ((*seq_parameter_set_Item)->vui_parameters->colour_description_present_flag)
+            Fill(Stream_Video, 0, Video_Standard, Avc_video_format[vui_parameters->video_format]);
+            Fill(Stream_Video, 0, Video_colour_range, Avc_video_full_range[vui_parameters->flags[video_full_range_flag]]);
+            if (vui_parameters->flags[colour_description_present_flag])
             {
                 Fill(Stream_Video, 0, Video_colour_description_present, "Yes");
-                Fill(Stream_Video, 0, Video_colour_primaries, Mpegv_colour_primaries((*seq_parameter_set_Item)->vui_parameters->colour_primaries));
-                Fill(Stream_Video, 0, Video_transfer_characteristics, Mpegv_transfer_characteristics((*seq_parameter_set_Item)->vui_parameters->transfer_characteristics));
-                Fill(Stream_Video, 0, Video_matrix_coefficients, Mpegv_matrix_coefficients((*seq_parameter_set_Item)->vui_parameters->matrix_coefficients));
-                if ((*seq_parameter_set_Item)->vui_parameters->matrix_coefficients!=2)
-                    Fill(Stream_Video, 0, Video_ColorSpace, Mpegv_matrix_coefficients_ColorSpace((*seq_parameter_set_Item)->vui_parameters->matrix_coefficients), Unlimited, true, true);
+                Fill(Stream_Video, 0, Video_colour_primaries, Mpegv_colour_primaries(vui_parameters->colour_primaries));
+                Fill(Stream_Video, 0, Video_transfer_characteristics, Mpegv_transfer_characteristics(vui_parameters->transfer_characteristics));
+                Fill(Stream_Video, 0, Video_matrix_coefficients, Mpegv_matrix_coefficients(vui_parameters->matrix_coefficients));
+                if (vui_parameters->matrix_coefficients!=2)
+                    Fill(Stream_Video, 0, Video_ColorSpace, Mpegv_matrix_coefficients_ColorSpace(vui_parameters->matrix_coefficients), Unlimited, true, true);
             }
         }
     }
@@ -2665,7 +2663,7 @@ void File_Hevc::sei_message_pic_timing(int32u &seq_parameter_set_id, int32u payl
 
     //Parsing
     BS_Begin();
-    if ((*seq_parameter_set_Item)->vui_parameters?(*seq_parameter_set_Item)->vui_parameters->frame_field_info_present_flag:((*seq_parameter_set_Item)->profile_tier_level_info.general_progressive_source_flag && (*seq_parameter_set_Item)->profile_tier_level_info.general_interlaced_source_flag))
+    if ((*seq_parameter_set_Item)->vui_parameters?(*seq_parameter_set_Item)->vui_parameters->flags[frame_field_info_present_flag]:((*seq_parameter_set_Item)->profile_tier_level_info.general_progressive_source_flag && (*seq_parameter_set_Item)->profile_tier_level_info.general_interlaced_source_flag))
     {
         Skip_S1(4,                                              "pic_struct");
         Skip_S1(2,                                              "source_scan_type");
@@ -2746,7 +2744,7 @@ void File_Hevc::sei_message_user_data_registered_itu_t_t35_B5_0031_DTG1()
         File_AfdBarData DTG1_Parser;
         for (auto seq_parameter_set_Item : seq_parameter_sets)
         {
-            if (seq_parameter_set_Item && seq_parameter_set_Item->vui_parameters && seq_parameter_set_Item->vui_parameters->aspect_ratio_info_present_flag)
+            if (seq_parameter_set_Item && seq_parameter_set_Item->vui_parameters && seq_parameter_set_Item->vui_parameters->sar_width && seq_parameter_set_Item->vui_parameters->sar_height)
             {
                 //TODO: avoid duplicated code
                 int32u Width = seq_parameter_set_Item->pic_width_in_luma_samples;
@@ -2760,11 +2758,7 @@ void File_Hevc::sei_message_user_data_registered_itu_t_t35_B5_0031_DTG1()
                 Height-=(seq_parameter_set_Item->conf_win_top_offset +seq_parameter_set_Item->conf_win_bottom_offset)*CropUnitY;
                 if (Height)
                 {
-                    float64 PixelAspectRatio = 1;
-                    if (seq_parameter_set_Item->vui_parameters->aspect_ratio_idc<Avc_PixelAspectRatio_Size)
-                            PixelAspectRatio = Avc_PixelAspectRatio[seq_parameter_set_Item->vui_parameters->aspect_ratio_idc];
-                    else if (seq_parameter_set_Item->vui_parameters->aspect_ratio_idc == 0xFF && seq_parameter_set_Item->vui_parameters->sar_height)
-                            PixelAspectRatio = ((float64) seq_parameter_set_Item->vui_parameters->sar_width) / seq_parameter_set_Item->vui_parameters->sar_height;
+                    float32 PixelAspectRatio=((float32)seq_parameter_set_Item->vui_parameters->sar_width) / seq_parameter_set_Item->vui_parameters->sar_height;
                     auto DAR=Width*PixelAspectRatio/Height;
                     if (DAR>=4.0/3.0*0.95 && DAR<4.0/3.0*1.05) DTG1_Parser.aspect_ratio_FromContainer=0; //4/3
                     if (DAR>=16.0/9.0*0.95 && DAR<16.0/9.0*1.05) DTG1_Parser.aspect_ratio_FromContainer=1; //16/9
@@ -2855,24 +2849,24 @@ void File_Hevc::sei_message_user_data_registered_itu_t_t35_B5_0031_GA94_03_Delay
             }
             if (((File_DtvccTransport*)GA94_03_Parser)->AspectRatio==0)
             {
-                float64 PixelAspectRatio=1;
-                std::vector<seq_parameter_set_struct*>::iterator seq_parameter_set_Item=seq_parameter_sets.begin();
-                for (; seq_parameter_set_Item!=seq_parameter_sets.end(); ++seq_parameter_set_Item)
-                    if ((*seq_parameter_set_Item))
+                std::vector<seq_parameter_set_struct*>::iterator seq_parameter_set_Item_=seq_parameter_sets.begin();
+                for (; seq_parameter_set_Item_!=seq_parameter_sets.end(); ++seq_parameter_set_Item_)
+                    if ((*seq_parameter_set_Item_))
                         break;
-                if (seq_parameter_set_Item!=seq_parameter_sets.end())
+                if (seq_parameter_set_Item_!=seq_parameter_sets.end())
                 {
-                    if (((*seq_parameter_set_Item)->vui_parameters) && ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_info_present_flag))
+                    const auto seq_parameter_set_Item=*seq_parameter_set_Item_;
+                    const auto vui_parameters=seq_parameter_set_Item->vui_parameters;
+                    if (vui_parameters && vui_parameters->sar_width && vui_parameters->sar_height)
                     {
-                        if ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc<Avc_PixelAspectRatio_Size)
-                            PixelAspectRatio=Avc_PixelAspectRatio[(*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc];
-                        else if ((*seq_parameter_set_Item)->vui_parameters->aspect_ratio_idc==0xFF && (*seq_parameter_set_Item)->vui_parameters->sar_height)
-                            PixelAspectRatio=((float64)(*seq_parameter_set_Item)->vui_parameters->sar_width)/(*seq_parameter_set_Item)->vui_parameters->sar_height;
+                        const int32u Width =seq_parameter_set_Item->pic_width_in_luma_samples;
+                        const int32u Height=seq_parameter_set_Item->pic_height_in_luma_samples;
+                        if (Height)
+                        {
+                            auto PixelAspectRatio=((float32)seq_parameter_set_Item->vui_parameters->sar_width)/seq_parameter_set_Item->vui_parameters->sar_height;
+                            ((File_DtvccTransport*)GA94_03_Parser)->AspectRatio=Width*PixelAspectRatio/Height;
+                        }
                     }
-                    const int32u Width =(*seq_parameter_set_Item)->pic_width_in_luma_samples;
-                    const int32u Height=(*seq_parameter_set_Item)->pic_height_in_luma_samples;
-                    if(Height)
-                        ((File_DtvccTransport*)GA94_03_Parser)->AspectRatio=Width*PixelAspectRatio/Height;
                 }
             }
             if (GA94_03_Parser->PTS_DTS_Needed)
@@ -4210,25 +4204,37 @@ void File_Hevc::vui_parameters(seq_parameter_set_struct::vui_parameters_struct* 
     //Parsing
     seq_parameter_set_struct::vui_parameters_struct::xxl_common *xxL_Common=NULL;
     seq_parameter_set_struct::vui_parameters_struct::xxl *NAL = NULL, *VCL = NULL;
-    int32u  num_units_in_tick = (int32u)-1, time_scale = (int32u)-1;
-    int16u  sar_width=(int16u)-1, sar_height=(int16u)-1;
-    int8u   aspect_ratio_idc=0, video_format=5, video_full_range_flag=0, colour_primaries=2, transfer_characteristics=2, matrix_coefficients=2;
-    bool    aspect_ratio_info_present_flag, video_signal_type_present_flag, frame_field_info_present_flag, colour_description_present_flag=false, timing_info_present_flag;
-    TEST_SB_GET (aspect_ratio_info_present_flag,                "aspect_ratio_info_present_flag");
-        Get_S1 (8, aspect_ratio_idc,                            "aspect_ratio_idc"); Param_Info1C((aspect_ratio_idc<Avc_PixelAspectRatio_Size), Avc_PixelAspectRatio[aspect_ratio_idc]);
+    vui_flags flags;
+    int32u  num_units_in_tick=0, time_scale=0;
+    int16u  sar_width=1, sar_height=1;
+    int8u   video_format=5, colour_primaries=2, transfer_characteristics=2, matrix_coefficients=2;
+    bool flag;
+    TEST_SB_SKIP(                                               "aspect_ratio_info_present_flag");
+        int8u aspect_ratio_idc=0;
+        Get_S1 (8, aspect_ratio_idc,                            "aspect_ratio_idc"); Param_Info1C((aspect_ratio_idc < Avc_PixelAspectRatio_Size), ((float32)Avc_PixelAspectRatio[aspect_ratio_idc].w)/Avc_PixelAspectRatio[aspect_ratio_idc].h);
         if (aspect_ratio_idc==0xFF)
         {
             Get_S2 (16, sar_width,                              "sar_width");
             Get_S2 (16, sar_height,                             "sar_height");
         }
+        else if (aspect_ratio_idc<Avc_PixelAspectRatio_Size)
+        {
+            const auto& aspect_ratio=Avc_PixelAspectRatio[aspect_ratio_idc];
+            sar_width=aspect_ratio.w;
+            sar_height=aspect_ratio.h;
+        }
     TEST_SB_END();
     TEST_SB_SKIP(                                               "overscan_info_present_flag");
         Skip_SB(                                                "overscan_appropriate_flag");
     TEST_SB_END();
-    TEST_SB_GET (video_signal_type_present_flag,                "video_signal_type_present_flag");
+    TEST_SB_SKIP(                                               "video_signal_type_present_flag");
+        flags[video_signal_type_present_flag]=true;
+        bool video_full_range_flag_;
         Get_S1 (3, video_format,                                "video_format"); Param_Info1(Avc_video_format[video_format]);
-        Get_S1 (1, video_full_range_flag,                       "video_full_range_flag"); Param_Info1(Avc_video_full_range[video_full_range_flag]);
-        TEST_SB_GET (colour_description_present_flag,           "colour_description_present_flag");
+        Get_SB (   video_full_range_flag_,                      "video_full_range_flag"); Param_Info1(Avc_video_full_range[video_full_range_flag_]);
+        flags[video_full_range_flag]=video_full_range_flag_;
+        TEST_SB_SKIP(                                           "colour_description_present_flag");
+            flags[colour_description_present_flag]=true;
             Get_S1 (8, colour_primaries,                        "colour_primaries"); Param_Info1(Mpegv_colour_primaries(colour_primaries));
             Get_S1 (8, transfer_characteristics,                "transfer_characteristics"); Param_Info1(Mpegv_transfer_characteristics(transfer_characteristics));
             Get_S1 (8, matrix_coefficients,                     "matrix_coefficients"); Param_Info1(Mpegv_matrix_coefficients(matrix_coefficients));
@@ -4240,14 +4246,15 @@ void File_Hevc::vui_parameters(seq_parameter_set_struct::vui_parameters_struct* 
     TEST_SB_END();
     Skip_SB(                                                    "neutral_chroma_indication_flag");
     Skip_SB(                                                    "field_seq_flag");
-    Get_SB (   frame_field_info_present_flag,                   "frame_field_info_present_flag");
+    Get_SB (   flag,                                            "frame_field_info_present_flag");
+    flags[frame_field_info_present_flag]=flag;
     TEST_SB_SKIP(                                               "default_display_window_flag ");
         Skip_UE(                                                "def_disp_win_left_offset");
         Skip_UE(                                                "def_disp_win_right_offset");
         Skip_UE(                                                "def_disp_win_top_offset");
         Skip_UE(                                                "def_disp_win_bottom_offset");
     TEST_SB_END();
-    TEST_SB_GET (timing_info_present_flag,                      "timing_info_present_flag");
+    TEST_SB_SKIP(                                               "timing_info_present_flag");
         Get_S4 (32, num_units_in_tick,                          "num_units_in_tick");
         Get_S4 (32, time_scale,                                 "time_scale");
         TEST_SB_SKIP(                                           "vui_poc_proportional_to_timing_flag");
@@ -4277,17 +4284,11 @@ void File_Hevc::vui_parameters(seq_parameter_set_struct::vui_parameters_struct* 
                                                                                     time_scale,
                                                                                     sar_width,
                                                                                     sar_height,
-                                                                                    aspect_ratio_idc,
                                                                                     video_format,
-                                                                                    video_full_range_flag,
                                                                                     colour_primaries,
                                                                                     transfer_characteristics,
                                                                                     matrix_coefficients,
-                                                                                    aspect_ratio_info_present_flag,
-                                                                                    video_signal_type_present_flag,
-                                                                                    frame_field_info_present_flag,
-                                                                                    colour_description_present_flag,
-                                                                                    timing_info_present_flag
+                                                                                    flags
                                                                                   );
     FILLING_ELSE();
     delete xxL_Common; xxL_Common=NULL;

--- a/Source/MediaInfo/Video/File_Hevc.h
+++ b/Source/MediaInfo/Video/File_Hevc.h
@@ -110,6 +110,16 @@ private :
     typedef vector<video_parameter_set_struct*> video_parameter_set_structs;
 
     //Structures - seq_parameter_set
+    enum vui_flag
+    {
+        video_signal_type_present_flag,
+        video_full_range_flag,
+        colour_description_present_flag,
+        pic_struct_present_flag,
+        frame_field_info_present_flag,
+        vui_flags_Max
+    };
+    typedef std::bitset<vui_flags_Max> vui_flags;
     struct seq_parameter_set_struct
     {
         struct vui_parameters_struct
@@ -183,19 +193,13 @@ private :
             int32u  time_scale;
             int16u  sar_width;
             int16u  sar_height;
-            int8u   aspect_ratio_idc;
             int8u   video_format;
-            int8u   video_full_range_flag;
             int8u   colour_primaries;
             int8u   transfer_characteristics;
             int8u   matrix_coefficients;
-            bool    aspect_ratio_info_present_flag;
-            bool    video_signal_type_present_flag;
-            bool    frame_field_info_present_flag;
-            bool    colour_description_present_flag;
-            bool    timing_info_present_flag;
+            vui_flags flags;
 
-            vui_parameters_struct(xxl* NAL_, xxl* VCL_, xxl_common* xxL_Common_, int32u num_units_in_tick_, int32u time_scale_, int16u sar_width_, int16u sar_height_, int8u aspect_ratio_idc_, int8u video_format_, int8u video_full_range_flag_, int8u colour_primaries_, int8u transfer_characteristics_, int8u matrix_coefficients_, bool aspect_ratio_info_present_flag_, bool video_signal_type_present_flag_, bool frame_field_info_present_flag_, bool colour_description_present_flag_, bool timing_info_present_flag_)
+            vui_parameters_struct(xxl* NAL_, xxl* VCL_, xxl_common* xxL_Common_, int32u num_units_in_tick_, int32u time_scale_, int16u sar_width_, int16u sar_height_, int8u video_format_, int8u colour_primaries_, int8u transfer_characteristics_, int8u matrix_coefficients_, vui_flags flags_)
                 :
                 NAL(NAL_),
                 VCL(VCL_),
@@ -204,17 +208,11 @@ private :
                 time_scale(time_scale_),
                 sar_width(sar_width_),
                 sar_height(sar_height_),
-                aspect_ratio_idc(aspect_ratio_idc_),
                 video_format(video_format_),
-                video_full_range_flag(video_full_range_flag_),
                 colour_primaries(colour_primaries_),
                 transfer_characteristics(transfer_characteristics_),
                 matrix_coefficients(matrix_coefficients_),
-                aspect_ratio_info_present_flag(aspect_ratio_info_present_flag_),
-                video_signal_type_present_flag(video_signal_type_present_flag_),
-                frame_field_info_present_flag(frame_field_info_present_flag_),
-                colour_description_present_flag(colour_description_present_flag_),
-                timing_info_present_flag(timing_info_present_flag_)
+                flags(flags_)
             {
             }
 


### PR DESCRIPTION
Specs: "When aspect_ratio_idc is equal to 0 or sar_width is equal to 0 or sar_height is equal to 0, the sample aspect ratio is unspecified in this Specification".