### PR TITLE
ARM64: Enable Signed Returns / Pointer Authentication

### DIFF
--- a/Project/MSVC2022/Dll/MediaInfoDll.vcxproj
+++ b/Project/MSVC2022/Dll/MediaInfoDll.vcxproj
@@ -251,6 +251,7 @@
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
+      <GuardSignedReturns>true</GuardSignedReturns>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Project/MSVC2022/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2022/Library/MediaInfoLib.vcxproj
@@ -235,6 +235,7 @@
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
+      <GuardSignedReturns>true</GuardSignedReturns>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/Project/MSVC2022/ShellExtension/MediaInfoShellExt.vcxproj
+++ b/Project/MSVC2022/ShellExtension/MediaInfoShellExt.vcxproj
@@ -350,6 +350,7 @@
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
+      <GuardSignedReturns>true</GuardSignedReturns>
     </ClCompile>
     <ResourceCompile>
       <Culture>0x0409</Culture>


### PR DESCRIPTION
Since we have enabled all security mitigations that we know for x86/x64 (except Spectre), let's enable all for ARM64 as well.

Depends on:
- [ ] https://github.com/MediaArea/zlib/pull/20
- [ ] https://github.com/MediaArea/ZenLib/pull/164