### PR TITLE
ARM64EC: Resolve Compiler Warning C4163

### DIFF
--- a/Source/ThirdParty/aes-gladman/aes_ni.c
+++ b/Source/ThirdParty/aes-gladman/aes_ni.c
@@ -22,7 +22,9 @@ Issue Date: 13/11/2013
 
 #if defined( USE_INTEL_AES_IF_PRESENT )
 
+#ifndef _ARM64EC_
 #pragma intrinsic(__cpuid)
+#endif // !_ARM64EC_
 
 __inline int has_aes_ni()
 {


### PR DESCRIPTION
`_M_AMD64` is defined in ARM64EC mode causing `USE_INTEL_AES_IF_PRESENT` to be defined and the Intel AES intrinsics do actually work via `softintrin`. However, `#pragma intrinsic(__cpuid)` causes [Compiler Warning C4163](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4163?view=msvc-170) since it is not actually an intrinsic in ARM64EC mode. This PR adds a guard that excludes this line in ARM64EC mode.