### PR TITLE
MP4: Handle more metadata

### DIFF
--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -1168,6 +1168,7 @@ void MediaInfo_Config_DefaultLanguage (Translation &Info)
     "SamplesPerFrame;Samples per frame\n"
     "SamplingCount;Samples count\n"
     "SamplingRate;Sampling rate\n"
+    "Samsung_Model_Number;Samsung model number\n"
     "Save;Save\n"
     "ScanOrder;Scan order\n"
     "ScanOrder_Original;Original scan order\n"

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -215,6 +215,7 @@ void MediaInfo_Config_DefaultLanguage (Translation &Info)
     "Alignment_Split;Split across interleaves\n"
     "All;All\n"
     "AlternateGroup;Alternate group\n"
+    "Android_Version;Android version\n"
     "Archival_Location;Archival location\n"
     "Arranger;Arranger\n"
     "ArtDirector;ArtDirector\n"

--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -370,6 +370,8 @@ private :
     void moov_udta_rtng();
     void moov_udta_ptv ();
     void moov_udta_Sel0();
+    void moov_udta_smta();
+    void moov_udta_smta_mdln();
     void moov_udta_tags();
     void moov_udta_tags_meta();
     void moov_udta_tags_tseg();

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -6285,6 +6285,7 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxxVideo()
 
     int16u Width, Height, Depth, ColorTableID;
     int8u  CompressorName_Size;
+    Ztring  CompressorName;
     bool   IsGreyscale;
     Skip_B2(                                                    "Version");
     Skip_B2(                                                    "Revision level");
@@ -6302,12 +6303,12 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxxVideo()
     {
         //This is pascal string
         Skip_B1(                                                "Compressor name size");
-        Skip_UTF8(CompressorName_Size,                          "Compressor name");
+        Get_UTF8(CompressorName_Size, CompressorName,           "Compressor name");
         Skip_XX(32-1-CompressorName_Size,                       "Padding");
     }
     else
         //this is hard-coded 32-byte string
-        Skip_UTF8(32,                                           "Compressor name");
+        Get_UTF8(32, CompressorName,                            "Compressor name");
     Get_B2 (Depth,                                              "Depth");
     if (Depth>0x20 && Depth<0x40)
     {
@@ -6345,6 +6346,7 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxxVideo()
             CodecID_Fill(Codec, Stream_Video, StreamPos_Last, InfoCodecID_Format_Mpeg4);
         Fill(Stream_Video, StreamPos_Last, Video_Codec, Codec, true);
         Fill(Stream_Video, StreamPos_Last, Video_Codec_CC, Codec, true);
+        Fill(Stream_Video, StreamPos_Last, Video_Encoded_Library, CompressorName);
         if (Codec==__T("drms"))
             Fill(Stream_Video, StreamPos_Last, Video_Encryption, "iTunes");
         if (Codec==__T("encv"))

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -967,6 +967,8 @@ namespace Elements
     const int64u moov_udta_ptv =0x70747620;
     const int64u moov_udta_rtng=0x72746E67;
     const int64u moov_udta_Sel0=0x53656C30;
+    const int64u moov_udta_smta=0x736d7461;
+    const int64u moov_udta_smta_mdln=0x6d646c6e;
     const int64u moov_udta_tags=0x74616773;
     const int64u moov_udta_tags_meta=0x6D657461;
     const int64u moov_udta_tags_tseg=0x74736567;
@@ -1431,6 +1433,10 @@ void File_Mpeg4::Data_Parse()
             ATOM(moov_udta_ptv )
             ATOM(moov_udta_rtng)
             ATOM(moov_udta_Sel0)
+            LIST(moov_udta_smta)
+                ATOM_BEGIN
+                ATOM(moov_udta_smta_mdln)
+                ATOM_END
             LIST(moov_udta_tags)
                 ATOM_BEGIN
                 ATOM(moov_udta_tags_meta)
@@ -9807,6 +9813,27 @@ void File_Mpeg4::moov_udta_Sel0()
 
     //Parsing
     Skip_XX(Element_Size,                                       "Data");
+}
+
+//---------------------------------------------------------------------------
+void File_Mpeg4::moov_udta_smta()
+{
+    NAME_VERSION_FLAG("Samsung Metadata");
+}
+
+//---------------------------------------------------------------------------
+void File_Mpeg4::moov_udta_smta_mdln()
+{
+    Element_Name("Model Number");
+
+    //Parsing
+    string SamsungModelNumber;
+    Get_String(Element_Size, SamsungModelNumber, "Value");
+
+    //Filling
+    FILLING_BEGIN();
+        Fill(Stream_General, 0, "Samsung_Model_Number", SamsungModelNumber);
+    FILLING_END();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -3987,6 +3987,8 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                         Fill(Stream_General, 0, "Media/History/UUID", Value);
                     else if (Parameter=="com.android.capture.fps")
                         FrameRate_Real=Value;
+                    else if (Parameter=="com.android.version")
+                        Fill(Stream_General, 0, "Android_Version", Value);
                     else if (Parameter=="com.universaladid.idregistry")
                     {
                         Fill(Stream_General, 0, "UniversalAdID_Registry", Value);

--- a/Source/Resource/Text/Language/DefaultLanguage.csv
+++ b/Source/Resource/Text/Language/DefaultLanguage.csv
@@ -186,6 +186,7 @@ Alignment_Aligned;Aligned on interleaves
 Alignment_Split;Split across interleaves
 All;All
 AlternateGroup;Alternate group
+Android_Version;Android version
 Archival_Location;Archival location
 Arranger;Arranger
 ArtDirector;ArtDirector

--- a/Source/Resource/Text/Language/DefaultLanguage.csv
+++ b/Source/Resource/Text/Language/DefaultLanguage.csv
@@ -1139,6 +1139,7 @@ SamplePeakLevel_Album;Sample peak level (album)
 SamplesPerFrame;Samples per frame
 SamplingCount;Samples count
 SamplingRate;Sampling rate
+Samsung_Model_Number;Samsung model number
 Save;Save
 ScanOrder;Scan order
 ScanOrder_Original;Original scan order


### PR DESCRIPTION
- Extract Samsung Model Number metadata from `udta->smta->mdln` atom
- Show writing library metadata from container in output
- Handle `com.android.version` metadata

Issue #2175

MediaTrace:
```
96BED65   Text - Performer (31 bytes)
96BED65    Header (8 bytes)
96BED65     Size:                               31 (0x0000001F)
96BED69     Name:                               auth
96BED6D    Version:                             0 (0x00)
96BED6E    Flags:                               0 (0x000000)
96BED71    Language:                            5575 (0x15C7) - eng
96BED73    Value:                               Galaxy S23 Ultra
96BED84   Samsung Metadata (42 bytes)
96BED84    Header (8 bytes)
96BED84     Size:                               42 (0x0000002A)
96BED88     Name:                               smta
96BED8C    Version:                             0 (0x00)
96BED8D    Flags:                               0 (0x000000)
96BED90    saut (14 bytes)
96BED90     Header (8 bytes)
96BED90      Size:                              14 (0x0000000E)
96BED94      Name:                              saut
96BED98     Unknown:                            (6 bytes)
96BED9E    Model Number (16 bytes)
96BED9E     Header (8 bytes)
96BED9E      Size:                              16 (0x00000010)
96BEDA2      Name:                              mdln
96BEDA6     Value:                              SM-S918B
```

MediaInfo:
```
Performer                                : Galaxy S23 Ultra
Encoded date                             : 2025-01-12 06:12:18 UTC
Tagged date                              : 2025-01-12 06:12:18 UTC
Samsung model number                     : SM-S918B
Android version                          : 14
```
