### PR TITLE
Fix Visual Studio Code analysis warnings + some other issues

### DIFF
--- a/Project/MSVC2022/Dll/MediaInfoDll.vcxproj
+++ b/Project/MSVC2022/Dll/MediaInfoDll.vcxproj
@@ -184,6 +184,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -198,6 +199,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -212,6 +214,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -226,6 +229,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -258,6 +262,7 @@
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -279,6 +284,7 @@
       <DebugInformationFormat>None</DebugInformationFormat>
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -301,6 +307,7 @@
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
       <GuardSignedReturns>true</GuardSignedReturns>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -323,6 +330,7 @@
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
       <GuardSignedReturns>true</GuardSignedReturns>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -343,6 +351,7 @@
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Project/MSVC2022/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2022/Library/MediaInfoLib.vcxproj
@@ -186,6 +186,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -198,6 +199,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -210,6 +212,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64EC'">
@@ -222,6 +225,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -253,6 +257,7 @@
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -267,6 +272,7 @@
       <DebugInformationFormat>None</DebugInformationFormat>
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -283,6 +289,7 @@
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
       <GuardSignedReturns>true</GuardSignedReturns>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64EC'">
@@ -299,6 +306,7 @@
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
       <GuardSignedReturns>true</GuardSignedReturns>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -313,6 +321,7 @@
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/MediaInfo/Audio/File_Aac.cpp
+++ b/Source/MediaInfo/Audio/File_Aac.cpp
@@ -126,6 +126,7 @@ void File_Aac::Streams_Accept()
          case Mode_ADTS :
                        if (!IsSub)
                             TestContinuousFileNames();
+                       break;
         default : ;
     }
     if (Frame_Count_NotParsedIncluded==(int64u)-1)

--- a/Source/MediaInfo/Audio/File_Aac_GeneralAudio_Sbr.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_GeneralAudio_Sbr.cpp
@@ -893,7 +893,7 @@ bool Aac_f_master_Compute(int8u &num_env_bands_Master, int8u* f_Master, sbr_hand
     }
 
     int8u numBands0=2*Aac_bands_Compute(false, bands, k0, k1, divisor);
-    if (numBands0 == 0 || numBands0 >= 64)
+    if (numBands0 <= 0 || numBands0 >= 64)
         return false;
 
     int8u vDk0[64];

--- a/Source/MediaInfo/Audio/File_Aac_Main.cpp
+++ b/Source/MediaInfo/Audio/File_Aac_Main.cpp
@@ -723,6 +723,7 @@ void File_Aac::AudioSpecificConfig (size_t End)
                     Frame_Count=(size_t)-1; //Forcing not to parse following data anymore
                 }
             }
+            break;
         default : ;
     }
 

--- a/Source/MediaInfo/Audio/File_Ac4.cpp
+++ b/Source/MediaInfo/Audio/File_Ac4.cpp
@@ -3799,7 +3799,7 @@ void File_Ac4::metadata(audio_substream& AudioSubstream, size_t Substream_Index)
             Get_SB (b_discard_unknown_payload,                  "b_discard_unknown_payload");
             if (!b_discard_unknown_payload)
             {
-                bool b_payload_frame_aligned;
+                bool b_payload_frame_aligned{};
                 if (!b_smpoffst)
                 {
                     TEST_SB_GET(b_payload_frame_aligned,        "b_payload_frame_aligned");

--- a/Source/MediaInfo/Audio/File_Ac4.cpp
+++ b/Source/MediaInfo/Audio/File_Ac4.cpp
@@ -1152,7 +1152,7 @@ void File_Ac4::Streams_Fill()
         {
             set<size_t>::iterator It=IFrames_IsVariable.begin();
             size_t Value1=*It;
-            It++;
+            ++It;
             size_t Value2=*It;
             if (Value1+1==Value2)
             {
@@ -1577,7 +1577,7 @@ void File_Ac4::Streams_Fill()
                 continue;
             size_t AudioSubstream_Pos=0;
             std::map<int8u, substream_type_t>::iterator Substream_Type_Item=Substream_Type.begin();
-            for (; Substream_Type_Item!=Substream_Type.end() && Substream_Type_Item->first!=GroupInfo.substream_index; Substream_Type_Item++)
+            for (; Substream_Type_Item!=Substream_Type.end() && Substream_Type_Item->first!=GroupInfo.substream_index; ++Substream_Type_Item)
                 if (Substream_Type_Item->second==Type_Ac4_Substream)
                     AudioSubstream_Pos++;
             if (Substream_Type_Item==Substream_Type.end())
@@ -1592,7 +1592,7 @@ void File_Ac4::Streams_Fill()
         Fill(Stream_Audio, 0, (G+" LinkedTo_Substream_Pos/String").c_str(), SubstreamNum.Read());
         Fill_SetOptions(Stream_Audio, 0, (G+" LinkedTo_Substream_Pos/String").c_str(), "Y NIN");
     }
-    for (map<int8u, audio_substream>::iterator Substream_Info=AudioSubstreams.begin(); Substream_Info!=AudioSubstreams.end(); Substream_Info++)
+    for (map<int8u, audio_substream>::iterator Substream_Info=AudioSubstreams.begin(); Substream_Info!=AudioSubstreams.end(); ++Substream_Info)
     {
         string ChannelMode, ImmersiveStereo;
         for (size_t g=0; g<Groups.size(); g++)
@@ -1670,7 +1670,7 @@ void File_Ac4::Streams_Fill()
             Summary="?";
         }
         size_t AudioSubstream_Pos=0;
-        for (std::map<int8u, substream_type_t>::iterator Substream_Type_Item=Substream_Type.begin(); Substream_Type_Item!=Substream_Type.end() && Substream_Type_Item->first!=Substream_Info->first; Substream_Type_Item++)
+        for (std::map<int8u, substream_type_t>::iterator Substream_Type_Item=Substream_Type.begin(); Substream_Type_Item!=Substream_Type.end() && Substream_Type_Item->first!=Substream_Info->first; ++Substream_Type_Item)
             if (Substream_Type_Item->second==Type_Ac4_Substream)
                 AudioSubstream_Pos++;
         string S=Ztring(__T("Substream")+Ztring::ToZtring(AudioSubstream_Pos)).To_UTF8();
@@ -2170,7 +2170,7 @@ void File_Ac4::ac4_toc()
     {
         //We parse only Iframes, but also the frames associated to this I-frame
         if (!AudioSubstreams.empty())
-            for (map<int8u, audio_substream>::iterator Substream_Info=AudioSubstreams.begin(); Substream_Info!=AudioSubstreams.end(); Substream_Info++)
+            for (map<int8u, audio_substream>::iterator Substream_Info=AudioSubstreams.begin(); Substream_Info!=AudioSubstreams.end(); ++Substream_Info)
                 if (Substream_Info->second.Buffer_Index)
                     NoSkip=true;
     }

--- a/Source/MediaInfo/Audio/File_Ac4.cpp
+++ b/Source/MediaInfo/Audio/File_Ac4.cpp
@@ -1820,7 +1820,7 @@ void File_Ac4::Read_Buffer_Unsynched()
 bool File_Ac4::Synchronize()
 {
     //Synchronizing
-    size_t Buffer_Offset_Current;
+    size_t Buffer_Offset_Current{};
     while (Buffer_Offset<Buffer_Size)
     {
         Buffer_Offset_Current=Buffer_Offset;

--- a/Source/MediaInfo/Audio/File_Ac4.h
+++ b/Source/MediaInfo/Audio/File_Ac4.h
@@ -360,10 +360,12 @@ private :
                 uint8_t* Data_ToDelete=Data;
                 Size=NewOffset;
                 Data=new int8u[Size];
-                memcpy(Data, Data_ToDelete, Offset);
+                if (Data_ToDelete)
+                    memcpy(Data, Data_ToDelete, Offset);
                 delete[] Data_ToDelete;
             }
-            memcpy(Data+Offset, BufferToAdd, SizeToAdd);
+            if (Data+Offset)
+                memcpy(Data+Offset, BufferToAdd, SizeToAdd);
             Offset=NewOffset;
         }
 

--- a/Source/MediaInfo/Audio/File_Adm.cpp
+++ b/Source/MediaInfo/Audio/File_Adm.cpp
@@ -2398,7 +2398,7 @@ public:
     file_adm_private()
     {
         auto OldLocale_Temp = setlocale(LC_NUMERIC, nullptr);
-        if (*OldLocale_Temp != 'C' || *(OldLocale_Temp + 1)) {
+        if (OldLocale_Temp && (*OldLocale_Temp != 'C' || *(OldLocale_Temp + 1))) {
             OldLocale = OldLocale_Temp;
             setlocale(LC_NUMERIC, "C");
         }

--- a/Source/MediaInfo/Audio/File_Adm.cpp
+++ b/Source/MediaInfo/Audio/File_Adm.cpp
@@ -5482,7 +5482,7 @@ void File_Adm::Streams_Fill()
                 IsAdvSSE = true;
                 IsAdvSSE_Versions.push_back(strtoul(Profile_Item.Attributes[profile_profileVersion].c_str(), nullptr, 10));
                 IsAdvSSE_Levels.push_back(strtoul(Profile_Item.Attributes[profile_profileLevel].c_str(), nullptr, 10));
-                if (IsAdvSSE_Levels.back() > 2 && (Profile == "ITU-R BS.[ADM-NGA-EMISSION]-0" || Profile == "ITU-R BS.[ADM-NGA-EMISSION]-0")) {
+                if (IsAdvSSE_Levels.back() > 2 && (Profile == "ITU-R BS.[ADM-NGA-EMISSION]-0")) {
                     Profiles.back().AddError(Error, ':' + CraftName(item_Infos[item_profile].Name) + to_string(i) + ":profileLevel:profileLevel attribute value " + Profile_Item.Attributes[profile_profileLevel] + " is not permitted, max is 2", Source_AdvSSE_1);
                 }
             }

--- a/Source/MediaInfo/Audio/File_Adm.cpp
+++ b/Source/MediaInfo/Audio/File_Adm.cpp
@@ -2827,6 +2827,8 @@ static void CheckErrors_ID_Additions(file_adm_private* File_Adm_Private, item it
 };
 
 //---------------------------------------------------------------------------
+#pragma warning( push )
+#pragma warning( disable : 26813 ) //false positive "Use 'bitwise and' to check if a flag is set."
 static void CheckErrors_formatLabelDefinition(file_adm_private* File_Adm_Private, item item_Type, size_t i, const label_info& label_Info) {
     const bool IsAtmos = File_Adm_Private->IsAtmos;
     auto& Item = File_Adm_Private->Items[item_Type].Items[i];
@@ -2892,6 +2894,7 @@ static void CheckErrors_formatLabelDefinition(file_adm_private* File_Adm_Private
         }
     }
 };
+#pragma warning( pop )
 
 //---------------------------------------------------------------------------
 static void CheckErrors_Attributes(file_adm_private* File_Adm_Private, item Item_Type, const vector<size_t>& Attributes_Counts) {

--- a/Source/MediaInfo/Audio/File_Adm.cpp
+++ b/Source/MediaInfo/Audio/File_Adm.cpp
@@ -3027,7 +3027,7 @@ static void CheckErrors_Elements(file_adm_private* File_Adm_Private, item Item_T
             }
             else if (Elem.empty() && Item_Type) {
                 #define ITEM_ELEM(A,B) ((A << 8) | B)
-                switch (ITEM_ELEM(Item_Type, j)) {
+                switch (ITEM_ELEM(static_cast<size_t>(Item_Type), j)) {
                 case ITEM_ELEM(item_audioProgrammeReferenceScreen, audioProgrammeReferenceScreen_screenCentrePosition):
                 case ITEM_ELEM(item_audioProgrammeReferenceScreen, audioProgrammeReferenceScreen_screenWidth):
                 case ITEM_ELEM(item_audioBlockFormat, audioBlockFormat_headphoneVirtualise):

--- a/Source/MediaInfo/Audio/File_Adm.cpp
+++ b/Source/MediaInfo/Audio/File_Adm.cpp
@@ -2923,7 +2923,7 @@ static void CheckErrors_Attributes(file_adm_private* File_Adm_Private, item Item
             break;
         default:
             Item.AddError(Error, ':' + CraftName(item_Infos[Item_Type].Name) + to_string(i) + ":" + CraftName(Attribute_Infos[j].Name) + ":" + string(Attribute_Infos[j].Name) + " attribute shall be unique");
-            // Fallthrough
+            [[fallthrough]];
         case 1:
         {
             Attributes_Present[j] = true;
@@ -3572,7 +3572,7 @@ void audioBlockFormat_Check(file_adm_private* File_Adm_Private) {
             BlockFormat.AddError(Error, ":GeneralCompliance:jumpPosition subelement count " + to_string(jumpPositions.size()) + " is not permitted, max is 1", Source_Atmos_1_0);
             break;
         }
-        // Fallthrough
+        [[fallthrough]];
     case 1:
         switch (Type) {
         case Type_Objects: {

--- a/Source/MediaInfo/Audio/File_Adm.cpp
+++ b/Source/MediaInfo/Audio/File_Adm.cpp
@@ -2141,7 +2141,10 @@ size_t Atmos_zone_Pos(const string& Name, float32* Values) {
 }
 
 string CraftName(const char* Name, bool ID = false) {
-    return (ID && !strcmp(Name, "Track")) ? "track" : ((Name && Name[0] < 'a' ? "audio" : "") + string(Name));
+    if (Name)
+        return (ID && !strcmp(Name, "Track")) ? "track" : ((Name && Name[0] < 'a' ? "audio" : "") + string(Name));
+    else
+        return "";
 }
 
 enum class E {

--- a/Source/MediaInfo/Audio/File_ChannelGrouping.cpp
+++ b/Source/MediaInfo/Audio/File_ChannelGrouping.cpp
@@ -329,7 +329,7 @@ void File_ChannelGrouping::Read_Buffer_Continue()
             {
                 if (!Common->Parsers[Pos]->Status[IsAccepted] && Common->Parsers[Pos]->Status[IsFinished])
                 {
-                    delete *(Common->Parsers.begin()+Pos);
+                    delete static_cast<MediaInfoLib::File__Analyze*>(*(Common->Parsers.begin()+Pos));
                     Common->Parsers.erase(Common->Parsers.begin()+Pos);
                     Pos--;
                 }
@@ -339,7 +339,7 @@ void File_ChannelGrouping::Read_Buffer_Continue()
                     for (size_t Pos2=0; Pos2<Common->Parsers.size(); Pos2++)
                     {
                         if (Pos2!=Pos)
-                            delete *(Common->Parsers.begin()+Pos2);
+                            delete static_cast<MediaInfoLib::File__Analyze*>(*(Common->Parsers.begin()+Pos2));
                     }
                     Common->Parsers.clear();
                     Common->Parsers.push_back(Parser);

--- a/Source/MediaInfo/Audio/File_ChannelSplitting.cpp
+++ b/Source/MediaInfo/Audio/File_ChannelSplitting.cpp
@@ -430,7 +430,7 @@ void File_ChannelSplitting::Read_Buffer_Continue_Parse()
                     }
                     if (!SplittedChannel->Parsers[Pos]->Status[IsAccepted] && SplittedChannel->Parsers[Pos]->Status[IsFinished])
                     {
-                        delete *(SplittedChannel->Parsers.begin()+Pos);
+                        delete static_cast<MediaInfoLib::File__Analyze*>(*(SplittedChannel->Parsers.begin()+Pos));
                         SplittedChannel->Parsers.erase(SplittedChannel->Parsers.begin()+Pos);
                         Pos--;
                     }
@@ -443,7 +443,7 @@ void File_ChannelSplitting::Read_Buffer_Continue_Parse()
                         for (size_t Pos2=0; Pos2<SplittedChannel->Parsers.size(); Pos2++)
                         {
                             if (Pos2!=Pos)
-                                delete *(SplittedChannel->Parsers.begin()+Pos2);
+                                delete static_cast<MediaInfoLib::File__Analyze*>(*(SplittedChannel->Parsers.begin()+Pos2));
                         }
                         SplittedChannel->Parsers.clear();
                         SplittedChannel->Parsers.push_back(Parser);

--- a/Source/MediaInfo/Audio/File_Dat.cpp
+++ b/Source/MediaInfo/Audio/File_Dat.cpp
@@ -564,7 +564,7 @@ void File_Dat::Data_Parse()
                             Previous = Priv->Frame_Last.TCs[i];
                             Previous.SetFramesMax(Frame.TCs[i].GetFramesMax());
                             Ref = Previous;
-                            Ref++;
+                            ++Ref;
                         }
                         int32u Value = 0;
                         Value |= (int32u)Frame.TCs[i].ToSeconds() << 8;

--- a/Source/MediaInfo/Audio/File_DolbyE.cpp
+++ b/Source/MediaInfo/Audio/File_DolbyE.cpp
@@ -2388,7 +2388,7 @@ void File_DolbyE::program_assignment()
                 {
                     bool b_standard_chan_assign;
                     Get_SB (b_standard_chan_assign,             "b_standard_chan_assign");
-                    int32u nonstd_bed_channel_assignment_mask;
+                    int32u nonstd_bed_channel_assignment_mask{};
                     if (b_standard_chan_assign)
                     {
                         int16u bed_channel_assignment_mask;

--- a/Source/MediaInfo/Audio/File_Dts.cpp
+++ b/Source/MediaInfo/Audio/File_Dts.cpp
@@ -956,13 +956,20 @@ void File_Dts_Common::FileHeader_Parse()
     //https://www.atsc.org/wp-content/uploads/2015/03/Non-Real-Time-Content-Delivery.pdf
     if (IsSub || CC8(Buffer)!=CHUNK_DTSHDHDR || CC4(Buffer+8))
         return;
-    int64u StreamSize=-1;
-    int16u Bitw_Stream_Metadata;
-    bool Header_Parsed=false;
-    int64u Num_Samples_Orig_Audio_At_Max_Fs=0;
-    int32u Num_Frames_Total, TimeStamp, Max_Sample_Rate_Hz=0, Ext_Ss_Avg_Bit_Rate_Kbps=0, Ext_Ss_Peak_Bit_Rate_Kbps=0;
-    int16u Core_Ss_Bit_Rate_Kbps=0, Samples_Per_Frame_At_Max_Fs=0, Codec_Delay_At_Max_Fs=0;
-    int8u RefClockCode, TC_Frame_Rate=-1;
+    int64u StreamSize{ static_cast<int64u>(-1) };
+    int16u Bitw_Stream_Metadata{};
+    bool Header_Parsed{ false };
+    int64u Num_Samples_Orig_Audio_At_Max_Fs{ 0 };
+    int32u Num_Frames_Total{};
+    int32u TimeStamp{};
+    int32u Max_Sample_Rate_Hz{ 0 };
+    int32u Ext_Ss_Avg_Bit_Rate_Kbps{ 0 };
+    int32u Ext_Ss_Peak_Bit_Rate_Kbps{ 0 };
+    int16u Core_Ss_Bit_Rate_Kbps{ 0 };
+    int16u Samples_Per_Frame_At_Max_Fs{ 0 };
+    int16u Codec_Delay_At_Max_Fs{ 0 };
+    int8u RefClockCode{};
+    int8u TC_Frame_Rate{ static_cast<int8u>(-1) };
     while (StreamSize==-1 && Element_Size-Element_Offset>=16)
     {
         int64u Name, Size;

--- a/Source/MediaInfo/Audio/File_Flac.cpp
+++ b/Source/MediaInfo/Audio/File_Flac.cpp
@@ -159,7 +159,7 @@ void File_Flac::Data_Parse()
         CASE_INFO(CUESHEET);
         CASE_INFO(PICTURE);
         case (int8u)-1: Element_Name("Frame");
-                // Fallthrough
+                [[fallthrough]];
         default : Skip_XX(Element_Size,                         "Data");
     }
 

--- a/Source/MediaInfo/Audio/File_Opus.cpp
+++ b/Source/MediaInfo/Audio/File_Opus.cpp
@@ -160,7 +160,7 @@ void File_Opus::Identification()
             case 0 : // Mono/Stereo
                     if (ch_count>2)
                         break; // Not in spec
-                    // else it is as Vorbis specs, no break
+                    [[fallthrough]]; // else it is as Vorbis specs, no break
             case 1 : // Vorbis order
                     if (ch_count && ch_count<=Opus_ChannelLayout_Max)
                     {
@@ -174,6 +174,7 @@ void File_Opus::Identification()
                     if (ChannelLayout2!=Retrieve(Stream_Audio, 0, Audio_ChannelLayout))
                         Fill(Stream_Audio, 0, Audio_ChannelLayout, ChannelLayout2);
                     }
+                    break;
             default: ; //Unknown
         }
 

--- a/Source/MediaInfo/Audio/File_Usac.cpp
+++ b/Source/MediaInfo/Audio/File_Usac.cpp
@@ -4489,7 +4489,7 @@ void File_Usac::UsacCoreCoderData(size_t nrChannels, bool usacIndependencyFlag)
     Element_Begin1("UsacCoreCoderData");
 
     bool coreModes[2];
-    bool tnsDataPresent[2];
+    bool tnsDataPresent[2]{};
 
     for (size_t ch=0; ch<nrChannels; ch++)
         Get_SB(coreModes[ch],                                   "core_mode");
@@ -4750,7 +4750,7 @@ void File_Usac::pvcEnvelope(bool usacIndependencyFlag)
     }
     else
     {
-        int8u num_grid_info;
+        int8u num_grid_info{};
         switch (divMode)
         {
         case 4:
@@ -5606,7 +5606,7 @@ void File_Usac::LsbData(ec_data_type dataType, bool bsQuantCoarseXXX, int8u data
 //---------------------------------------------------------------------------
 void File_Usac::EcDataPair(ec_data_type dataType, int8u paramIdx, int8u setIdx, int8u dataBands, bool bsDataPairXXX, bool bsQuantCoarseXXX, bool usacIndependencyFlag)
 {
-    int8u numQuantSteps;
+    int8u numQuantSteps{};
     switch (dataType)
     {
     case CLD:

--- a/Source/MediaInfo/Audio/File_Usac.cpp
+++ b/Source/MediaInfo/Audio/File_Usac.cpp
@@ -2406,7 +2406,7 @@ void File_Usac::UsacDecoderConfig()
             bool AccrossCpe = false;
             for (size_t i = 0 ; i < C.usacElements.size(); i++)
             {
-                auto usacElement = C.usacElements[i];
+                auto& usacElement = C.usacElements[i];
                 switch (usacElement.usacElementType)
                 {
                     case ID_USAC_SCE                          : ChannelCount_NonLfe++; break;
@@ -2465,7 +2465,7 @@ void File_Usac::UsacDecoderConfig()
                 channelConfiguration_Orders_Pos = channelConfiguration_Orders_Max;
                 channelConfiguration_Orders_Max = channelConfiguration_Orders[i];
                 auto channelConfiguration_Orders_Base = channelConfiguration_Orders + Aac_Channels_Size_Usac;
-                for (auto usacElement : C.usacElements)
+                for (auto& usacElement : C.usacElements)
                 {
                     if (usacElement.usacElementType >= ID_USAC_EXT)
                         continue;
@@ -2477,14 +2477,14 @@ void File_Usac::UsacDecoderConfig()
                 if (!IsNotMatch)
                 {
                     string ActualOrder;
-                    for (auto usacElement : C.usacElements)
+                    for (auto& usacElement : C.usacElements)
                     {
                         if (usacElement.usacElementType >= ID_USAC_EXT)
                             continue;
                         ActualOrder += usacElementType_IdNames[usacElement.usacElementType];
                         ActualOrder += ' ';
                     }
-                    ActualOrder.pop_back();
+                    if (!ActualOrder.empty()) ActualOrder.pop_back();
                     Fill_Conformance("UsacConfig channelConfigurationIndex", ("channelConfigurationIndex " + to_string(C.channelConfigurationIndex) + " is used but the usacElementType sequence contains " + ActualOrder + ", which is the configuration indicated by channelConfigurationIndex " + to_string(i)).c_str(), bitset8(), Warning);
                     break;
                 }
@@ -2503,14 +2503,14 @@ void File_Usac::UsacDecoderConfig()
             }
             if (!ExpectedOrder.empty()) ExpectedOrder.pop_back();
             string ActualOrder;
-            for (auto usacElement : C.usacElements)
+            for (auto& usacElement : C.usacElements)
             {
                 if (usacElement.usacElementType >= ID_USAC_EXT)
                     continue;
                 ActualOrder += usacElementType_IdNames[usacElement.usacElementType];
                 ActualOrder += ' ';
             }
-            ActualOrder.pop_back();
+            if (!ActualOrder.empty()) ActualOrder.pop_back();
             Fill_Conformance("UsacConfig channelConfigurationIndex", ("channelConfigurationIndex " + to_string(C.channelConfigurationIndex) + " implies element order " + ExpectedOrder + " but actual element order is " + ActualOrder).c_str());
         }
     #endif

--- a/Source/MediaInfo/Audio/File_Usac.cpp
+++ b/Source/MediaInfo/Audio/File_Usac.cpp
@@ -1896,7 +1896,7 @@ void File_Usac::Streams_Finish_Conformance()
         auto& Conformance_Total = ConformanceErrors_Total[Level];
         if (Conformance_Total.empty())
             continue;
-        for (size_t i = Conformance_Total.size() - 1; i < Conformance_Total.size(); i--) {
+        for (size_t i = Conformance_Total.size(); i-- > 0;) {
             if (!CheckIf(Conformance_Total[i].Flags)) {
                 Conformance_Total.erase(Conformance_Total.begin() + i);
             }

--- a/Source/MediaInfo/Audio/File_Usac.cpp
+++ b/Source/MediaInfo/Audio/File_Usac.cpp
@@ -5071,7 +5071,7 @@ void File_Usac::UsacSbrData(size_t nrSbrChannels, bool usacIndependencyFlag)
     int64s sampling_frequency=C.sampling_frequency;
     if (C.coreSbrFrameLengthIndex==4)
     {
-        sampling_frequency=Frequency_b/2;
+        if (Frequency_b!=0) sampling_frequency=Frequency_b/2;
         C.sbrHandler.ratio=QUAD;
     }
 

--- a/Source/MediaInfo/Audio/File_Usac.cpp
+++ b/Source/MediaInfo/Audio/File_Usac.cpp
@@ -2501,7 +2501,7 @@ void File_Usac::UsacDecoderConfig()
                 ExpectedOrder += usacElementType_IdNames[channelConfiguration_Orders_Base[channelConfiguration_Orders_Pos]];
                 ExpectedOrder += ' ';
             }
-            ExpectedOrder.pop_back();
+            if (!ExpectedOrder.empty()) ExpectedOrder.pop_back();
             string ActualOrder;
             for (auto usacElement : C.usacElements)
             {

--- a/Source/MediaInfo/Audio/File_Usac.cpp
+++ b/Source/MediaInfo/Audio/File_Usac.cpp
@@ -2902,6 +2902,7 @@ void File_Usac::uniDrcConfigExtension()
             default:
                 Skip_BS(bitSize,                                "Unknown");
         }
+        #pragma warning (suppress : 6385) //Visual Studio fail to detect 'uniDrcConfigExtType<UNIDRCCONFEXT_Max' check when it is inside function parameter and warns about reading invalid data
         BS_Bookmark(B, uniDrcConfigExtType<UNIDRCCONFEXT_Max?string(uniDrcConfigExtType_ConfNames[uniDrcConfigExtType]):("uniDrcConfigExtType"+to_string(uniDrcConfigExtType)));
         Element_End0();
     }
@@ -3377,6 +3378,7 @@ void File_Usac::UsacConfigExtension()
                 case ID_CONFIG_EXT_STREAM_ID                  : streamId(); break;
                 default                                       : Skip_BS(usacConfigExtLength,                "Unknown");
             }
+            #pragma warning (suppress : 6385) //Visual Studio fail to detect 'usacConfigExtType<ID_CONFIG_EXT_Max' check when it is inside function parameter and warns about reading invalid data
             if (BS_Bookmark(B, usacConfigExtType<ID_CONFIG_EXT_Max?string(usacConfigExtType_ConfNames[usacConfigExtType]):("usacConfigExtType"+to_string(usacConfigExtType))))
             {
                 #if MEDIAINFO_CONFORMANCE
@@ -5944,6 +5946,7 @@ void File_Usac::UsacExtElement(size_t elemIdx, bool usacIndependencyFlag)
                 default:
                     Skip_BS(usacExtElementPayloadLength,        usacExtElementType==ID_EXT_ELE_FILL?"(Not parsed)":"Unknown");
             }
+            #pragma warning (suppress : 6385) //Visual Studio fail to detect 'usacExtElementType<ID_EXT_ELE_Max' check when it is inside function parameter and warns about reading invalid data
             BS_Bookmark(B, usacExtElementType<ID_EXT_ELE_Max?string(usacExtElementType_Names[usacExtElementType]):("usacExtElementType"+to_string(usacExtElementType)));
         }
     }

--- a/Source/MediaInfo/Audio/File_Wvpk.cpp
+++ b/Source/MediaInfo/Audio/File_Wvpk.cpp
@@ -154,7 +154,7 @@ void File_Wvpk::Streams_Finish()
         int64u BitDepth=dsf?1:(Wvpk_Resolution[(resolution1?1:0)*2+(resolution0?1:0)]);
         int64u Duration=Samples*1000/SamplingRate;
         int64u CompressedSize=File_Size-TagsSize;
-        int64u UncompressedSize=Duration*(num_channels?num_channels:(mono?1:2))*BitDepth*(SamplingRate<<(3*dsf))/8/1000;
+        int64u UncompressedSize=Duration*(num_channels?num_channels:(mono?1:2))*BitDepth*(static_cast<int64u>(SamplingRate)<<(3*dsf))/8/1000;
         float32 CompressionRatio=((float32)UncompressedSize)/CompressedSize;
         Fill(Stream_Audio, 0, Audio_StreamSize, CompressedSize, 3, true);
         Fill(Stream_Audio, 0, Audio_Duration, Duration, 10, true);
@@ -576,7 +576,7 @@ void File_Wvpk::Data_Parse_Fill()
     {
         Fill(Stream_Audio, StreamPos_Last, Audio_SamplingRate, (Wvpk_SamplingRate[SamplingRate_Index]<<SamplingRate_Shift)<<(3*dsf));
         if (total_samples_FirstFrame!=(int32u)-1) //--> this is a valid value
-            Fill(Stream_Audio, 0, Audio_Duration, ((int64u)total_samples_FirstFrame)*1000/(Wvpk_SamplingRate[SamplingRate_Index]<<SamplingRate_Shift));
+            Fill(Stream_Audio, 0, Audio_Duration, ((int64u)total_samples_FirstFrame)*1000/((int64u)Wvpk_SamplingRate[SamplingRate_Index]<<SamplingRate_Shift));
     }
     Fill(Stream_Audio, 0, Audio_Encoded_Library_Settings, Encoded_Library_Settings);
     Fill(Stream_Audio, 0, Audio_BitRate_Mode, "VBR");

--- a/Source/MediaInfo/Export/Export_Graph_gvc_Include.h
+++ b/Source/MediaInfo/Export/Export_Graph_gvc_Include.h
@@ -45,15 +45,7 @@ extern "C"
     static GModule* cgraph_Module=NULL;
 #elif defined (_WIN32) || defined (WIN32)
     #undef __TEXT
-    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
-        namespace WindowsNamespace
-        {
-    #endif
     #include "windows.h"
-    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
-        }
-        using namespace WindowsNamespace;
-    #endif
     static HMODULE gvc_Module=NULL;
     static HMODULE cgraph_Module=NULL;
 #else

--- a/Source/MediaInfo/Export/Export_Mpeg7.cpp
+++ b/Source/MediaInfo/Export/Export_Mpeg7.cpp
@@ -220,9 +220,10 @@ Ztring Mpeg7_ContentCS_Name(int32u termID, MediaInfo_Internal &MI, size_t) //xxy
                         case 2 : return __T("Video");
                         case 3 : return __T("Graphics");
                     }
-        case 50: return __T("Text");
-        default : return MI.Get(Stream_General, 0, General_FileExtension);
+                    break;
+        case 50 : return __T("Text");
     }
+    return MI.Get(Stream_General, 0, General_FileExtension);
 }
 
 //---------------------------------------------------------------------------
@@ -2668,7 +2669,7 @@ Ztring Export_Mpeg7::Transform(MediaInfo_Internal &MI, size_t Version)
              || !MI.Get(Stream_Video, 0, Video_Language).empty()
              || (!Mpeg7_AudioPresentationCS_termID(MI, 0) && !MI.Get(Stream_Audio, 0, Audio_ChannelLayout).empty()))
                 Extended=1;
-            //fall through
+            [[fallthrough]];
         case Export_Mpeg7::Version_BestEffort_Strict:
             if (Video_Count>1
              || Audio_Count>1

--- a/Source/MediaInfo/ExternalCommandHelpers.cpp
+++ b/Source/MediaInfo/ExternalCommandHelpers.cpp
@@ -159,8 +159,8 @@ int External_Command_Run(const Ztring& Command, const ZtringList& Arguments, Ztr
     {
         if (!CreatePipe(&StdErrRead, &StdErrWrite, &Attrs, 0))
         {
-            CloseHandle(StdOutWrite);
-            CloseHandle(StdOutRead);
+            if (StdOutWrite) CloseHandle(StdOutWrite);
+            if (StdOutRead)  CloseHandle(StdOutRead);
             return -1;
         }
     }
@@ -182,15 +182,15 @@ int External_Command_Run(const Ztring& Command, const ZtringList& Arguments, Ztr
 
     if (!CreateProcessW(nullptr, (LPWSTR)CommandLine.Read().To_Unicode().c_str(), nullptr, nullptr, TRUE, CREATE_NO_WINDOW, nullptr, nullptr, &StartupInfo, &ProcessInfo))
     {
-        CloseHandle(StdOutWrite);
-        CloseHandle(StdOutRead);
-        CloseHandle(StdErrWrite);
-        CloseHandle(StdErrRead);
+        if (StdOutWrite) CloseHandle(StdOutWrite);
+        if (StdOutRead)  CloseHandle(StdOutRead);
+        if (StdErrWrite) CloseHandle(StdErrWrite);
+        if (StdErrRead)  CloseHandle(StdErrRead);
         return -1;
     }
 
-    CloseHandle(StdOutWrite);
-    CloseHandle(StdErrWrite);
+    if (StdOutWrite) CloseHandle(StdOutWrite);
+    if (StdErrWrite) CloseHandle(StdErrWrite);
 
     char Buf[128];
     if (StdOut)
@@ -214,8 +214,8 @@ int External_Command_Run(const Ztring& Command, const ZtringList& Arguments, Ztr
         }
     }
 
-    CloseHandle(StdOutRead);
-    CloseHandle(StdErrRead);
+    if (StdOutRead) CloseHandle(StdOutRead);
+    if (StdErrRead) CloseHandle(StdErrRead);
 
     WaitForSingleObject(ProcessInfo.hProcess, INFINITE);
     GetExitCodeProcess(ProcessInfo.hProcess, &ExitCode);

--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -1829,6 +1829,7 @@ size_t File__Analyze::Read_Buffer_Seek_OneFramePerFile (size_t Method, int64u Va
                         if (Config->Demux_Rate_Get()==0)
                             return (size_t)-1; //Not supported
                         Value=float64_int64s(((float64)Value)/1000000000*Config->Demux_Rate_Get());
+                        return 1;
                     #else //MEDIAINFO_DEMUX
                         return (size_t)-1; //Not supported
                     #endif //MEDIAINFO_DEMUX

--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -362,7 +362,7 @@ void conformance::Streams_Finish_Conformance()
         auto& Conformance_Total = ConformanceErrors_Total[Level];
         if (Conformance_Total.empty())
             continue;
-        for (size_t i = Conformance_Total.size() - 1; i < Conformance_Total.size(); i--) {
+        for (size_t i = Conformance_Total.size(); i-- > 0;) {
             if (!CheckIf(Conformance_Total[i].Flags)) {
                 Conformance_Total.erase(Conformance_Total.begin() + i);
             }

--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -266,7 +266,7 @@ string BuildConformanceName(const string& ParserName, const char* Prefix, const 
     }
     if (Suffix) {
         Result += Suffix;
-        if (Result.empty() && Result.back() >= '0' && Result.back() <= '9') {
+        if (!Result.empty() && Result.back() >= '0' && Result.back() <= '9') {
             Result += '_';
         }
     }

--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -397,7 +397,7 @@ void conformance::Streams_Finish_Conformance()
                 size_t Frames_HasContent, Times_HasContent, Offsets_HasContent;
                 Frames_HasContent = Times_HasContent = Offsets_HasContent = Pos_Total;
                 for (size_t i = 0; i < Pos_Total; i++) {
-                    auto FramePos = ConformanceError.FramePoss[i];
+                    auto& FramePos = ConformanceError.FramePoss[i];
                     if (FramePos.Frame_Count_Min == (int64u)-2) {
                         Frames += "conf";
                     }

--- a/Source/MediaInfo/File__Analyze_Buffer.cpp
+++ b/Source/MediaInfo/File__Analyze_Buffer.cpp
@@ -1440,6 +1440,7 @@ void File__Analyze::Get_VL(const vlc Vlc[], size_t &Info, const char* Name)
                         if (BS->GetB())
                             Value++;
                         CountOfBits++;
+                        break;
             case   0 :  ;
         }
 

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -3098,21 +3098,18 @@ void File__Analyze::Duration_Duration123(stream_t StreamKind, size_t StreamPos, 
                         if (FrameRateF>=FrameRateF_Min && FrameRateF<FrameRateF_Max)
                         {
                             // Default from user
-                            if (!DropFrame_IsValid)
-                            {
-                                #if MEDIAINFO_ADVANCED
-                                    switch (Config->File_DefaultTimeCodeDropFrame_Get())
-                                    {
-                                        case 0 :
-                                                DropFrame=false;
-                                                break;
-                                        default:
-                                                DropFrame=true;
-                                    }
-                                #else //MEDIAINFO_ADVANCED
-                                    DropFrame=true;
-                                #endif //MEDIAINFO_ADVANCED
-                            }
+                            #if MEDIAINFO_ADVANCED
+                                switch (Config->File_DefaultTimeCodeDropFrame_Get())
+                                {
+                                    case 0 :
+                                            DropFrame=false;
+                                            break;
+                                    default:
+                                            DropFrame=true;
+                                }
+                            #else //MEDIAINFO_ADVANCED
+                                DropFrame=true;
+                            #endif //MEDIAINFO_ADVANCED
                         }
                         else
                             DropFrame=false;

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -665,7 +665,7 @@ void File__Analyze::Get_LightLevel(Ztring &MaxCLL, Ztring &MaxFALL, int32u Divis
 size_t File__Analyze::Stream_Prepare (stream_t KindOfStream, size_t StreamPos)
 {
     //Integrity
-    if (KindOfStream>Stream_Max)
+    if (KindOfStream<0 || KindOfStream>Stream_Max)
         return Error;
 
     //Clear
@@ -1000,7 +1000,7 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Paramete
         "ContainerExtra",
     };
     assert(sizeof(SourceValue)==StreamSource_Max*sizeof(const char*));
-    if (StreamKind==Stream_Video && ShowSource_IsInList((video)Parameter) && StreamSource<StreamSource_Max && Retrieve_Const(Stream_Video, StreamPos, Parameter+1).empty())
+    if (StreamKind==Stream_Video && ShowSource_IsInList((video)Parameter) && StreamSource>=0 && StreamSource<StreamSource_Max && Retrieve_Const(Stream_Video, StreamPos, Parameter+1).empty())
     {
         Fill(Stream_Video, StreamPos, Parameter+1, SourceValue[StreamSource]);
     }
@@ -1054,7 +1054,7 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, size_t Paramete
     if (StreamKind==Stream_Max || StreamPos>=(*Stream)[StreamKind].size())
     {
         size_t StreamKindS=(size_t)StreamKind;
-        if (StreamKind!=Stream_Max)
+        if (StreamKind>=0 && StreamKind!=Stream_Max)
         {
             //Stream kind is found, moving content
             for (size_t Pos=0; Pos<Fill_Temp[Stream_Max].size(); Pos++)
@@ -1737,7 +1737,7 @@ void File__Analyze::Fill (stream_t StreamKind, size_t StreamPos, const char* Par
     if (StreamKind==Stream_Max || StreamPos>=(*Stream)[StreamKind].size())
     {
         size_t StreamKindS=(size_t)StreamKind;
-        if (StreamKind!=Stream_Max)
+        if (StreamKind>=0 && StreamKind!=Stream_Max)
         {
             //Stream kind is found, moving content
             for (size_t Pos=0; Pos<Fill_Temp[Stream_Max].size(); Pos++)
@@ -1888,7 +1888,7 @@ void File__Analyze::Fill_SetOptions(stream_t StreamKind, size_t StreamPos, const
         return;
 
     //Handle Value before StreamKind
-    if (StreamKind==Stream_Max || StreamPos>=(*Stream)[StreamKind].size())
+    if (StreamKind>=0 && (StreamKind==Stream_Max || StreamPos>=(*Stream)[StreamKind].size()))
     {
         Fill_Temp_Options[StreamKind][Parameter]=Options;
         return; //No streams

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -583,7 +583,7 @@ void File__Analyze::dvcC(bool has_dependency_pid, std::map<std::string, Ztring>*
             }
 
             string Layers;
-            if (rpu_present_flag|el_present_flag|bl_present_flag)
+            if (rpu_present_flag||el_present_flag||bl_present_flag)
             {
                 if (bl_present_flag)
                     Layers +="BL+";

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -68,7 +68,7 @@ inline void add_dec_2chars(string& In, uint8_t Value)
         Value=(uint8_t)Value100.rem;
         In+='0'+Value100.quot;
     }
-    In.append(add_dec_cache+(Value<<1), 2);
+    In.append(add_dec_cache+((size_t)Value<<1), 2);
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -98,7 +98,7 @@ bool DateTime_Adapt(string& Value_)
         IsUtc = false;
     
     // Unix style
-    if (Value.size() < 4)
+    if (Value.size() < 5)
         return false;
     if (Value[4]!='-')
     {

--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -1153,7 +1153,7 @@ void File__Analyze::Streams_Finish_StreamOnly_Video(size_t Pos)
                         {
                             case Video_HDR_Format_Version: Summary[j]+=__T(", Version "); break;
                             case Video_HDR_Format_Level: Summary[j]+=__T('.'); break;
-                            case Video_HDR_Format_Compression: ToAdd[j][0]+=0x20; if (ToAdd[j].size()==4) ToAdd[j].resize(2); ToAdd[j]+=__T(" metadata compression"); // Fallthrough
+                            case Video_HDR_Format_Compression: ToAdd[j][0]+=0x20; if (ToAdd[j].size()==4) ToAdd[j].resize(2); ToAdd[j]+=__T(" metadata compression"); [[fallthrough]];
                             default: Summary[j] += __T(", ");
                         }
                         Summary[j]+=ToAdd[j];

--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -931,7 +931,7 @@ void File__Analyze::Streams_Finish_StreamOnly(stream_t StreamKind, size_t Pos)
                 const auto& Item=List[i];
                 if (HI_ME_Pos==(size_t)-1 && (Item==HI_ME_Text || Item==VI_ME_Text))
                     HI_ME_Pos=i;
-                if (HI_D_Pos==(size_t)-1 && (Item==HI_D_Text || Item==HI_D_Text))
+                if (HI_D_Pos==(size_t)-1 && (Item==HI_D_Text || Item==VI_D_Text))
                     HI_D_Pos=i;
             }
             if (HI_ME_Pos!=(size_t)-1 && HI_D_Pos!=(size_t)-1)

--- a/Source/MediaInfo/HashWrapper.h
+++ b/Source/MediaInfo/HashWrapper.h
@@ -64,7 +64,7 @@ public:
 
     void            Update      (const int8u* Buffer, const size_t Buffer_Size);
     string          Generate    (const HashFunction Function);
-    static string   Generate    (const HashFunction Function, const int8u* Buffer, const size_t Buffer_Size) {return HashWrapper(1<<Function, Buffer, Buffer_Size).Generate(Function);}
+    static string   Generate    (const HashFunction Function, const int8u* Buffer, const size_t Buffer_Size) {return HashWrapper(static_cast<HashFunctions>(1)<<Function, Buffer, Buffer_Size).Generate(Function);}
     
     static string   Name        (const HashFunction Function);
     static string   Hex2String  (const int8u* Digest, const size_t Digest_Size);

--- a/Source/MediaInfo/Image/File_Jpeg.cpp
+++ b/Source/MediaInfo/Image/File_Jpeg.cpp
@@ -396,6 +396,7 @@ bool File_Jpeg::Demux_UnpacketizeContainer_Test()
             {
                 case Elements::SOD  :   //JPEG-2000 start
                                         StartIsFound=true;
+                                        break;
                 case Elements::TEM  :
                 case Elements::RST0 :
                 case Elements::RST1 :

--- a/Source/MediaInfo/Image/File_Png.cpp
+++ b/Source/MediaInfo/Image/File_Png.cpp
@@ -546,7 +546,7 @@ void File_Png::Textual(bitset8 Method)
     }
     Get_ISO_8859_1(Zero-Element_Offset, Keyword,                "Keyword");
     Skip_B1(                                                    "Null separator");
-    int8u Compression;
+    int8u Compression{};
     if (Method[IsCompressed])
     {
         if (Method[IsUTF8])

--- a/Source/MediaInfo/Image/File_Png.cpp
+++ b/Source/MediaInfo/Image/File_Png.cpp
@@ -316,7 +316,7 @@ void File_Png::IHDR()
             {
                 case 3:
                     Bit_depth=8; // From spec: "indexed-colour PNG images (colour type 3), in which the sample depth is always 8 bits" (sample depth is our bit depth
-                    // Fallthrough
+                    [[fallthrough]];
                 case 0 :
                 case 2:
                 case 4:

--- a/Source/MediaInfo/MediaInfo_Config.cpp
+++ b/Source/MediaInfo/MediaInfo_Config.cpp
@@ -2896,7 +2896,7 @@ const Ztring &MediaInfo_Config::Codec_Get (const Ztring &Value, infocodec_t Kind
 //---------------------------------------------------------------------------
 const Ztring &MediaInfo_Config::CodecID_Get (stream_t KindOfStream, infocodecid_format_t Format, const Ztring &Value, infocodecid_t KindOfCodecIDInfo)
 {
-    if (Format>=InfoCodecID_Format_Max || KindOfStream>=Stream_Max)
+    if (Format>=InfoCodecID_Format_Max || Format<0 || KindOfStream>=Stream_Max || KindOfStream<0)
         return EmptyString_Get();
     {
     CriticalSectionLocker CSL(CS);
@@ -2957,7 +2957,7 @@ const Ztring &MediaInfo_Config::CodecID_Get (stream_t KindOfStream, infocodecid_
 //---------------------------------------------------------------------------
 const Ztring &MediaInfo_Config::Library_Get (infolibrary_format_t Format, const Ztring &Value, infolibrary_t KindOfLibraryInfo)
 {
-    if (Format>=InfoLibrary_Format_Max)
+    if (Format>=InfoLibrary_Format_Max || Format<0)
         return EmptyString_Get();
     {
     CriticalSectionLocker CSL(CS);
@@ -3039,7 +3039,7 @@ const Ztring MediaInfo_Config::Iso639_Translate (const Ztring &Value)
 void MediaInfo_Config::Language_Set_Internal(stream_t KindOfStream)
 {
     //Loading codec table if not yet done
-    if (KindOfStream<Stream_Max && Info[KindOfStream].empty())
+    if (KindOfStream>=0 && KindOfStream<Stream_Max && Info[KindOfStream].empty())
         switch (KindOfStream)
         {
             case Stream_General :   MediaInfo_Config_General(Info[Stream_General]);   Language_Set(Stream_General); break;
@@ -3057,7 +3057,7 @@ void MediaInfo_Config::Language_Set_Internal(stream_t KindOfStream)
 const Ztring &MediaInfo_Config::Info_Get (stream_t KindOfStream, const Ztring &Value, info_t KindOfInfo)
 {
     Language_Set_All(KindOfStream);
-    if (KindOfStream>=Stream_Max)
+    if (KindOfStream<0 || KindOfStream>=Stream_Max)
         return EmptyString_Get();
     size_t Pos=Info[KindOfStream].Find(Value);
     if (Pos==Error || (size_t)KindOfInfo>=Info[KindOfStream][Pos].size())
@@ -3069,7 +3069,7 @@ const Ztring &MediaInfo_Config::Info_Get (stream_t KindOfStream, size_t Pos, inf
 {
     Language_Set_All(KindOfStream);
 
-    if (KindOfStream>=Stream_Max)
+    if (KindOfStream<0 || KindOfStream>=Stream_Max)
         return EmptyString_Get();
     if (Pos>=Info[KindOfStream].size() || (size_t)KindOfInfo>=Info[KindOfStream][Pos].size())
         return EmptyString_Get();
@@ -3078,7 +3078,7 @@ const Ztring &MediaInfo_Config::Info_Get (stream_t KindOfStream, size_t Pos, inf
 
 const ZtringListList &MediaInfo_Config::Info_Get(stream_t KindOfStream)
 {
-    if (KindOfStream>=Stream_Max)
+    if (KindOfStream<0 || KindOfStream>=Stream_Max)
         return EmptyStringListList_Get();
 
     Language_Set_All(KindOfStream);

--- a/Source/MediaInfo/MediaInfo_Config.h
+++ b/Source/MediaInfo/MediaInfo_Config.h
@@ -230,10 +230,10 @@ public :
           Ztring    Input_Compressed_Get();
           #endif //MEDIAINFO_COMPRESS
           #if MEDIAINFO_FLAG1
-          bool      Flags1_Get(config_flags1 Flag) { return Flags1&(1 << Flag); }
+          bool      Flags1_Get(config_flags1 Flag) { return Flags1&(static_cast<int64u>(1) << Flag); }
           #endif //MEDIAINFO_FLAGX
           #if MEDIAINFO_FLAGX
-          bool      FlagsX_Get(config_flagsX Flag) { return FlagsX&(1 << Flag); }
+          bool      FlagsX_Get(config_flagsX Flag) { return FlagsX&(static_cast<int64u>(1) << Flag); }
           #endif //MEDIAINFO_FLAGX
 
     const Ztring   &Format_Get (const Ztring &Value, infoformat_t KindOfFormatInfo=InfoFormat_Name);

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -3802,7 +3802,7 @@ config_probe MediaInfo_Config_MediaInfo::File_ProbeCaption_Get(const string& Par
             return {};
         const auto& Item = File_ProbeCaption[File_ProbeCaption_Pos];
         File_ProbeCaption_Pos++;
-        if (Item.Parser.empty()) {
+        if (!Item.Parser.empty()) {
             if (Item.Parser[0] == '-') {
                 if (Item.Parser.rfind(ParserName, 1) == 1) {
                     continue;

--- a/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_MediaInfo.cpp
@@ -3717,19 +3717,19 @@ Ztring MediaInfo_Config_MediaInfo::File_ProbeCaption_Set (const Ztring& NewValue
                 {
                 case 'E':
                     Value_Int <<= 10;
-                    // Fall through
+                    [[fallthrough]];
                 case 'P':
                     Value_Int <<= 10;
-                    // Fall through
+                    [[fallthrough]];
                 case 'T':
                     Value_Int <<= 10;
-                    // Fall through
+                    [[fallthrough]];
                 case 'G':
                     Value_Int <<= 10;
-                    // Fall through
+                    [[fallthrough]];
                 case 'M':
                     Value_Int <<= 10;
-                    // Fall through
+                    [[fallthrough]];
                 default:
                     Value_Int <<= 10;
                 }

--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -638,7 +638,7 @@ namespace
 {
 struct nested
 {
-    std::vector<Node*>* Target;
+    std::vector<Node*>* Target{};
     Ztring Name;
 };
 }

--- a/Source/MediaInfo/Multiple/File_Bdmv.cpp
+++ b/Source/MediaInfo/Multiple/File_Bdmv.cpp
@@ -1542,6 +1542,7 @@ void File_Bdmv::Mpls_ExtensionData_SubPath_entries()
                         for (int8u Pos=0; Pos<number_of_SubPlayItems; Pos++)
                             Mpls_PlayList_SubPlayItem(SubPath_type, Pos);
                         }
+                        break;
             default   : ;
         }
         if (SubPath_extension_End-Element_Offset)

--- a/Source/MediaInfo/Multiple/File_DvDif.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif.cpp
@@ -396,6 +396,7 @@ void File_DvDif::Streams_Fill()
                         case 7 : Fill(Stream_Video, 0, Video_DisplayAspectRatio, 4.0/3.0, 3, true); break;
                         default: ; //No indication of aspect ratio?
                      }
+                     break;
             default: ;
         }
     }
@@ -935,7 +936,7 @@ size_t File_DvDif::Read_Buffer_Seek (size_t Method, int64u Value, int64u /*ID*/)
                         //We transform TimeStamp to a frame number
                         Value=float64_int64s(((float64)Value)*(DSF?25.000:(30.000*1000/1001))/1000000000);
                     }
-                    //No break;
+                    [[fallthrough]];
         case 3  :   //FrameNumber
                     if (!FSP_WasNotSet)
                     {

--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -781,7 +781,7 @@ void File_DvDif::Errors_Stats_Update()
 
         // Coherency checking
         bool FSC_Incoherency=false;
-        if (FSC_WasSet_Sum && FSC_WasSet_Sum)
+        if (FSC_WasNotSet_Sum || FSC_WasSet_Sum)
         {
             int FSC_Diff=FSC_WasSet_Sum-FSC_WasNotSet_Sum;
             if (FSC_Diff<0)

--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -1073,12 +1073,12 @@ void File_DvDif::Errors_Stats_Update()
             if (AbstBf_Current_Weighted.abst[j].size()>1 && !AbstBf_Current_Weighted.StoredValues.empty())
             {
                 //Difficult to trust one value other another one, we use the smallest trustable stored value
-                for (set<int32s>::iterator StoredValue=AbstBf_Current_Weighted.StoredValues.begin(); ; StoredValue++)
+                for (set<int32s>::iterator StoredValue=AbstBf_Current_Weighted.StoredValues.begin(); ; ++StoredValue)
                     if (abst<=*StoredValue)
                     {
                         abst=*StoredValue;
                         AbstBf_Current_MaxAbst=abst;
-                        for (; StoredValue!=AbstBf_Current_Weighted.StoredValues.end(); StoredValue++)
+                        for (; StoredValue!=AbstBf_Current_Weighted.StoredValues.end(); ++StoredValue)
                         {
                             if (*StoredValue>=(abst+(DSF?12:10)*(FSC_WasSet?2:1)*2)) //Max 2x the expected gap
                                 break;

--- a/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
+++ b/Source/MediaInfo/Multiple/File_DvDif_Analysis.cpp
@@ -1422,8 +1422,7 @@ void File_DvDif::Errors_Stats_Update()
             #if MEDIAINFO_EVENTS
                 Event.Arb|=1<<7;
             #endif //MEDIAINFO_EVENTS
-            if (Speed_Arb_Current.Value!=0xF)
-                Arb_AreDetected=true;
+            Arb_AreDetected=true;
 
             Speed_Arb_Current_Theory.IsValid=false;
         }

--- a/Source/MediaInfo/Multiple/File_Gxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Gxf.cpp
@@ -713,7 +713,7 @@ size_t File_Gxf::Read_Buffer_Seek (size_t Method, int64u Value, int64u)
                         else
                             Value=float64_int64s(((float64)(Value-Delay))/1000000000*Gxf_FrameRate(Streams[0x00].FrameRate_Code));
                     }
-                    //No break;
+                    [[fallthrough]];
         case 3  :   //FrameNumber
                     {
                     if (Seeks.empty())

--- a/Source/MediaInfo/Multiple/File_Gxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Gxf.cpp
@@ -1482,7 +1482,7 @@ void File_Gxf::media()
         {
             if (!Streams[TrackNumber].Parsers[Pos]->Status[IsAccepted] && Streams[TrackNumber].Parsers[Pos]->Status[IsFinished])
             {
-                delete *(Streams[TrackNumber].Parsers.begin()+Pos);
+                delete static_cast<MediaInfoLib::File__Analyze*>(*(Streams[TrackNumber].Parsers.begin()+Pos));
                 Streams[TrackNumber].Parsers.erase(Streams[TrackNumber].Parsers.begin()+Pos);
                 Pos--;
             }
@@ -1492,7 +1492,7 @@ void File_Gxf::media()
                 for (size_t Pos2=0; Pos2<Streams[TrackNumber].Parsers.size(); Pos2++)
                 {
                     if (Pos2!=Pos)
-                        delete *(Streams[TrackNumber].Parsers.begin()+Pos2);
+                        delete static_cast<MediaInfoLib::File__Analyze*>(*(Streams[TrackNumber].Parsers.begin()+Pos2));
                 }
                 Streams[TrackNumber].Parsers.clear();
                 Streams[TrackNumber].Parsers.push_back(Parser);

--- a/Source/MediaInfo/Multiple/File_Lxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Lxf.cpp
@@ -1552,7 +1552,7 @@ void File_Lxf::Audio_Stream(size_t Pos)
         {
             if (!Audios[Pos].Parsers[Pos2]->Status[IsAccepted] && Audios[Pos].Parsers[Pos2]->Status[IsFinished])
             {
-                delete *(Audios[Pos].Parsers.begin()+Pos2);
+                delete static_cast<MediaInfoLib::File__Analyze*>(*(Audios[Pos].Parsers.begin()+Pos2));
                 Audios[Pos].Parsers.erase(Audios[Pos].Parsers.begin()+Pos2);
                 Pos2--;
             }
@@ -1562,7 +1562,7 @@ void File_Lxf::Audio_Stream(size_t Pos)
                 for (size_t Pos3=0; Pos3<Audios[Pos].Parsers.size(); Pos3++)
                 {
                     if (Pos3!=Pos2)
-                        delete *(Audios[Pos].Parsers.begin()+Pos3);
+                        delete static_cast<MediaInfoLib::File__Analyze*>(*(Audios[Pos].Parsers.begin()+Pos3));
                 }
                 Audios[Pos].Parsers.clear();
                 Audios[Pos].Parsers.push_back(Parser);
@@ -1843,7 +1843,7 @@ void File_Lxf::Video_Stream_2()
         {
             if (!Videos[2].Parsers[Pos2]->Status[IsAccepted] && Videos[2].Parsers[Pos2]->Status[IsFinished])
             {
-                delete *(Videos[2].Parsers.begin()+Pos2);
+                delete static_cast<MediaInfoLib::File__Analyze*>(*(Videos[2].Parsers.begin()+Pos2));
                 Videos[2].Parsers.erase(Videos[2].Parsers.begin()+Pos2);
                 Pos2--;
             }
@@ -1853,7 +1853,7 @@ void File_Lxf::Video_Stream_2()
                 for (size_t Pos3=0; Pos3<Videos[2].Parsers.size(); Pos3++)
                 {
                     if (Pos3!=Pos2)
-                        delete *(Videos[2].Parsers.begin()+Pos3);
+                        delete static_cast<MediaInfoLib::File__Analyze*>(*(Videos[2].Parsers.begin()+Pos3));
                 }
                 Videos[2].Parsers.clear();
                 Videos[2].Parsers.push_back(Parser);

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -1439,7 +1439,7 @@ void File_Mk::Read_Buffer_Unsynched()
     if (!File_GoTo)
         Element_Level=0;
 
-    for (std::map<int64u, stream>::iterator streamItem=Stream.begin(); streamItem!=Stream.end(); streamItem++)
+    for (std::map<int64u, stream>::iterator streamItem=Stream.begin(); streamItem!=Stream.end(); ++streamItem)
     {
         if (!File_GoTo)
             streamItem->second.PacketCount=0;

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -5361,7 +5361,7 @@ void File_Mk::sei_message_user_data_registered_itu_t_t35_B5_003C_0001_04()
     Get_B1 (application_version,                                "application_version");
     if (application_version<=1)
     {
-        int32u targeted_system_display_maximum_luminance, maxscl[4], distribution_maxrgb_percentiles[16];
+        int32u targeted_system_display_maximum_luminance, maxscl[4]{}, distribution_maxrgb_percentiles[16];
         int16u fraction_bright_pixels;
         int8u num_distribution_maxrgb_percentiles, distribution_maxrgb_percentages[16], num_windows, num_bezier_curve_anchors;
         bool targeted_system_display_actual_peak_luminance_flag, mastering_display_actual_peak_luminance_flag, color_saturation_mapping_flag;

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Descriptors.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Descriptors.cpp
@@ -545,7 +545,7 @@ void File_Mpeg4_Descriptors::Data_Parse()
 void File_Mpeg4_Descriptors::Descriptor_01()
 {
     //Parsing
-    int8u ProfileLevel[5];
+    int8u ProfileLevel[5]{};
     bool URL_Flag;
     BS_Begin();
     Skip_S2(10,                                                 "ObjectDescriptorID");

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -1683,10 +1683,11 @@ void File_Mpeg4::ftyp()
                                            #if MEDIAINFO_CONFORMANCE
                                                IsCmaf=true;
                                            #endif
-                                           //fall through
+                                           [[fallthrough]];
                 case Elements::ftyp_dash :
                                            if (Config->File_Names.size()==1)
                                                TestContinuousFileNames(1, __T("m4s"));
+                                           [[fallthrough]];
                 default : ;
             }
         CodecID_Fill(Ztring().From_CC4(MajorBrand), Stream_General, 0, InfoCodecID_Format_Mpeg4);
@@ -2223,7 +2224,7 @@ void File_Mpeg4::mdat_xxxx()
                                             Probe.Start=Probe.Start*100/File_Size; //File pos is not relevant there
                                             if (!Probe.Start)
                                                 Probe.Start=50;
-                                            // Fall through
+                                            [[fallthrough]];
                                         case config_probe_percent:
                                             ProbeCaption_mdatPos=Stream.second.stts_FrameCount*Probe.Start/100;
                                             break;
@@ -2236,7 +2237,7 @@ void File_Mpeg4::mdat_xxxx()
                                             Probe.Duration=Probe.Duration*100/File_Size; //File pos is not relevant there
                                             if (!Probe.Duration)
                                                 Probe.Duration++;
-                                            // Fall through
+                                            [[fallthrough]];
                                         case config_probe_percent:
                                             ProbeCaption_mdatDur=Stream.second.stts_FrameCount*Probe.Duration/100;
                                             break;
@@ -2295,7 +2296,7 @@ void File_Mpeg4::mdat_xxxx()
         {
             if (!Stream_Temp.Parsers[Pos]->Status[IsAccepted] && Stream_Temp.Parsers[Pos]->Status[IsFinished])
             {
-                delete *(Stream_Temp.Parsers.begin()+Pos);
+                delete static_cast<MediaInfoLib::File__Analyze*>(*(Stream_Temp.Parsers.begin()+Pos));
                 Stream_Temp.Parsers.erase(Stream_Temp.Parsers.begin()+Pos);
                 Pos--;
             }
@@ -2305,7 +2306,7 @@ void File_Mpeg4::mdat_xxxx()
                 for (size_t Pos2=0; Pos2<Stream_Temp.Parsers.size(); Pos2++)
                 {
                     if (Pos2!=Pos)
-                        delete *(Stream_Temp.Parsers.begin()+Pos2);
+                        delete static_cast<MediaInfoLib::File__Analyze*>(*(Stream_Temp.Parsers.begin()+Pos2));
                 }
                 Stream_Temp.Parsers_Clear();
                 Stream_Temp.Parsers.push_back(Parser);
@@ -3562,6 +3563,7 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                                              //Not normal
                                              Kind=0x00;
                                          }
+                                         [[fallthrough]];
         default                        : ;
     }
 
@@ -4033,6 +4035,7 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                         Fill(Stream_General, 0, Parameter.c_str(), Value, true);
                 FILLING_END();
             }
+            break;
         default: ;
     }
 }
@@ -4413,6 +4416,7 @@ void File_Mpeg4::moov_trak_mdia_hdlr()
                 break;
             case Elements::moov_trak_mdia_hdlr_MPEG :
                 mdat_MustParse=true; //Data is in MDAT
+                break;
             case Elements::moov_trak_mdia_hdlr_alis :
                 //Stream_Prepare(Stream_Other);
                 //Fill(Stream_Other, StreamPos_Last, Other_Type, "Alias"); //TODO: what is the meaning of such hdlr?
@@ -5132,7 +5136,7 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_sgpd()
     }
 
     //Parsing
-    int32u grouping_type, Count, default_length;
+    int32u grouping_type, Count, default_length{};
     Get_C4 (grouping_type,                                      "grouping_type");
     if (Version==1)
         Get_B4 (default_length,                                 "default_length");

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -2184,12 +2184,9 @@ void File_Mpeg4::mdat_xxxx()
                     File_Offset_Next_IsValid=false;
                 }
                 mdat_pos mdat_Pos_New;
-                if (!mdat_Pos.empty())
-                {
-                    for (mdat_Pos_Type* mdat_Pos_Item=&mdat_Pos[0]; mdat_Pos_Item<mdat_Pos_Max; ++mdat_Pos_Item)
-                        if (mdat_Pos_Item->StreamID!=(int32u)Element_Code)
-                            mdat_Pos_New.push_back(*mdat_Pos_Item);
-                }
+                for (mdat_Pos_Type* mdat_Pos_Item=&mdat_Pos[0]; mdat_Pos_Item<mdat_Pos_Max; ++mdat_Pos_Item)
+                    if (mdat_Pos_Item->StreamID!=(int32u)Element_Code)
+                        mdat_Pos_New.push_back(*mdat_Pos_Item);
                 if (!mdat_Pos_New.empty())
                 {
                     mdat_Pos=std::move(mdat_Pos_New);
@@ -2300,7 +2297,7 @@ void File_Mpeg4::mdat_xxxx()
                 Stream_Temp.Parsers.erase(Stream_Temp.Parsers.begin()+Pos);
                 Pos--;
             }
-            else if (Stream_Temp.Parsers.size()>1 && Stream_Temp.Parsers[Pos]->Status[IsAccepted])
+            else if (Stream_Temp.Parsers[Pos]->Status[IsAccepted])
             {
                 File__Analyze* Parser=Stream_Temp.Parsers[Pos];
                 for (size_t Pos2=0; Pos2<Stream_Temp.Parsers.size(); Pos2++)
@@ -2329,14 +2326,9 @@ void File_Mpeg4::mdat_StreamJump()
             std::map<int64u, int64u>::iterator StreamOffset_Jump_Temp=StreamOffset_Jump.find(File_Offset+Buffer_Offset+Element_Size);
             if (StreamOffset_Jump_Temp!=StreamOffset_Jump.end())
             {
-                if (!mdat_Pos.empty())
-                {
-                    mdat_Pos_Temp=&mdat_Pos[0];
-                    while (mdat_Pos_Temp<mdat_Pos_Max && mdat_Pos_Temp->Offset!=StreamOffset_Jump_Temp->second)
-                        mdat_Pos_Temp++;
-                }
-                else
-                    mdat_Pos_Temp=NULL;
+                mdat_Pos_Temp=&mdat_Pos[0];
+                while (mdat_Pos_Temp<mdat_Pos_Max && mdat_Pos_Temp->Offset!=StreamOffset_Jump_Temp->second)
+                    mdat_Pos_Temp++;
             }
         }
     #endif // MEDIAINFO_DEMUX
@@ -8119,7 +8111,7 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxx_pcmC()
             if (Streams[moov_trak_tkhd_TrackID].IsPcm)
             {
                 char EndiannessC=(format_flags&1)?'L':'B';
-                std::vector<File__Analyze*>& Parsers=Streams[moov_trak_tkhd_TrackID].Parsers;
+                const std::vector<File__Analyze*>& Parsers=Streams[moov_trak_tkhd_TrackID].Parsers;
                 for (size_t i=0; i< Parsers.size(); i++)
                 {
                     ((File_Pcm_Base*)Parsers[i])->Endianness=EndiannessC;
@@ -8414,7 +8406,7 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxx_wave_enda()
             if (Streams[moov_trak_tkhd_TrackID].IsPcm)
             {
                 char EndiannessC=Endianness?'L':'B';
-                std::vector<File__Analyze*>& Parsers=Streams[moov_trak_tkhd_TrackID].Parsers;
+                const std::vector<File__Analyze*>& Parsers=Streams[moov_trak_tkhd_TrackID].Parsers;
                 for (size_t i=0; i< Parsers.size(); i++)
                     ((File_Pcm_Base*)Parsers[i])->Endianness=EndiannessC;
             }
@@ -8993,7 +8985,6 @@ void File_Mpeg4::moov_trak_tkhd()
 
     FILLING_BEGIN();
         //Handle tracks with same ID than a previous track
-        bool tkhd_SameID=false;
         std::map<int32u, stream>::iterator PreviousTrack=Streams.find(moov_trak_tkhd_TrackID);
         if (PreviousTrack!=Streams.end() && PreviousTrack->second.tkhd_Found)
         {
@@ -9897,7 +9888,7 @@ void File_Mpeg4::moov_udta_thmb()
     MediaInfo_Internal MI;
     Ztring Demux_Save = MI.Option(__T("Demux_Get"), __T(""));
     MI.Option(__T("Demux"), Ztring());
-    size_t MiOpenResult = MI.Open(Buffer + (size_t)(Buffer_Offset + Element_Offset), (size_t)(Element_Size - Element_Offset), nullptr, 0, (size_t)(Element_Size - Element_Offset));
+    MI.Open(Buffer + (size_t)(Buffer_Offset + Element_Offset), (size_t)(Element_Size - Element_Offset), nullptr, 0, (size_t)(Element_Size - Element_Offset));
     MI.Option(__T("Demux"), Demux_Save); //This is a global value, need to reset it. TODO: local value
     if (MI.Count_Get(Stream_Image))
     {

--- a/Source/MediaInfo/Multiple/File_MpegPs.cpp
+++ b/Source/MediaInfo/Multiple/File_MpegPs.cpp
@@ -4032,6 +4032,7 @@ void File_MpegPs::xxx_stream_Parse(ps_stream &Temp, int8u &stream_Count)
                     Temp.Searching_TimeStamp_Start=false;
                 }
             }
+            break;
         default : ;
     }
 

--- a/Source/MediaInfo/Multiple/File_MpegPs.cpp
+++ b/Source/MediaInfo/Multiple/File_MpegPs.cpp
@@ -4096,7 +4096,7 @@ void File_MpegPs::xxx_stream_Parse(ps_stream &Temp, int8u &stream_Count)
             {
                 if (!Temp.Parsers[Pos]->Status[IsAccepted] && Temp.Parsers[Pos]->Status[IsFinished])
                 {
-                    delete *(Temp.Parsers.begin()+Pos);
+                    delete static_cast<MediaInfoLib::File__Analyze*>(*(Temp.Parsers.begin()+Pos));
                     Temp.Parsers.erase(Temp.Parsers.begin()+Pos);
                     Pos--;
                 }
@@ -4106,7 +4106,7 @@ void File_MpegPs::xxx_stream_Parse(ps_stream &Temp, int8u &stream_Count)
                     for (size_t Pos2=0; Pos2<Temp.Parsers.size(); Pos2++)
                     {
                         if (Pos2!=Pos)
-                            delete *(Temp.Parsers.begin()+Pos2);
+                            delete static_cast<MediaInfoLib::File__Analyze*>(*(Temp.Parsers.begin()+Pos2));
                     }
                     Temp.Parsers.clear();
                     Temp.Parsers.push_back(Parser);

--- a/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
@@ -3266,6 +3266,7 @@ void File_Mpeg_Descriptors::Descriptor_7B()
                         {
                             Complete_Stream->Streams[elementary_PID]->descriptor_tag=0x7B;
                         }
+                        break;
             default   : ;
         }
     FILLING_END();
@@ -3304,6 +3305,7 @@ void File_Mpeg_Descriptors::Descriptor_7C()
                             Complete_Stream->Streams[elementary_PID]->descriptor_tag=0x7C;
                             Complete_Stream->Streams[elementary_PID]->Infos["Format_Profile"]=Mpeg_Descriptors_MPEG_4_audio_profile_and_level(Profile_and_level);
                         }
+                        break;
             default   : ;
         }
     FILLING_END();

--- a/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
@@ -3499,7 +3499,7 @@ void File_Mpeg_Descriptors::Descriptor_7F_19()
         {
             Complete_Stream->Streams[elementary_PID]->StreamKind_FromDescriptor=Stream_Audio;
             size_t Infos_Pos=0;
-            for (map<int8u, Descriptor_7F_19_Info>::iterator Info=Infos.begin(); Info!=Infos.end(); Info++)
+            for (map<int8u, Descriptor_7F_19_Info>::iterator Info=Infos.begin(); Info!=Infos.end(); ++Info)
             {
                 string Prefix="Preselection"+Ztring::ToZtring(Info->first).To_UTF8();
                 if (Info->second.preselection_id!=Infos_Pos)

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -6503,7 +6503,7 @@ void File_Mxf::Data_Parse()
                     {
                         if (!Essence->second.Parsers[Pos]->Status[IsAccepted] && Essence->second.Parsers[Pos]->Status[IsFinished])
                         {
-                            delete *(Essence->second.Parsers.begin()+Pos);
+                            delete static_cast<MediaInfoLib::File__Analyze*>(*(Essence->second.Parsers.begin()+Pos));
                             Essence->second.Parsers.erase(Essence->second.Parsers.begin()+Pos);
                             Pos--;
                         }
@@ -6513,7 +6513,7 @@ void File_Mxf::Data_Parse()
                             for (size_t Pos2=0; Pos2<Essence->second.Parsers.size(); Pos2++)
                             {
                                 if (Pos2!=Pos)
-                                    delete *(Essence->second.Parsers.begin()+Pos2);
+                                    delete static_cast<MediaInfoLib::File__Analyze*>(*(Essence->second.Parsers.begin()+Pos2));
                             }
                             Essence->second.Parsers.clear();
                             Essence->second.Parsers.push_back(Parser);

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -5132,7 +5132,7 @@ size_t File_Mxf::Read_Buffer_Seek (size_t Method, int64u Value, int64u ID)
                         }
                         Value=float64_int64s(((float64)Value)/1000000000*Descriptor->second.SampleRate);
                         }
-                    //No break;
+                    [[fallthrough]];
         case 3  :   //FrameNumber
                     Value+=Config->File_IgnoreEditsBefore;
 
@@ -14321,6 +14321,7 @@ void File_Mxf::ChooseParser__FromCodingScheme(const essences::iterator &Essence,
                                                                         ChooseParser_SmpteSt0337(Essence, Descriptor);
                                                                     if (Descriptor->second.ChannelCount>=2 && Descriptor->second.ChannelCount!=(int32u)-1) //PCM, but one file is found with Dolby E in it
                                                                         ChooseParser_ChannelSplitting(Essence, Descriptor);
+                                                                    [[fallthrough]];
                                                         default   : return ChooseParser_Pcm(Essence, Descriptor);
                                                     }
                                         case 0x02 : //Compressed coding

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -2718,7 +2718,7 @@ void File_Mxf::Streams_Finish_Essence(int32u EssenceUID, int128u TrackUID)
         //Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_TimeCode_FirstFrame), TC.ToString().c_str());
         //Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_TimeCode_Source), "Time code track (stripped)");
     }
-    size_t SDTI_TimeCode_StartTimecode_StreamPos_Last;
+    size_t SDTI_TimeCode_StartTimecode_StreamPos_Last{};
     if (SDTI_TimeCode_StartTimecode.IsSet())
     {
         SDTI_TimeCode_StartTimecode_StreamPos_Last=StreamPos_Last;
@@ -2729,7 +2729,7 @@ void File_Mxf::Streams_Finish_Essence(int32u EssenceUID, int128u TrackUID)
         //Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_TimeCode_FirstFrame), SDTI_TimeCode_StartTimecode.c_str());
         //Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_TimeCode_Source), "SDTI");
     }
-    size_t SystemScheme1_TimeCodeArray_StartTimecode_StreamPos_Last;
+    size_t SystemScheme1_TimeCodeArray_StartTimecode_StreamPos_Last{};
     if (!SystemScheme1s.empty() && !SystemScheme1s.begin()->second.TimeCodeArray_StartTimecodes.empty())
     {
         SystemScheme1_TimeCodeArray_StartTimecode_StreamPos_Last=StreamPos_Last;

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -4034,7 +4034,7 @@ void File_Mxf::Streams_Finish_Component_ForTimeCode(const int128u ComponentUID, 
                     TimeCode TC2=Component_TC2->second.MxfTimeCode.RoundedTimecodeBase<0x8000?TimeCode((int64_t)(Component_TC2->second.MxfTimeCode.StartTimecode+Config->File_IgnoreEditsBefore), Component_TC2->second.MxfTimeCode.RoundedTimecodeBase-1, TimeCode::DropFrame(Component2->second.MxfTimeCode.DropFrame).FPS1001(Component2->second.MxfTimeCode.DropFrame)):TimeCode();
                     if (TC2.ToFrames()-TC.ToFrames()==2)
                     {
-                        TC++;
+                        ++TC;
                         IsHybridTimeCode=true;
                     }
                 }
@@ -8817,7 +8817,7 @@ void File_Mxf::SDTISystemMetadataPack() //SMPTE 385M + 326M
             if (SDTI_TimeCode_Previous.IsSet() && TimeCode_Current==SDTI_TimeCode_Previous)
             {
                 SDTI_TimeCode_RepetitionCount++;
-                TimeCode_Current++;
+                ++TimeCode_Current;
                 if (!SDTI_TimeCode_StartTimecode.IsSet() && SDTI_TimeCode_RepetitionCount>=RepetitionMaxCount)
                     SDTI_TimeCode_StartTimecode=SDTI_TimeCode_Previous; //The first time code was the first one of the repetition sequence
             }
@@ -8828,7 +8828,7 @@ void File_Mxf::SDTISystemMetadataPack() //SMPTE 385M + 326M
                     SDTI_TimeCode_StartTimecode=SDTI_TimeCode_Previous;
                     while(SDTI_TimeCode_RepetitionCount<RepetitionMaxCount)
                     {
-                        SDTI_TimeCode_StartTimecode++;
+                        ++SDTI_TimeCode_StartTimecode;
                         SDTI_TimeCode_RepetitionCount++;
                     }
                 }

--- a/Source/MediaInfo/Multiple/File_Nsv.cpp
+++ b/Source/MediaInfo/Multiple/File_Nsv.cpp
@@ -837,7 +837,7 @@ void File_StarDiva::Read_Buffer_Continue()
 
 
     size_t Begin;
-    size_t End;
+    size_t End{};
 
     Element_Begin1("StarDiva time line data");
         Element_Begin1("Header");

--- a/Source/MediaInfo/Multiple/File_Nsv.cpp
+++ b/Source/MediaInfo/Multiple/File_Nsv.cpp
@@ -1248,7 +1248,7 @@ void File_StarDiva::Read_Buffer_Continue()
                 // Eliminate obviously wrong catches: 1 char long but another catch has longer strings
                 size_t MinMinStringSize=(size_t)-1;
                 size_t MaxMinStringSize=0;
-                for(map<int, size_t>::iterator It=CheckOfMultiplesOfTimes2x_Values.begin(); It!=CheckOfMultiplesOfTimes2x_Values.end(); It++)
+                for(map<int, size_t>::iterator It=CheckOfMultiplesOfTimes2x_Values.begin(); It!=CheckOfMultiplesOfTimes2x_Values.end(); ++It)
                 {
                     if (MinMinStringSize>It->second)
                         MinMinStringSize=It->second;
@@ -1256,7 +1256,7 @@ void File_StarDiva::Read_Buffer_Continue()
                         MaxMinStringSize=It->second;
                 }
                 if (MinMinStringSize==1 && MaxMinStringSize>1)
-                    for(map<int, size_t>::iterator It=CheckOfMultiplesOfTimes2x_Values.begin(); It!=CheckOfMultiplesOfTimes2x_Values.end(); It++)
+                    for(map<int, size_t>::iterator It=CheckOfMultiplesOfTimes2x_Values.begin(); It!=CheckOfMultiplesOfTimes2x_Values.end(); ++It)
                     {
                         if (It->second!=1)
                         {

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -2635,7 +2635,7 @@ void File_Riff::AVI__movi_xxxx()
             {
                 if (!StreamItem.Parsers[Pos]->Status[IsAccepted] && StreamItem.Parsers[Pos]->Status[IsFinished])
                 {
-                    delete *(StreamItem.Parsers.begin()+Pos);
+                    delete static_cast<MediaInfoLib::File__Analyze*>(*(StreamItem.Parsers.begin()+Pos));
                     StreamItem.Parsers.erase(StreamItem.Parsers.begin()+Pos);
                     Pos--;
                 }
@@ -2645,7 +2645,7 @@ void File_Riff::AVI__movi_xxxx()
                     for (size_t Pos2=0; Pos2<StreamItem.Parsers.size(); Pos2++)
                     {
                         if (Pos2!=Pos)
-                            delete *(StreamItem.Parsers.begin()+Pos2);
+                            delete static_cast<MediaInfoLib::File__Analyze*>(*(StreamItem.Parsers.begin()+Pos2));
                     }
                     StreamItem.Parsers.clear();
                     StreamItem.Parsers.push_back(Parser);

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -2795,7 +2795,7 @@ void File_Riff::AVI__movi_StreamJump()
     else if (Stream_Structure_Temp!=Stream_Structure.end())
     {
         do
-            Stream_Structure_Temp++;
+            ++Stream_Structure_Temp;
         while (Stream_Structure_Temp!=Stream_Structure.end() && !(Stream[(int32u)Stream_Structure_Temp->second.Name].SearchingPayload && Config->ParseSpeed<1.0));
         if (Stream_Structure_Temp!=Stream_Structure.end())
         {

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -2169,6 +2169,7 @@ void File_Riff::AVI__hdlr_strl_vprp()
                             Fill(Stream_Video, 0, Video_ScanOrder, "TFF");
                         if (VideoYValidStartLines.size()==2 && VideoYValidStartLines[0]>VideoYValidStartLines[1])
                             Fill(Stream_Video, 0, Video_ScanOrder, "BFF");
+                        break;
             default: ;
         }
     FILLING_END();

--- a/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
+++ b/Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
@@ -1220,7 +1220,8 @@ void File__ReferenceFilesHelper::ParseReference()
                     }
                 #endif //MEDIAINFO_DEMUX
 
-                DTS_Temp+=Sequences[Sequences_Current]->Resources[Sequences[Sequences_Current]->Resources_Current]->Demux_Offset_DTS;
+                if (!Sequences[Sequences_Current]->Resources.empty())
+                    DTS_Temp+=Sequences[Sequences_Current]->Resources[Sequences[Sequences_Current]->Resources_Current]->Demux_Offset_DTS;
                 if (!Sequences[Sequences_Current]->Resources.empty() && Sequences[Sequences_Current]->Resources_Current<Sequences[Sequences_Current]->Resources.size() && Sequences[Sequences_Current]->Resources[Sequences[Sequences_Current]->Resources_Current]->EditRate && Sequences[Sequences_Current]->Resources[Sequences[Sequences_Current]->Resources_Current]->IgnoreEditsBefore)
                 {
                     int64u TimeOffset=float64_int64s(((float64)Sequences[Sequences_Current]->Resources[Sequences[Sequences_Current]->Resources_Current]->IgnoreEditsBefore)/Sequences[Sequences_Current]->Resources[Sequences[Sequences_Current]->Resources_Current]->EditRate*1000000000);
@@ -1445,7 +1446,7 @@ void File__ReferenceFilesHelper::ParseReference_Finalize_PerStream ()
                 MI2.Option(__T("File_Demux_Rate"), Ztring::ToZtring(FrameRate));
             else if (!Sequences[Sequences_Current]->Resources.empty() && Sequences[Sequences_Current]->Resources[0]->EditRate) //TODO: per Pos
                 MI2.Option(__T("File_Demux_Rate"), Ztring::ToZtring(Sequences[Sequences_Current]->Resources[0]->EditRate));
-            size_t MiOpenResult=MI2.Open(Sequences[Sequences_Current]->Resources[Pos]->FileNames.Read());
+            size_t MiOpenResult = (!Sequences[Sequences_Current]->Resources.empty()) ? MI2.Open(Sequences[Sequences_Current]->Resources[Pos]->FileNames.Read()) : 0;
             MI2.Option(__T("ParseSpeed"), ParseSpeed_Save); //This is a global value, need to reset it. TODO: local value
             MI2.Option(__T("Demux"), Demux_Save); //This is a global value, need to reset it. TODO: local value
             if (MiOpenResult)

--- a/Source/MediaInfo/Reader/Reader_File.cpp
+++ b/Source/MediaInfo/Reader/Reader_File.cpp
@@ -28,15 +28,7 @@
 #include "ZenLib/FileName.h"
 #ifdef WINDOWS
     #undef __TEXT
-    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
-        namespace WindowsNamespace
-        {
-    #endif
-    #include "windows.h"
-    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
-        }
-        using namespace WindowsNamespace;
-    #endif
+    #include "Windows.h"
 #endif //WINDOWS
 using namespace ZenLib;
 using namespace std;

--- a/Source/MediaInfo/Reader/Reader_File.h
+++ b/Source/MediaInfo/Reader/Reader_File.h
@@ -25,15 +25,7 @@
 #if MEDIAINFO_READTHREAD
     #ifdef WINDOWS
         #undef __TEXT
-        #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
-            namespace WindowsNamespace
-            {
-        #endif
-        #include "windows.h"
-        #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
-            }
-            using namespace WindowsNamespace;
-        #endif
+        #include "Windows.h"
     #endif //WINDOWS
 #endif //MEDIAINFO_READTHREAD
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Reader/Reader_libcurl_Include.h
+++ b/Source/MediaInfo/Reader/Reader_libcurl_Include.h
@@ -912,15 +912,7 @@ extern "C"
     static GModule* libcurl_Module=NULL;
 #elif defined (_WIN32) || defined (WIN32)
     #undef __TEXT
-    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
-        namespace WindowsNamespace
-        {
-    #endif
-    #include "windows.h"
-    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
-        }
-        using namespace WindowsNamespace;
-    #endif
+    #include <windows.h>
     static HMODULE  libcurl_Module=NULL;
 #else
     #include <dlfcn.h>

--- a/Source/MediaInfo/Text/File_AribStdB24B37.cpp
+++ b/Source/MediaInfo/Text/File_AribStdB24B37.cpp
@@ -748,8 +748,9 @@ void File_AribStdB24B37::caption_statement() //caption_data()
                     MuxingMode=HasCcis?7:(int8u)-1; // "CCIS" or nothing
             }
         Frame_Count_NotParsedIncluded=Frame_Count;
-        EVENT_BEGIN (Global, SimpleText, 0)
-            Event.Content=Streams[(size_t)(Element_Code-1)].Line.To_Unicode().c_str();
+        EVENT_BEGIN(Global, SimpleText, 0)
+            std::wstring Line_Unicode{ Streams[(size_t)(Element_Code - 1)].Line.To_Unicode() };
+            Event.Content=Line_Unicode.c_str();
             Event.Flags=0;
             Event.MuxingMode=MuxingMode;
             Event.Service=(int8u)Element_Code;

--- a/Source/MediaInfo/Text/File_AribStdB24B37.cpp
+++ b/Source/MediaInfo/Text/File_AribStdB24B37.cpp
@@ -28,15 +28,7 @@
 #include <vector>
 #ifdef __WINDOWS__
     #undef __TEXT
-    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
-        namespace WindowsNamespace
-        {
-    #endif
     #include "windows.h"
-    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
-        }
-        using namespace WindowsNamespace;
-    #endif
 #endif // __WINDOWS__
 
 #if MEDIAINFO_EVENTS

--- a/Source/MediaInfo/Text/File_Eia608.cpp
+++ b/Source/MediaInfo/Text/File_Eia608.cpp
@@ -982,6 +982,7 @@ void File_Eia608::Special_14(int8u cc_data_2)
         case 0x2F : //EOC - end of Caption
                     TextMode=false;
                     StreamPos=TextMode*2+DataChannelMode;
+                    break;
         default: ;
     }
 

--- a/Source/MediaInfo/Text/File_N19.cpp
+++ b/Source/MediaInfo/Text/File_N19.cpp
@@ -826,11 +826,12 @@ void File_N19::Data_Parse()
                 }
             }
 
-            EVENT_BEGIN (Global, SimpleText, 0)
+            EVENT_BEGIN(Global, SimpleText, 0)
+                std::wstring TF_Unicode{ TF.To_Unicode() };
                 Event.DTS=((int64u)N19_HHMMSSFF_TC(TCI, FrameRate).ToMilliseconds())*1000000; // "-TCP" removed for the moment. TODO: find a way for when TCP should be removed and when it should not
                 Event.PTS=Event.DTS;
                 Event.DUR=((int64u)(N19_HHMMSSFF_TC(TCO, FrameRate)-N19_HHMMSSFF_TC(TCI, FrameRate)).ToMilliseconds())*1000000;
-                Event.Content=TF.To_Unicode().c_str();
+                Event.Content=TF_Unicode.c_str();
                 Event.Flags=0;
                 Event.MuxingMode=(int8u)-1;
                 Event.Service=(int8u)-1;

--- a/Source/MediaInfo/Text/File_Pac.cpp
+++ b/Source/MediaInfo/Text/File_Pac.cpp
@@ -115,7 +115,7 @@ void File_Pac::Streams_Finish()
     Fill(Stream_Text, 0, Text_TimeCode_FirstFrame, Time_Start_Command.ToString());
     Fill(Stream_Text, 0, Text_Duration_End_Command, (int64s)(Time_End_Command - Offset).ToMilliseconds());
     TimeCode LastFrame = Time_End_Command;
-    LastFrame--;
+    --LastFrame;
     Fill(Stream_Text, 0, Text_TimeCode_LastFrame, LastFrame.ToString());
     if (Time_Start.IsValid()) {
         Time_Start.SetFramesMax(FrameMax);

--- a/Source/MediaInfo/Text/File_SubRip.cpp
+++ b/Source/MediaInfo/Text/File_SubRip.cpp
@@ -438,11 +438,12 @@ void File_SubRip::Read_Buffer_Continue()
         for (; Items_Pos<Items.size(); Items_Pos++)
         {
             Frame_Count_NotParsedIncluded=Frame_Count;
-            EVENT_BEGIN (Global, SimpleText, 0)
+            EVENT_BEGIN(Global, SimpleText, 0)
+                std::wstring Content_Unicode{ Items[Items_Pos].Content.To_Unicode() };
                 Event.DTS=Items[Items_Pos].PTS_Begin;
                 Event.PTS=Event.DTS;
                 Event.DUR=Items[Items_Pos].PTS_End-Items[Items_Pos].PTS_Begin;
-                Event.Content=Items[Items_Pos].Content.To_Unicode().c_str();
+                Event.Content=Content_Unicode.c_str();
                 Event.Flags=IsVTT?1:0;
                 Event.MuxingMode=(int8u)-1;
                 Event.Service=(int8u)-1;

--- a/Source/MediaInfo/Text/File_Ttml.cpp
+++ b/Source/MediaInfo/Text/File_Ttml.cpp
@@ -217,7 +217,7 @@ void File_Ttml::Streams_Finish()
         if (!Time_End.IsTimed() && Time_End>Time_Begin)
         {
             TimeCode LastFrame=Time_End;
-            LastFrame--;
+            --LastFrame;
             Fill(Stream_Text, 0, Text_TimeCode_LastFrame, LastFrame.ToString());
         }
         auto MediaTimeToMilliseconds=[&](TimeCode TC)

--- a/Source/MediaInfo/Text/File_Ttml.cpp
+++ b/Source/MediaInfo/Text/File_Ttml.cpp
@@ -736,10 +736,11 @@ void File_Ttml::Read_Buffer_Continue()
                     Content.FindAndReplace(__T("<br/>"), EOL, 0, ZenLib::Ztring_Recursive);
                     Content.FindAndReplace(__T("<br />"), EOL, 0, ZenLib::Ztring_Recursive);
 
+                    std::wstring Content_Unicode{ Content.To_Unicode() };
                     Event.DTS=DTS_Begin;
                     Event.PTS=Event.DTS;
                     Event.DUR=DTS_End-DTS_Begin;
-                    Event.Content=Content.To_Unicode().c_str();
+                    Event.Content=Content_Unicode.c_str();
                     Event.Flags=0;
                     Event.MuxingMode=MuxingMode;
                     Event.Service=(int8u)Element_Code;

--- a/Source/MediaInfo/TimeCode.cpp
+++ b/Source/MediaInfo/TimeCode.cpp
@@ -508,6 +508,10 @@ int TimeCode::FromString(const string_view& V, bool Ignore1001FromDropFrame)
                 return 1;
             }
             int FramesRate_Index = i - 1 - i_Start;
+            if (FramesRate_Index < 0) {
+                *this = TimeCode();
+                return 1;
+            }
             uint64_t FramesRate = PowersOf10[FramesRate_Index];
             SetFramesMax((uint32_t)FramesRate - 1);
             switch (Unit)

--- a/Source/MediaInfo/TimeCode.cpp
+++ b/Source/MediaInfo/TimeCode.cpp
@@ -723,7 +723,7 @@ TimeCode TimeCode::ToRescaled(uint32_t FramesMax, flags Flags, rounding Rounding
     {
     case Nearest:
         Result += FrameRate / 2;
-        //fall through
+        [[fallthrough]];
     case Floor:
         Result /= FrameRate;
         break;

--- a/Source/MediaInfo/Video/File_Av1.cpp
+++ b/Source/MediaInfo/Video/File_Av1.cpp
@@ -259,7 +259,7 @@ void File_Av1::sequence_header()
 {
     //Parsing
     int32u max_frame_width_minus_1, max_frame_height_minus_1;
-    int8u seq_profile, seq_level_idx[33], operating_points_cnt_minus_1, buffer_delay_length_minus_1, frame_width_bits_minus_1, frame_height_bits_minus_1, seq_force_screen_content_tools, BitDepth, color_primaries, transfer_characteristics, matrix_coefficients, chroma_sample_position;
+    int8u seq_profile, seq_level_idx[33]{}, operating_points_cnt_minus_1, buffer_delay_length_minus_1, frame_width_bits_minus_1, frame_height_bits_minus_1, seq_force_screen_content_tools, BitDepth, color_primaries, transfer_characteristics, matrix_coefficients, chroma_sample_position;
     bool reduced_still_picture_header, seq_tier[33], timing_info_present_flag, decoder_model_info_present_flag, seq_choose_screen_content_tools, mono_chrome, color_range, color_description_present_flag, subsampling_x, subsampling_y;
     BS_Begin();
     Get_S1 ( 3, seq_profile,                                    "seq_profile"); Param_Info1(Av1_seq_profile(seq_profile));

--- a/Source/MediaInfo/Video/File_Av1.cpp
+++ b/Source/MediaInfo/Video/File_Av1.cpp
@@ -678,7 +678,7 @@ void File_Av1::Get_leb128(int64u& Info, const char* Name)
             break; // End of stream reached, not normal
         int8u leb128_byte=BigEndian2int8u(Buffer+Buffer_Offset+(size_t)Element_Offset);
         Element_Offset++;
-        Info|=((leb128_byte&0x7f)<<(i*7));
+        Info|=(static_cast<int64u>(leb128_byte&0x7f)<<(i*7));
         if (!(leb128_byte&0x80))
         {
             #if MEDIAINFO_TRACE

--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -1181,7 +1181,7 @@ void File_Avc::Streams_Fill(std::vector<seq_parameter_set_struct*>::iterator seq
             case Video_MasteringDisplay_Luminance:
                 if (Retrieve_Const(Stream_Video, 0, Item->first) == Item->second)
                     break;
-                // Fallthrough
+                [[fallthrough]];
             default:
                 Fill(Stream_Video, 0, Item->first, Item->second);
             }
@@ -2950,7 +2950,7 @@ void File_Avc::dec_ref_pic_marking(std::vector<int8u> &memory_management_control
                                 break;
                     case 3 :
                                 Skip_UE(                        "difference_of_pic_nums_minus1");
-                                //break; 3 --> difference_of_pic_nums_minus1 then long_term_frame_idx
+                                [[fallthrough]]; // 3 --> difference_of_pic_nums_minus1 then long_term_frame_idx
                     case 6 :
                                 Skip_UE(                        "long_term_frame_idx");
                                 break;
@@ -4796,6 +4796,7 @@ void File_Avc::SPS_PPS()
                             Element_End0();
                         }
                         }
+                        break;
             default:;
         }
     }

--- a/Source/MediaInfo/Video/File_Avc.cpp
+++ b/Source/MediaInfo/Video/File_Avc.cpp
@@ -3160,7 +3160,7 @@ void File_Avc::sei_message_pic_timing(int32u /*payloadSize*/, int32u seq_paramet
                             n_frames=0;
                             FrameMax=0; //Unsupported type
                         }
-                        else if ((*seq_parameter_set_Item)->vui_parameters->flags[fixed_frame_rate_flag] && (*seq_parameter_set_Item)->vui_parameters->time_scale && (*seq_parameter_set_Item)->vui_parameters->time_scale && (*seq_parameter_set_Item)->vui_parameters->num_units_in_tick)
+                        else if ((*seq_parameter_set_Item)->vui_parameters->flags[fixed_frame_rate_flag] && (*seq_parameter_set_Item)->vui_parameters->time_scale && (*seq_parameter_set_Item)->vui_parameters->num_units_in_tick)
                             FrameMax=(int32u)(float64_int64s((float64)(*seq_parameter_set_Item)->vui_parameters->time_scale/(*seq_parameter_set_Item)->vui_parameters->num_units_in_tick/((*seq_parameter_set_Item)->frame_mbs_only_flag?2:(((*seq_parameter_set_Item)->pic_order_cnt_type==2 && Structure_Frame/2>Structure_Field)?1:2))/FrameRate_Divider)-1);
                         else if (n_frames>99)
                             FrameMax=n_frames;

--- a/Source/MediaInfo/Video/File_Avc.h
+++ b/Source/MediaInfo/Video/File_Avc.h
@@ -75,12 +75,14 @@ private :
         {
             delete[] Iso14496_10_Buffer;
             Iso14496_10_Buffer_Size = (size_t)(Element_Size + 4);
-            Iso14496_10_Buffer = new int8u[Iso14496_10_Buffer_Size];
-            Iso14496_10_Buffer[0] = 0x00;
-            Iso14496_10_Buffer[1] = 0x00;
-            Iso14496_10_Buffer[2] = 0x01;
-            Iso14496_10_Buffer[3] = c;
-            std::memcpy(Iso14496_10_Buffer + 4, Buffer, (size_t)Element_Size);
+            if (Iso14496_10_Buffer_Size > 3) {
+                Iso14496_10_Buffer = new int8u[Iso14496_10_Buffer_Size];
+                Iso14496_10_Buffer[0] = 0x00;
+                Iso14496_10_Buffer[1] = 0x00;
+                Iso14496_10_Buffer[2] = 0x01;
+                Iso14496_10_Buffer[3] = c;
+                std::memcpy(Iso14496_10_Buffer + 4, Buffer, (size_t)Element_Size);
+            }
         }
 #endif //MEDIAINFO_DEMUX
     };

--- a/Source/MediaInfo/Video/File_Hevc.cpp
+++ b/Source/MediaInfo/Video/File_Hevc.cpp
@@ -3182,7 +3182,7 @@ void File_Hevc::sei_message_user_data_registered_itu_t_t35_B5_003C_0001_04()
     Get_B1 (application_version,                                "application_version");
     if (application_version==1)
     {
-        int32u targeted_system_display_maximum_luminance, maxscl[4], distribution_maxrgb_percentiles[16];
+        int32u targeted_system_display_maximum_luminance, maxscl[4]{}, distribution_maxrgb_percentiles[16];
         int16u fraction_bright_pixels;
         int8u num_distribution_maxrgb_percentiles, distribution_maxrgb_percentages[16], num_windows, num_bezier_curve_anchors;
         bool targeted_system_display_actual_peak_luminance_flag, mastering_display_actual_peak_luminance_flag, color_saturation_mapping_flag;

--- a/Source/MediaInfo/Video/File_ProRes.cpp
+++ b/Source/MediaInfo/Video/File_ProRes.cpp
@@ -209,7 +209,7 @@ void File_ProRes::Read_Buffer_Continue()
     //Parsing
     int32u  Name, creatorID;
     int16u  hdrSize, version, frameWidth, frameHeight;
-    int8u   chrominance_factor, frame_type, primaries, transf_func, colorMatrix, alpha_info;
+    int8u   chrominance_factor{}, frame_type{}, primaries{}, transf_func{}, colorMatrix{}, alpha_info{};
     bool    IsOk=true, luma, chroma;
     Element_Begin1("Header");
         Skip_B4(                                                "Size");

--- a/Source/MediaInfo/Video/File_Vp9.cpp
+++ b/Source/MediaInfo/Video/File_Vp9.cpp
@@ -178,9 +178,9 @@ void File_Vp9::Read_Buffer_Continue()
 
     Element_Begin1("uncompressed_header");
     BS_Begin();
-    int16u width_minus_one, height_minus_one;
-    int8u FRAME_MARKER, profile, bit_depth, colorspace, subsampling;
-    bool version0, version1, version2, show_existing_frame, frame_type, show_frame, error_resilient_mode, yuv_range_flag;
+    int16u width_minus_one{}, height_minus_one{};
+    int8u FRAME_MARKER, profile, bit_depth{}, colorspace{}, subsampling{};
+    bool version0, version1, version2, show_existing_frame, frame_type, show_frame, error_resilient_mode, yuv_range_flag{};
     Get_S1(2, FRAME_MARKER,                                     "FRAME_MARKER (0b10)");
     if (FRAME_MARKER!=0x2)
         Trusted_IsNot("FRAME_MARKER is wrong");

--- a/Source/ThirdParty/tinyxml2/tinyxml2.cpp
+++ b/Source/ThirdParty/tinyxml2/tinyxml2.cpp
@@ -432,17 +432,17 @@ void XMLUtil::ConvertUTF32ToUTF8( unsigned long input, char* output, int* length
             --output;
             *output = (char)((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
-            //fall through
+            [[fallthrough]];
         case 3:
             --output;
             *output = (char)((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
-            //fall through
+            [[fallthrough]];
         case 2:
             --output;
             *output = (char)((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
-            //fall through
+            [[fallthrough]];
         case 1:
             --output;
             *output = (char)(input | FIRST_BYTE_MARK[*length]);


### PR DESCRIPTION
- Set C++ standard in MSVC Project for all configurations to C++20. Previously it was set to C++20 only for debug x64 in commit ee81209e09e6fa7d1fd33c692fea3397629476e0.
- Fix following issues in `MediaInfo_Inform` and `File_Mpeg4_Elements` flagged by Visual Studio Code analysis:
   ```
   Warning	C26495	Variable 'MediaInfoLib::`anonymous-namespace'::nested::Target' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	MediaInfo_Inform.cpp	647		

   Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	Multiple\File_Mpeg4_Elements.cpp	1669		
   Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	Multiple\File_Mpeg4_Elements.cpp	1681		
   Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	Multiple\File_Mpeg4_Elements.cpp	2221		
   Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	Multiple\File_Mpeg4_Elements.cpp	2234		
   Warning	C6031	Return value ignored: 'std::_Vector_iterator<std::_Vector_val<std::_Simple_types<MediaInfoLib::File__Analyze *> > >::*'.	MediaInfoLib	Multiple\File_Mpeg4_Elements.cpp	2292		
   Warning	C6031	Return value ignored: 'std::_Vector_iterator<std::_Vector_val<std::_Simple_types<MediaInfoLib::File__Analyze *> > >::*'.	MediaInfoLib	Multiple\File_Mpeg4_Elements.cpp	2302		
   Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	Multiple\File_Mpeg4_Elements.cpp	3562		
   Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	Multiple\File_Mpeg4_Elements.cpp	3998			
   Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	Multiple\File_Mpeg4_Elements.cpp	4408	
   Warning	C6001	Using uninitialized memory 'default_length'.	MediaInfoLib	Multiple\File_Mpeg4_Elements.cpp	5142		
   ```
- Fix 43 cases of unannotated fallthroughs
- Other fixes to resolve warnings from Visual Studio Code analysis
