### PR TITLE
MP4: fix moov meta support

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -3463,6 +3463,10 @@ void File_Mpeg4::moov_iods()
 void File_Mpeg4::moov_meta()
 {
     Element_Name("Metadata");
+    if (!IsQt() && Element_Size>=12 && BigEndian2int32u(Buffer+Buffer_Offset+4)<=Element_Size && BigEndian2int32u(Buffer+Buffer_Offset+8)==Elements::moov_meta_hdlr)
+    {
+        VERSION_FLAG();
+    }
 
     //Filling
     moov_meta_hdlr_Type=0;


### PR DESCRIPTION
QuickTime says without version/flag, MP4 says with version flag, and some MP4 files are without version/flag, so checking if the version/flag is present or not.

Before this patch only moov meta atoms without version/flag were supported.
Fix https://github.com/MediaArea/MediaInfoLib/issues/2199.