### PR TITLE
Fix codecvt include

### DIFF
--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -55,7 +55,9 @@
 //---------------------------------------------------------------------------
 #include <ctime>
 #include <regex>
+#if !defined(UNICODE) && !defined(_UNICODE)
 #include <codecvt>
+#endif
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib


### PR DESCRIPTION
Does not compile anymore on old CentOS 7 / SLE 12 but we actually don't need it as it is used only with non Unicode builds and we use non Unicode builds only for JavaScript and 1 sponsor who does not use theses operating systems.