### PR TITLE
Curl: Fix parsing Literal IPv6 Addresses in URLs

### DIFF
--- a/Source/MediaInfo/Reader/Reader_libcurl.cpp
+++ b/Source/MediaInfo/Reader/Reader_libcurl.cpp
@@ -88,6 +88,31 @@ namespace Http
             Input           = Input.substr(0, Delimiter_Pos);
         }
     }
+    static void CutWithBracketsColon(std::string& Input, std::string& Output)
+    {
+        size_t BracketCount = 0;
+        const auto Input_Size = Input.size();
+        for (size_t i = 0; i < Input_Size; ++i) {
+            switch (Input[i])
+            {
+            case '[':
+                ++BracketCount;
+                break;
+            case ']':
+                if (!BracketCount)
+                    return;
+                --BracketCount;
+                break;
+            case ':':
+                if (!BracketCount) {
+                    Output = Input.substr(i + 1);
+                    Input.resize(i);
+                    return;
+                }
+                break;
+            }
+        }
+    }
 
     class Url
     {
@@ -101,7 +126,7 @@ namespace Http
             CutHead (Host,  User,       "@"     );
             CutTail (Host,  Path,       "/"     );
             CutTail (User,  Password,   ":"     );
-            CutTail (Host,  Port,       ":"     );
+            CutWithBracketsColon(Host, Port);
             if (User.find('/')!=(size_t)-1 && Password.empty() && Path.empty())
             {
                 // Something was weird, trying another method
@@ -112,7 +137,7 @@ namespace Http
                 CutTail (Host,  Path,       "/"     );
                 CutHead (Host,  User,       "@"     );
                 CutTail (User,  Password,   ":"     );
-                CutTail (Host,  Port,       ":"     );
+                CutWithBracketsColon(Host, Port);
                 if (Port.find_first_not_of("0123456789")!=(size_t)-1)
                 {
                     // Format not understood, putting all in Protocol
@@ -412,7 +437,7 @@ struct Reader_libcurl::curl_data
 //---------------------------------------------------------------------------
 struct Reader_libcurl_curl_data_getregion
 {
-    CURL*               Curl;
+    CURL*               Curl{};
     Ztring              File_Name;
     std::string         Amazon_AWS_Region;
 };


### PR DESCRIPTION
Fixes https://github.com/MediaArea/MediaInfoLib/issues/2233

Hope nothing gets broken by this.

Test:
```
General
Complete name                            : http://[2400:8901::f03c:94ff:fed0:3fee]:80/images-nc/knob_green.png
Format                                   : PNG
Format/Info                              : Portable Network Graphic
File size                                : 9.52 KiB

Image
Format                                   : PNG
Format/Info                              : Portable Network Graphic
Compression                              : Deflate
Format settings                          : Indexed-8
Width                                    : 299 pixels
Height                                   : 299 pixels
Display aspect ratio                     : 1.000
Color space                              : RGB
Bit depth                                : 8 bits
Compression mode                         : Lossless
Stream size                              : 9.52 KiB (100%)
Gamma                                    : 0.455
```
