### PR TITLE
update to MJD processing to support 16 bit rollover in 2038 - accepted solution for the next version of ETSI EN 300 468

### DIFF
--- a/Source/MediaInfo/TimeCode.cpp
+++ b/Source/MediaInfo/TimeCode.cpp
@@ -894,6 +894,8 @@ std::string Date_MJD(uint16_t Date_)
 {
     //Calculating
     double Date = Date_;
+    // adjust the MJD to support dates beyond the 16 bit rollover in 2038
+    if ((Date_ & 0x8000) == 0) Date += 0x10000;
     int Y2 = (int)((Date - 15078.2) / 365.25);
     int M2 = (int)(((Date - 14956.1) - ((int)(Y2 * 365.25))) / 30.6001);
     int D = (int)(Date - 14956 - ((int)(Y2 * 365.25)) - ((int)(M2 * 30.6001)));

--- a/Source/MediaInfo/TimeCode.cpp
+++ b/Source/MediaInfo/TimeCode.cpp
@@ -894,8 +894,8 @@ std::string Date_MJD(uint16_t Date_)
 {
     //Calculating
     double Date = Date_;
-    // adjust the MJD to support dates beyond the 16 bit rollover in 2038
-    if ((Date_ & 0x8000) == 0) Date += 0x10000;
+    if ((Date_ & 0x8000) == 0) 
+        Date += 0x10000;    // adjust the MJD to support dates beyond the 16 bit rollover in 2038
     int Y2 = (int)((Date - 15078.2) / 365.25);
     int M2 = (int)(((Date - 14956.1) - ((int)(Y2 * 365.25))) / 30.6001);
     int D = (int)(Date - 14956 - ((int)(Y2 * 365.25)) - ((int)(M2 * 30.6001)));


### PR DESCRIPTION
The current 16 bit definition of MJD in DVB systems 'rolls over' from 0xFFFF to 0x0000 on 23 April 2038.

> 
> **Explanation of proposed fix**
> This proposal is in effect the same as a receiver seeing a 16bit MJD of zero, and deciding it can’t possibly be 1858 or 1859, deciding the 16bit MJD must have rolled over, therefore it is likely 2038 or 2039.
> The most significant bit of the least significant 16bits of the MJD has been 1 since 5 August 1948. It seems unlikely anyone has signalled that date or earlier in a DVB system, since the first version of EN300 468 was published in 1995.
> This proposal is to change the receiver behaviour based on the most significant bit of the signalled 16bit MJD, this should require no change to headend equipment, provided they continue to set the 16bit MJD field to the least significant 16bits of the MJD. It requires a small change to receivers to handle dates from 23 April 2038. 
> Wording would be like: If the most significant bit of the 16 lsb of MJD is one then the 16bits is the MJD. If the most significant bit of the 16 lsb of MJD is zero, the MJD is 65536 (0x10000) plus the 16lsb of MJD.
> Note: the signalled 16bit MJD is still the 16 least significant bits of the MJD, but we have moved the “operating range” to start in 1948 from 1858, by re-designating the lower half of the 16bit number range for dates from 2038. The new operating range is highlighted in the table below. 
> The Receiver pseudo code, assuming MJD can store at least 17bits.
> `if (MJD<32768) MJD+=0x10000`
> With this change we can no longer signal dates before 5 August 1948 (seems unlikely there is a need for this), but we can signal a MJD until 1 September 2128. However, the equations in Annex C of EN300 468 are only valid until 28 February 2100. However, this gives up 62 additional years of operation for a minimal change, so we are good for another 75 years rather than just 13.


Test streams and their explanations are available at https://dvb-vandv.s3.eu-west-2.amazonaws.com/tm-mpeg2ts/TM-MPEG2TS1127_DVB_date_teststreams_r1.zip