### PR TITLE
Fix non-MSVC builds with AES NI enabled

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -109,6 +109,7 @@ set(MediaInfoLib_PUBLIC_HDRS
 set(MediaInfoLib_SRCS
   ${MediaInfoLib_SOURCES_PATH}/ThirdParty/md5/md5.c
   ${MediaInfoLib_SOURCES_PATH}/ThirdParty/aes-gladman/aes_modes.c
+  ${MediaInfoLib_SOURCES_PATH}/ThirdParty/aes-gladman/aes_ni.c
   ${MediaInfoLib_SOURCES_PATH}/ThirdParty/aes-gladman/aescrypt.c
   ${MediaInfoLib_SOURCES_PATH}/ThirdParty/aes-gladman/aeskey.c
   ${MediaInfoLib_SOURCES_PATH}/ThirdParty/aes-gladman/aestab.c

--- a/Project/GNU/Library/Makefile.am
+++ b/Project/GNU/Library/Makefile.am
@@ -266,6 +266,7 @@ endif
 if COMPILE_AES
 lib@MediaInfoLib_LibName@_la_SOURCES += \
                        ../../../Source/ThirdParty/aes-gladman/aes_modes.c \
+                       ../../../Source/ThirdParty/aes-gladman/aes_ni.c \
                        ../../../Source/ThirdParty/aes-gladman/aescrypt.c \
                        ../../../Source/ThirdParty/aes-gladman/aeskey.c \
                        ../../../Source/ThirdParty/aes-gladman/aestab.c

--- a/Project/Qt/MediaInfoLib.pro
+++ b/Project/Qt/MediaInfoLib.pro
@@ -508,6 +508,7 @@ SOURCES += \
 
 SOURCES += \
         ../../Source/ThirdParty/aes-gladman/aes_modes.c \
+        ../../Source/ThirdParty/aes-gladman/aes_ni.c \
         ../../Source/ThirdParty/aes-gladman/aescrypt.c \
         ../../Source/ThirdParty/aes-gladman/aeskey.c \
         ../../Source/ThirdParty/aes-gladman/aestab.c \


### PR DESCRIPTION
Resolves: https://github.com/MediaArea/MediaInfo/issues/1068

More details in the above issue.
