### PR TITLE
MP4: Map `com.apple.quicktime.location.ISO6709`

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -3991,6 +3991,8 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                         Fill(Stream_General, 0, General_Description, Value, true);
                     else if (Parameter == "com.apple.quicktime.creationdate")
                         Fill(Stream_General, 0, General_Recorded_Date, Value);
+                    else if (Parameter == "com.apple.quicktime.location.ISO6709")
+                        Fill(Stream_General, 0, General_Recorded_Location, Value);
                     else if (Parameter == "com.apple.quicktime.make")
                         Fill(Stream_General, 0, General_Encoded_Hardware_CompanyName, Value);
                     else if (Parameter == "com.apple.quicktime.model")


### PR DESCRIPTION
Map `com.apple.quicktime.location.ISO6709` to `General_Recorded_Location`.

Seems to be used by newer iPhones that appear to no longer use `loci` atom.

Before:
```
Recorded date                            : 2024-01-08T15:06:17-0800
Encoded date                             : 2024-01-08 23:06:17 UTC
Tagged date                              : 2024-01-08 23:07:18 UTC
Writing library                          : Apple QuickTime
Writing operating system                 : Apple iOS 17.2.1
Writing hardware                         : Apple iPhone 15 Pro Max
com.apple.quicktime.location.accuracy.ho : 21.307141
com.apple.quicktime.spatial.format-versi : 1.0
com.apple.quicktime.spatial.aggressors-s : 0
com.apple.quicktime.location.ISO6709     : +36.1318-115.1517+621.989/
```

After:
```
Recorded date                            : 2024-01-08T15:06:17-0800
Encoded date                             : 2024-01-08 23:06:17 UTC
Tagged date                              : 2024-01-08 23:07:18 UTC
Recorded location                        : +36.1318 -115.1517 +621.989
Writing library                          : Apple QuickTime
Writing operating system                 : Apple iOS 17.2.1
Writing hardware                         : Apple iPhone 15 Pro Max
com.apple.quicktime.location.accuracy.ho : 21.307141
com.apple.quicktime.spatial.format-versi : 1.0
com.apple.quicktime.spatial.aggressors-s : 0
```

The following remains unhandled:
```
com.apple.quicktime.location.accuracy.horizontal
com.apple.quicktime.spatial.format-version
com.apple.quicktime.spatial.aggressors-seen
```

Samples found from links on [this page](https://www.zdnet.com/article/download-my-spatial-videos-from-tech-events-and-view-them-on-quest-3-or-vision-pro/).
