### PR TITLE
Fix false positive conformance error

### DIFF
--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -2773,7 +2773,7 @@ void File__Analyze::Header_Fill_Size(int64u Size)
         Element[0].Next=File_Offset+Buffer_Offset+Size;
     else if (File_Offset+Buffer_Offset+Size>Element[Element_Level-2].Next)
     {
-        if (!IsSub || (File_Offset + Buffer_Size < File_Size && File_Size - (File_Offset + Buffer_Size) >= 0x10000)) { //TODO: good support of end of TS dumps
+        if (Element_IsComplete_Get() && (!IsSub || (File_Offset + Buffer_Size < File_Size && File_Size - (File_Offset + Buffer_Size) >= 0x10000))) { //TODO: good support of end of TS dumps
             auto Name = CreateElementName();
             if (!Name.empty()) {
                 Name += ' ';


### PR DESCRIPTION
When there is not enough buffer during any header parsing.

fix https://github.com/MediaArea/MediaInfoLib/pull/2252#issuecomment-2804616747.