### PR TITLE
FLAC: Add picture information

### DIFF
--- a/Source/MediaInfo/Audio/File_Flac.cpp
+++ b/Source/MediaInfo/Audio/File_Flac.cpp
@@ -318,6 +318,7 @@ void File_Flac::PICTURE()
     {
         File__Analyze::Stream_Prepare(Stream_Image);
         Merge(MI, Stream_Image, 0, StreamPos_Last);
+        Fill(Stream_Image, StreamPos_Last, Image_MuxingMode, "FLAC Picture");
     }
     #if MEDIAINFO_ADVANCED
         if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))

--- a/Source/MediaInfo/Audio/File_Flac.cpp
+++ b/Source/MediaInfo/Audio/File_Flac.cpp
@@ -21,6 +21,7 @@
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
+#include "MediaInfo/MediaInfo_Internal.h"
 #include "MediaInfo/Audio/File_Flac.h"
 #include "MediaInfo/Tag/File_VorbisCom.h"
 #include "ThirdParty/base64/base64.h"
@@ -308,6 +309,16 @@ void File_Flac::PICTURE()
     Fill(Stream_General, 0, General_Cover_Description, Description);
     Fill(Stream_General, 0, General_Cover_Type, Id3v2_PictureType((int8u)PictureType));
     Fill(Stream_General, 0, General_Cover_Mime, MimeType);
+    MediaInfo_Internal MI;
+    Ztring Demux_Save = MI.Option(__T("Demux_Get"), __T(""));
+    MI.Option(__T("Demux"), Ztring());
+    size_t MiOpenResult = MI.Open(Buffer + (size_t)(Buffer_Offset + Element_Offset), (size_t)(Element_Size - Element_Offset), nullptr, 0, (size_t)(Element_Size - Element_Offset));
+    MI.Option(__T("Demux"), Demux_Save); //This is a global value, need to reset it. TODO: local value
+    if (MI.Count_Get(Stream_Image))
+    {
+        File__Analyze::Stream_Prepare(Stream_Image);
+        Merge(MI, Stream_Image, 0, StreamPos_Last);
+    }
     #if MEDIAINFO_ADVANCED
         if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))
         {

--- a/Source/MediaInfo/File__Analyse_Automatic.h
+++ b/Source/MediaInfo/File__Analyse_Automatic.h
@@ -1758,6 +1758,7 @@ enum image
     Image_Format_Settings_Endianness,
     Image_Format_Settings_Packing,
     Image_Format_Settings_Wrapping,
+    Image_MuxingMode,
     Image_InternetMediaType,
     Image_CodecID,
     Image_CodecID_String,

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -5923,6 +5923,7 @@ void MediaInfo_Config_Image (ZtringListList &Info)
     "Format_Settings_Endianness;;;N YTY\n"
     "Format_Settings_Packing;;;N YTY\n"
     "Format_Settings_Wrapping;;;Y YTY\n"
+    "MuxingMode;;;Y YTY\n"
     "InternetMediaType;;;N YT\n"
     "CodecID;;;Y YTY\n"
     "CodecID/String;;;Y NT\n"

--- a/Source/MediaInfo/Tag/File_Id3v2.cpp
+++ b/Source/MediaInfo/Tag/File_Id3v2.cpp
@@ -986,6 +986,7 @@ void File_Id3v2::APIC()
     {
         Stream_Prepare(Stream_Image);
         Merge(MI, Stream_Image, 0, StreamPos_Last);
+        Fill(Stream_Image, 0, Image_MuxingMode, "ID3v2 APIC");
     }
     #if MEDIAINFO_ADVANCED
         if (MediaInfoLib::Config.Flags1_Get(Flags_Cover_Data_base64))

--- a/Source/Resource/Text/Stream/Image.csv
+++ b/Source/Resource/Text/Stream/Image.csv
@@ -39,6 +39,7 @@ Format_Settings;;;Y NT;;;Settings used and required by decoder
 Format_Settings_Endianness;;;N YTY;;;Order of bytes required for decoding. Options are Big/Little
 Format_Settings_Packing;;;N YTY;;;Data packing method used in DPX frames (e.g. Packed, Filled A, Filled B)
 Format_Settings_Wrapping;;;Y YTY;;;Wrapping mode set for format (e.g. Frame, Clip)
+MuxingMode;;;Y YTY;;;How this file is muxed in the container (e.g. Muxed in Video #1)
 InternetMediaType;;;N YT;;;Internet Media Type (aka MIME Type, Content-Type)
 CodecID;;;Y YTY;;;Codec identifier as indicated by the container
 CodecID/String;;;Y NT;;;Codec identifier, as indicated by the container


### PR DESCRIPTION
Image track, including muxing mode:

```
Image #1
Format                                   : JPEG
Muxing mode                              : ID3v2 APIC
Width                                    : 300 pixels
Height                                   : 300 pixels
Color space                              : YUV
Chroma subsampling                       : 4:4:4
Bit depth                                : 8 bits
Compression mode                         : Lossy
Stream size                              : 116 KiB (2%)

Image #2
Format                                   : JPEG
Muxing mode                              : FLAC Picture
Width                                    : 300 pixels
Height                                   : 300 pixels
Color space                              : YUV
Chroma subsampling                       : 4:4:4
Bit depth                                : 8 bits
Compression mode                         : Lossy
Stream size                              : 116 KiB (2%)
```