### PR TITLE
WebP support

### DIFF
--- a/Project/BCB/Library/MediaInfoLib.cbproj
+++ b/Project/BCB/Library/MediaInfoLib.cbproj
@@ -441,6 +441,9 @@
         <CppCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp">
             <BuildOrder>177</BuildOrder>
         </CppCompile>
+        <CppCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp">
+            <BuildOrder>240</BuildOrder>
+        </CppCompile>
         <CppCompile Include="..\..\..\Source\MediaInfo\MediaInfo.cpp">
             <DependentOn>..\..\..\Source\MediaInfo\MediaInfo.h</DependentOn>
             <BuildOrder>192</BuildOrder>

--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -235,6 +235,7 @@ set(MediaInfoLib_SRCS
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Image/File_Rle.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Image/File_Tiff.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Image/File_Tga.cpp
+  ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Image/File_WebP.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File__ReferenceFilesHelper_Resource.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Multiple/File__ReferenceFilesHelper_Sequence.cpp

--- a/Project/CodeBlocks/Library/MediaInfoLib.cbp
+++ b/Project/CodeBlocks/Library/MediaInfoLib.cbp
@@ -121,6 +121,8 @@
 		<Unit filename="..\..\..\Source\MediaInfo\Image\File_Png.h" />
 		<Unit filename="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp" />
 		<Unit filename="..\..\..\Source\MediaInfo\Image\File_Tiff.h" />
+		<Unit filename="..\..\..\Source\MediaInfo\Image\File_WebP.cpp" />
+		<Unit filename="..\..\..\Source\MediaInfo\Image\File_WebP.h" />
 		<Unit filename="..\..\..\Source\MediaInfo\MediaInfo.cpp" />
 		<Unit filename="..\..\..\Source\MediaInfo\MediaInfo.h" />
 		<Unit filename="..\..\..\Source\MediaInfo\MediaInfoList.cpp" />

--- a/Project/GNU/Library/Makefile.am
+++ b/Project/GNU/Library/Makefile.am
@@ -120,6 +120,7 @@ lib@MediaInfoLib_LibName@_la_SOURCES = \
                        ../../../Source/MediaInfo/Image/File_Rle.cpp \
                        ../../../Source/MediaInfo/Image/File_Tiff.cpp \
                        ../../../Source/MediaInfo/Image/File_Tga.cpp \
+                       ../../../Source/MediaInfo/Image/File_WebP.cpp \
                        ../../../Source/MediaInfo/Multiple/File__ReferenceFilesHelper.cpp \
                        ../../../Source/MediaInfo/Multiple/File__ReferenceFilesHelper_Resource.cpp \
                        ../../../Source/MediaInfo/Multiple/File__ReferenceFilesHelper_Sequence.cpp \

--- a/Project/GNU/Library/configure.ac
+++ b/Project/GNU/Library/configure.ac
@@ -131,6 +131,7 @@ AC_ARG_ENABLE(png,     AC_HELP_STRING([--disable-png],     [Disable Image - PNG]
 AC_ARG_ENABLE(psd,     AC_HELP_STRING([--disable-psd],     [Disable Image - PSD]),                                        MediaInfoPsd=$enableval,     MediaInfoPsd=depend)
 AC_ARG_ENABLE(rle,     AC_HELP_STRING([--disable-rle],     [Disable Image - Run-length encoding]),                        MediaInfoRle=$enableval,     MediaInfoRle=depend)
 AC_ARG_ENABLE(tiff,    AC_HELP_STRING([--disable-tiff],    [Disable Image - TIFF]),                                       MediaInfoTiff=$enableval,    MediaInfoTiff=depend)
+AC_ARG_ENABLE(webp,    AC_HELP_STRING([--disable-webp],    [Disable Image - WEBP]),                                       MediaInfoWebP=$enableval,    MediaInfoWebP=depend)
 AC_ARG_ENABLE(aaf,     AC_HELP_STRING([--disable-aaf],     [Disable Multiple - AAF]),                                     MediaInfoAaf=$enableval,     MediaInfoAaf=depend)
 AC_ARG_ENABLE(bdav,    AC_HELP_STRING([--disable-bdav],    [Disable Multiple - Blu-ray audio-video (BDAV)]),              MediaInfoBdav=$enableval,    MediaInfoBdav=depend)
 AC_ARG_ENABLE(bdmv,    AC_HELP_STRING([--disable-bdmv],    [Disable Multiple - Blu-ray Movie]),                           MediaInfoBdmv=$enableval,    MediaInfoBdmv=depend)
@@ -303,6 +304,7 @@ if test "$MediaInfoPcx"     = "no";  then AC_DEFINE(MEDIAINFO_PCX_NO)     fi; if
 if test "$MediaInfoPng"     = "no";  then AC_DEFINE(MEDIAINFO_PNG_NO)     fi; if test "$MediaInfoPng"     = "yes"; then AC_DEFINE(MEDIAINFO_PNG_YES)     fi
 if test "$MediaInfoPsd"     = "no";  then AC_DEFINE(MEDIAINFO_PSD_NO)     fi; if test "$MediaInfoPsd"     = "yes"; then AC_DEFINE(MEDIAINFO_PSD_YES)     fi
 if test "$MediaInfoTiff"    = "no";  then AC_DEFINE(MEDIAINFO_TIFF_NO)    fi; if test "$MediaInfoTiff"    = "yes"; then AC_DEFINE(MEDIAINFO_TIFF_YES)    fi
+if test "$MediaInfoWebP"    = "no";  then AC_DEFINE(MEDIAINFO_WEBP_NO)    fi; if test "$MediaInfoWebP"    = "yes"; then AC_DEFINE(MEDIAINFO_WEBP_YES)    fi
 if test "$MediaInfoAaf"     = "no";  then AC_DEFINE(MEDIAINFO_AAF_NO)     fi; if test "$MediaInfoAaf"     = "yes"; then AC_DEFINE(MEDIAINFO_AAF_YES)     fi
 if test "$MediaInfoBdav"    = "no";  then AC_DEFINE(MEDIAINFO_BDAV_NO)    fi; if test "$MediaInfoBdav"    = "yes"; then AC_DEFINE(MEDIAINFO_BDAV_YES)    fi
 if test "$MediaInfoBdmv"    = "no";  then AC_DEFINE(MEDIAINFO_BDMV_NO)    fi; if test "$MediaInfoBdmv"    = "yes"; then AC_DEFINE(MEDIAINFO_BDMV_YES)    fi
@@ -1066,6 +1068,7 @@ Mcho "Pcx    " "$MediaInfoPcx"
 Mcho "Png    " "$MediaInfoPng"
 Mcho "Psd    " "$MediaInfoPsd"
 Mcho "Tiff   " "$MediaInfoTiff"
+Mcho "WebP   " "$MediaInfoWebP"
 Mcho "Aaf    " "$MediaInfoAaf"
 Mcho "Bdav   " "$MediaInfoBdav"
 Mcho "Bdmv   " "$MediaInfoBdmv"

--- a/Project/MSVC2015/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2015/Library/MediaInfoLib.vcxproj
@@ -312,6 +312,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Png.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Rle.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Bdmv.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Cdxa.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Dpg.cpp" />

--- a/Project/MSVC2015/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2015/Library/MediaInfoLib.vcxproj.filters
@@ -320,6 +320,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp">
       <Filter>Source Files\Image</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp">
+      <Filter>Source Files\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Bdmv.cpp">
       <Filter>Source Files\Multiple</Filter>
     </ClCompile>

--- a/Project/MSVC2017/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2017/Library/MediaInfoLib.vcxproj
@@ -321,6 +321,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Png.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Rle.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Bdmv.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Cdxa.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Dpg.cpp" />

--- a/Project/MSVC2017/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2017/Library/MediaInfoLib.vcxproj.filters
@@ -320,6 +320,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp">
       <Filter>Source Files\Image</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp">
+      <Filter>Source Files\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Bdmv.cpp">
       <Filter>Source Files\Multiple</Filter>
     </ClCompile>

--- a/Project/MSVC2017/Library/MediaInfoLib_UWP.vcxproj
+++ b/Project/MSVC2017/Library/MediaInfoLib_UWP.vcxproj
@@ -373,6 +373,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Png.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Rle.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Bdmv.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Cdxa.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Dpg.cpp" />

--- a/Project/MSVC2019/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2019/Library/MediaInfoLib.vcxproj
@@ -323,6 +323,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Png.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Rle.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Bdmv.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Cdxa.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Dpg.cpp" />

--- a/Project/MSVC2019/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2019/Library/MediaInfoLib.vcxproj.filters
@@ -320,6 +320,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp">
       <Filter>Source Files\Image</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp">
+      <Filter>Source Files\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Bdmv.cpp">
       <Filter>Source Files\Multiple</Filter>
     </ClCompile>

--- a/Project/MSVC2019/Library/MediaInfoLib_UWP.vcxproj
+++ b/Project/MSVC2019/Library/MediaInfoLib_UWP.vcxproj
@@ -373,6 +373,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Png.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Rle.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Bdmv.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Cdxa.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Dpg.cpp" />

--- a/Project/MSVC2022/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2022/Library/MediaInfoLib.vcxproj
@@ -531,6 +531,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Png.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Rle.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Bdmv.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Cdxa.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Dpg.cpp" />

--- a/Project/MSVC2022/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2022/Library/MediaInfoLib.vcxproj.filters
@@ -320,6 +320,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp">
       <Filter>Source Files\Image</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp">
+      <Filter>Source Files\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Bdmv.cpp">
       <Filter>Source Files\Multiple</Filter>
     </ClCompile>

--- a/Project/MSVC2022/Library/MediaInfoLib_UWP.vcxproj
+++ b/Project/MSVC2022/Library/MediaInfoLib_UWP.vcxproj
@@ -373,6 +373,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Png.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Rle.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Tiff.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_WebP.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Bdmv.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Cdxa.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Multiple\File_Dpg.cpp" />

--- a/Project/Qt/MediaInfoLib.pro
+++ b/Project/Qt/MediaInfoLib.pro
@@ -371,6 +371,7 @@ SOURCES += \
         ../../Source/MediaInfo/Image/File_Rle.cpp \
         ../../Source/MediaInfo/Image/File_Tiff.cpp \
         ../../Source/MediaInfo/Image/File_Tga.cpp \
+        ../../Source/MediaInfo/Image/File_WebP.cpp \
         ../../Source/MediaInfo/MediaInfo.cpp \
         ../../Source/MediaInfo/MediaInfo_Config.cpp \
         ../../Source/MediaInfo/MediaInfo_Config_Automatic.cpp \

--- a/Source/MediaInfo/File_Other.cpp
+++ b/Source/MediaInfo/File_Other.cpp
@@ -154,16 +154,6 @@ void File_Other::Read_Buffer_Continue()
         return;
     }
     else if (CC4(Buffer)==CC4("RIFF") && CC4(Buffer+8)==CC4("AMV ")) {Format=__T("AMV");}
-    else if (CC4(Buffer)==CC4("RIFF") && CC4(Buffer+8)==CC4("WEBP"))
-    {
-        Accept("WEBP");
-
-        Stream_Prepare(Stream_Image);
-        Fill(Stream_Image, 0, Image_Format, "WebP");
-
-        Finish("WEBP");
-        return;
-    }
     else if (CC4(Buffer)==0x414D5697) {Format=__T("MTV");}
     else if (CC6(Buffer)==CC6("Z\0W\0F\0"))
     {

--- a/Source/MediaInfo/Image/File_WebP.cpp
+++ b/Source/MediaInfo/Image/File_WebP.cpp
@@ -1,0 +1,359 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//---------------------------------------------------------------------------
+// Pre-compilation
+#include "MediaInfo/PreComp.h"
+#ifdef __BORLANDC__
+    #pragma hdrstop
+#endif
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/Setup.h"
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#if defined(MEDIAINFO_WEBP_YES)
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/Image/File_WebP.h"
+#if defined(MEDIAINFO_ICC_YES)
+    #include "MediaInfo/Tag/File_Icc.h"
+#endif
+#if defined(MEDIAINFO_XMP_YES)
+    #include "MediaInfo/Tag/File_Xmp.h"
+#endif
+#if defined(MEDIAINFO_VP8_YES)
+    #include "MediaInfo/Video/File_Vp8.h"
+#endif
+using namespace std;
+//---------------------------------------------------------------------------
+
+namespace MediaInfoLib
+{
+
+//***************************************************************************
+// Const
+//***************************************************************************
+
+namespace Elements
+{
+    const int32u RIFF = 0x52494646;
+    const int32u WEBP = 0x57454250;
+    const int32u WEBP_ALPH = 0x414C5048;
+    const int32u WEBP_ANIM = 0x414E494D;
+    const int32u WEBP_ANMF = 0x414E4D46;
+    const int32u WEBP_EXIF = 0x45584946;
+    const int32u WEBP_ICCP = 0x49434350;
+    const int32u WEBP_VP8_ = 0x56503820;
+    const int32u WEBP_VP8L = 0x5650384C;
+    const int32u WEBP_VP8X = 0x56503858;
+    const int32u WEBP_XMP_ = 0x584D5020;
+}
+
+//***************************************************************************
+// Constructor/Destructor
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+File_WebP::File_WebP()
+{
+    HasAlpha = false;
+}
+
+//---------------------------------------------------------------------------
+File_WebP::~File_WebP()
+{
+    delete ICC_Parser;
+}
+
+//***************************************************************************
+// Streams management
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+void File_WebP::Streams_Finish()
+{
+    if (StreamKind_Last == Stream_Video) {
+        Fill(Stream_Video, 0, Video_FrameCount, Frame_Count);
+        Fill(Stream_Video, 0, Video_FrameRate_Mode, FrameDuration ? "CFR" : "VFR");
+        Fill(Stream_Video, 0, Video_Duration, TotalDuration);
+    }
+    if (HasAlpha) {
+        auto ColorSpace = Retrieve(StreamKind_Last, 0, Fill_Parameter(StreamKind_Last, Generic_ColorSpace));
+        if (!ColorSpace.empty() && ColorSpace.back() != __T('A')) {
+            ColorSpace += __T('A');
+            Fill(StreamKind_Last, 0, Fill_Parameter(StreamKind_Last, Generic_ColorSpace), ColorSpace, true);
+        }
+    }
+    if (StreamKind_Last == Stream_Image && ICC_Parser) {
+        Merge(*ICC_Parser, Stream_Image, 0, 0); // Merged here because we don't know the stream kind in advance
+    }
+}
+
+//***************************************************************************
+// Buffer
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+bool File_WebP::FileHeader_Begin()
+{
+    if (Buffer_Size < 12)
+        return false;
+
+    if (CC4(Buffer)      != Elements::RIFF
+     || CC4(Buffer + 8)  != Elements::WEBP) {
+        Reject();
+        return false;
+    }
+
+    Accept();
+    Fill(Stream_General, 0, General_Format, "WebP");
+    return true;
+}
+
+//---------------------------------------------------------------------------
+void File_WebP::Header_Parse()
+{
+    //Parsing
+    int32u Size, Name;
+    Get_C4 (Name,                                               "Name");
+    Get_L4 (Size,                                               "Size");
+
+    //Alignment
+    Alignment_ExtraByte = Size % 2 && Size < File_Size - (File_Offset + Buffer_Offset + Element_Offset);
+    Size += Alignment_ExtraByte;
+
+    //Top level chunks
+    if (Name == Elements::RIFF) {
+        Get_C4 (Name,                                           "Real Name");
+    }
+
+    FILLING_BEGIN();
+        Header_Fill_Size(8 + (int64u)Size);
+        Header_Fill_Code(Name, Ztring().From_CC4(Name));
+    FILLING_END();
+}
+
+//---------------------------------------------------------------------------
+void File_WebP::Data_Parse()
+{
+    //Alignment
+    if (Alignment_ExtraByte) {
+        Element_Size--;
+    }
+
+    DATA_BEGIN
+    LIST(WEBP)
+        ATOM_BEGIN
+        ATOM(WEBP_ALPH)
+        ATOM(WEBP_ANIM)
+        LIST(WEBP_ANMF)
+            ATOM_BEGIN
+            ATOM(WEBP_ALPH)
+            ATOM(WEBP_VP8_)
+            ATOM(WEBP_VP8L)
+        ATOM_END
+        ATOM(WEBP_EXIF)
+        ATOM(WEBP_ICCP)
+        ATOM(WEBP_VP8_)
+        ATOM(WEBP_VP8L)
+        ATOM(WEBP_VP8X)
+        ATOM(WEBP_XMP_)
+        ATOM_END
+    DATA_END
+
+    //Alignment
+    if (Alignment_ExtraByte) {
+        bool HasAlignment = Element_Offset == Element_Size;
+        Element_Size++;
+        if (HasAlignment) {
+            Skip_B1(                                            "Alignment");
+        }
+    }
+}
+
+//***************************************************************************
+// Elements
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+void File_WebP::WEBP_ALPH()
+{
+    Skip_XX(Element_Size,                                       "(Not parsed)"); 
+
+    HasAlpha = true;
+}
+
+//---------------------------------------------------------------------------
+void File_WebP::WEBP_ANIM()
+{
+    //Parsing
+    Skip_L4(                                                    "Background color");
+    Skip_L2(                                                    "Loop count");
+
+    FILLING_BEGIN();
+        //Ztring bg;
+        //bg.From_Number(bgColor, 16);
+        //bg.MakeUpperCase();
+        //bg.insert(0, __T("0x"));
+        //Fill(Stream_Image, 0, "Animation_BackgroundColor", bg);
+    FILLING_END();
+}
+
+//---------------------------------------------------------------------------
+void File_WebP::WEBP_ANMF()
+{
+    //Parsing
+    if (Element_Size < 16 && !Element_IsComplete_Get()) {
+        Element_WaitForMoreData();
+        return;
+    }
+    int32u Duration;
+    Skip_L3(                                                    "Frame X");
+    Skip_L3(                                                    "Frame Y");
+    Skip_L3(                                                    "Frame Width minus 1");
+    Skip_L3(                                                    "Frame Height minus 1");
+    Get_L3 (Duration,                                           "Frame Duration");
+    BS_Begin();
+    Skip_S1(6,                                                  "Reserved");
+    Skip_SB(                                                    "Blending method");
+    Skip_SB(                                                    "Disposal method");
+    BS_End();
+
+    FILLING_BEGIN();
+        if (!Frame_Count) {
+            Stream_Prepare(Stream_Video);
+            FrameDuration = Duration;
+        }
+        if (Frame_Count && Duration != FrameDuration) {
+            FrameDuration = 0; // VFR
+        }
+        Frame_Count++;
+        TotalDuration += Duration;
+    FILLING_END();
+}
+
+//---------------------------------------------------------------------------
+void File_WebP::WEBP_EXIF()
+{
+    Skip_XX(Element_Size,                                       "EXIF metadata"); 
+
+    //Fill(Stream_Image, 0, "Metadata_Exif", "Yes"); 
+}
+
+//---------------------------------------------------------------------------
+void File_WebP::WEBP_ICCP()
+{
+    if (ICC_Parser)
+        delete ICC_Parser;
+    ICC_Parser = new File_Icc;
+    ICC_Parser->StreamKind = Stream_Image;
+    ICC_Parser->IsAdditional = true;
+    Open_Buffer_Init(ICC_Parser);
+    Open_Buffer_Continue(ICC_Parser);
+    Open_Buffer_Finalize(ICC_Parser);
+}
+
+//---------------------------------------------------------------------------
+void File_WebP::WEBP_VP8_()
+{
+    if (!Frame_Count) {
+        Stream_Prepare(Stream_Image);
+    }
+
+    #if defined(MEDIAINFO_VP8_YES)
+    File_Vp8 MI;
+    MI.StreamKind = StreamKind_Last;
+    Open_Buffer_Init(&MI);
+    Open_Buffer_Continue(&MI);
+
+    FILLING_BEGIN();
+        if (Frame_Count <= 1) { // Using first frame data
+            Merge(MI, StreamKind_Last, 0, 0);
+        }
+    FILLING_END();
+    #else
+    Skip_XX(Element_Size,                                       "(Data)");
+    Fill(StreamKind_Last, 0, Fill_Parameter(StreamKind_Last, Generic_Format), "VP8");
+    #endif
+}
+
+//---------------------------------------------------------------------------
+void File_WebP::WEBP_VP8L()
+{
+    if (!Frame_Count) {
+        Stream_Prepare(Stream_Image);
+    }
+
+    //Parsing
+    int16u w, h;
+    int8u signature, version_number;
+    bool alpha_is_used;
+    Get_B1 (signature,                                          "signature");
+    if (signature != 0x2F)
+    {
+        Trusted_IsNot("Invalid VP8L signature");
+        return;
+    }
+    BS_Begin_LE();
+    Get_T2 (14, w,                                              "image_width minus 1");
+    Get_T2 (14, h,                                              "image_height minus 1");
+    Get_TB (    alpha_is_used,                                  "alpha_is_used");
+    Get_T1 ( 3, version_number,                                 "version_number");
+    BS_End_LE();
+    Skip_XX(Element_Size - Element_Offset,                      version_number ? "(Unsupported)" : "(Not parsed)");
+
+    FILLING_BEGIN();
+        if (Frame_Count <= 1) { // Using first frame data
+            Fill(StreamKind_Last, 0, Fill_Parameter(StreamKind_Last, Generic_Format), "WebP");
+            Fill(StreamKind_Last, 0, Fill_Parameter(StreamKind_Last, Generic_Format_Version), "Version " + to_string(version_number));
+            Fill(StreamKind_Last, 0, Fill_Parameter(StreamKind_Last, Generic_Width), ((int32u)w) + 1);
+            Fill(StreamKind_Last, 0, Fill_Parameter(StreamKind_Last, Generic_Height), ((int32u)h) + 1);
+            Fill(StreamKind_Last, 0, Fill_Parameter(StreamKind_Last, Generic_BitDepth), 8);
+            Fill(StreamKind_Last, 0, Fill_Parameter(StreamKind_Last, Generic_Compression_Mode), "Lossless");
+            Fill(StreamKind_Last, 0, Fill_Parameter(StreamKind_Last, Generic_ColorSpace), alpha_is_used ? "RGBA" : "RGB");
+        }
+    FILLING_END();
+}
+
+//---------------------------------------------------------------------------
+void File_WebP::WEBP_VP8X()
+{
+    //Parsing
+    BS_Begin();
+    Skip_S1(2,                                                  "Reserved");
+    Skip_SB(                                                    "ICC profile");
+    Skip_SB(                                                    "Alpha");
+    Skip_SB(                                                    "EXIF metadata");
+    Skip_SB(                                                    "XMP metadata");
+    Skip_SB(                                                    "Animation");
+    BS_End();
+    Skip_L3(                                                    "Reserved");
+    Skip_L3(                                                    "Canvas Width minus 1");
+    Skip_L3(                                                    "Canvas Height minus 1");
+}
+
+//---------------------------------------------------------------------------
+void File_WebP::WEBP_XMP_()
+{
+    //Parsing
+    #if defined(MEDIAINFO_XMP_YES)
+    File_Xmp MI;
+    Open_Buffer_Init(&MI);
+    Open_Buffer_Continue(&MI);
+    Open_Buffer_Finalize(&MI);
+    Merge(MI, Stream_General, 0, 0);
+    #else
+    Skip_UTF8(Element_Size                                      "XMP metadata");
+    #endif
+}
+
+} // namespace MediaInfoLib
+
+#endif

--- a/Source/MediaInfo/Image/File_WebP.h
+++ b/Source/MediaInfo/Image/File_WebP.h
@@ -1,0 +1,72 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+//
+// Information about VP8 files
+// http://datatracker.ietf.org/doc/rfc6386/?include_text=1
+//
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+//---------------------------------------------------------------------------
+#ifndef MediaInfo_WebpH
+#define MediaInfo_WebpH
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/File__Analyze.h"
+//---------------------------------------------------------------------------
+
+namespace MediaInfoLib
+{
+
+//***************************************************************************
+// Class File_WebP
+//***************************************************************************
+
+class File_Icc;
+
+class File_WebP : public File__Analyze
+{
+public:
+    //Constructor/Destructor
+    File_WebP();
+    ~File_WebP();
+
+private:
+    //Streams management
+    void Streams_Finish();
+
+    //Buffer - File header
+    bool FileHeader_Begin();
+
+    //Buffer - Per element
+    void Header_Parse();
+    void Data_Parse();
+
+    //Elements
+    void WEBP() {};
+    void WEBP_ALPH();
+    void WEBP_ANIM();
+    void WEBP_ANMF();
+    void WEBP_EXIF();
+    void WEBP_ICCP();
+    void WEBP_VP8_();
+    void WEBP_VP8L();
+    void WEBP_VP8X();
+    void WEBP_XMP_();
+
+    //Temp
+    File_Icc* ICC_Parser = nullptr;
+    int32u FrameDuration = 0;
+    int64u TotalDuration = 0;
+    bool HasAlpha = false;
+    bool Alignment_ExtraByte; //Padding from the container
+};
+
+} //NameSpace
+
+#endif

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -1538,6 +1538,7 @@ void MediaInfo_Config_Format (InfoMap &Info)
     "PlayLater Video;;;V;Other;;;;http://www.playon.tv/playlater\n"
     "WTV;;;M;WTV;Windows Recorded TV Show;wtv;video/wtv\n"
     "VVC;;;V;Vvc;Versatile Video Coding;vvc h266 266;video/H266\n"
+    "WebP;;;I;WebP;;webp;image/webp\n"
     ));
     Info.Separator_Set(0, ZenLib::EOL);
 }

--- a/Source/MediaInfo/MediaInfo_File.cpp
+++ b/Source/MediaInfo/MediaInfo_File.cpp
@@ -384,6 +384,9 @@
 #if defined(MEDIAINFO_TGA_YES)
     #include "MediaInfo/Image/File_Tga.h"
 #endif
+#if defined(MEDIAINFO_WEBP_YES)
+    #include "MediaInfo/Image/File_WebP.h"
+#endif
 
 //---------------------------------------------------------------------------
 // Tag
@@ -797,6 +800,9 @@ static File__Analyze* SelectFromExtension(const String& Parser)
     #if defined(MEDIAINFO_TGA_YES)
         if (Parser==__T("Tga"))         return new File_Tga();
     #endif
+    #if defined(MEDIAINFO_WEBP_YES)
+        if (Parser==__T("WebP"))        return new File_WebP();
+    #endif
 
     // Tags
     #if defined(MEDIAINFO_ICC_YES)
@@ -1204,6 +1210,9 @@ int MediaInfo_Internal::ListFormats(const String &File_Name)
     #if defined(MEDIAINFO_TGA_YES)
         //delete Info; Info=new File_Tga();                if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1; //At the end, too much sensible
     #endif
+    #if defined(MEDIAINFO_WEBP_YES)
+        delete Info; Info=new File_WebP();               if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1;
+    #endif
 
     // Archive
     #if defined(MEDIAINFO_ACE_YES)
@@ -1278,7 +1287,7 @@ bool MediaInfo_Internal::LibraryIsModified ()
      || defined(MEDIAINFO_AV1_NO) || defined(MEDIAINFO_AVC_NO) || defined(MEDIAINFO_AVSV_NO) || defined(MEDIAINFO_HEVC_NO) || defined(MEDIAINFO_MPEG4V_NO) || defined(MEDIAINFO_MPEGV_NO) || defined(MEDIAINFO_FLIC_NO) || defined(MEDIAINFO_THEORA_NO) || defined(MEDIAINFO_Y4M_NO) \
      || defined(MEDIAINFO_AC3_NO) || defined(MEDIAINFO_AC4_NO) || defined(MEDIAINFO_ADIF_NO) || defined(MEDIAINFO_ADTS_NO) || defined(MEDIAINFO_SMPTEST0337_NO) || defined(MEDIAINFO_AMR_NO) || defined(MEDIAINFO_DTS_NO) || defined(MEDIAINFO_DOLBYE_NO) || defined(MEDIAINFO_FLAC_NO) || defined(MEDIAINFO_APE_NO) || defined(MEDIAINFO_MPC_NO) || defined(MEDIAINFO_MPCSV8_NO) || defined(MEDIAINFO_MPEGA_NO) || defined(MEDIAINFO_OPENMG_NO) || defined(MEDIAINFO_TWINVQ_NO) || defined(MEDIAINFO_XM_NO) || defined(MEDIAINFO_MOD_NO) || defined(MEDIAINFO_S3M_NO) || defined(MEDIAINFO_IT_NO) || defined(MEDIAINFO_SPEEX_NO) || defined(MEDIAINFO_TAK_NO) || defined(MEDIAINFO_PS2A_NO) \
      || defined(MEDIAINFO_CMML_NO)  || defined(MEDIAINFO_KATE_NO)  || defined(MEDIAINFO_PGS_NO) || defined(MEDIAINFO_OTHERTEXT_NO) \
-     || defined(MEDIAINFO_ARRIRAW_NO) || defined(MEDIAINFO_BMP_NO) || defined(MEDIAINFO_DDS_NO) || defined(MEDIAINFO_DPX_NO) || defined(MEDIAINFO_EXR_NO) || defined(MEDIAINFO_GIF_NO) || defined(MEDIAINFO_ICO_NO) || defined(MEDIAINFO_JPEG_NO) || defined(MEDIAINFO_PNG_NO) || defined(MEDIAINFO_TGA_NO) || defined(MEDIAINFO_TIFF_NO) \
+     || defined(MEDIAINFO_ARRIRAW_NO) || defined(MEDIAINFO_BMP_NO) || defined(MEDIAINFO_DDS_NO) || defined(MEDIAINFO_DPX_NO) || defined(MEDIAINFO_EXR_NO) || defined(MEDIAINFO_GIF_NO) || defined(MEDIAINFO_ICO_NO) || defined(MEDIAINFO_JPEG_NO) || defined(MEDIAINFO_PNG_NO) || defined(MEDIAINFO_TGA_NO) || defined(MEDIAINFO_TIFF_NO) || defined(MEDIAINFO_WEBP_NO) \
      || defined(MEDIAINFO_7Z_NO) || defined(MEDIAINFO_ZIP_NO) || defined(MEDIAINFO_RAR_NO) || defined(MEDIAINFO_ACE_NO) || defined(MEDIAINFO_ELF_NO) || defined(MEDIAINFO_MZ_NO) \
      || defined(MEDIAINFO_OTHER_NO) || defined(MEDIAINFO_DUMMY_NO)
         return true;

--- a/Source/MediaInfo/Setup.h
+++ b/Source/MediaInfo/Setup.h
@@ -957,6 +957,9 @@
 #if !defined(MEDIAINFO_IMAGE_NO) && !defined(MEDIAINFO_TGA_NO) && !defined(MEDIAINFO_TGA_YES)
     #define MEDIAINFO_TGA_YES
 #endif
+#if !defined(MEDIAINFO_IMAGE_NO) && !defined(MEDIAINFO_WEBP_NO) && !defined(MEDIAINFO_WEBP_YES)
+    #define MEDIAINFO_WEBP_YES
+#endif
 
 //---------------------------------------------------------------------------
 // Archive

--- a/Source/Resource/Text/DataBase/Format.csv
+++ b/Source/Resource/Text/DataBase/Format.csv
@@ -170,3 +170,4 @@ AutoCAD;;;O;Other;;;;http://www.autodesk.com;
 PlayLater Video;;;V;Other;;;;http://www.playon.tv/playlater;
 WTV;;;M;WTV;Windows Recorded TV Show;wtv;video/wtv;;
 VVC;;;V;Vvc;Versatile Video Coding;vvc h266 266;video/H266;
+WebP;;;I;WebP;;webp;image/webp;


### PR DESCRIPTION
Hi, I noticed that WebP didn't work, so thought I'd add it using the info from #1391 

General file info is still handled by the RIFF parser, this just adds basic image stream support. It doesn't rely on libwebp, to keep the binary sizes down. It doesn't do EXIF metadata (that'd need the JPEG EXIF code split out?). I tried to add the .cpp files to all the projects, but only built it on Linux.

Test data with vp8, lossless, alpha channel, animated and iccp colour profiles attached:

[testdata.zip](https://github.com/user-attachments/files/19781107/testdata.zip)
