### PR TITLE
Basic Mach-O / Universal Binary detection

### DIFF
--- a/Project/BCB/Library/MediaInfoLib.cbproj
+++ b/Project/BCB/Library/MediaInfoLib.cbproj
@@ -140,6 +140,9 @@
         <CppCompile Include="..\..\..\Source\MediaInfo\Archive\File_Mz.cpp">
             <BuildOrder>137</BuildOrder>
         </CppCompile>
+        <CppCompile Include="..\..\..\Source\MediaInfo\Archive\File_MachO.cpp">
+            <BuildOrder>241</BuildOrder>
+        </CppCompile>
         <CppCompile Include="..\..\..\Source\MediaInfo\Archive\File_Rar.cpp">
             <BuildOrder>158</BuildOrder>
         </CppCompile>

--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -148,6 +148,7 @@ set(MediaInfoLib_SRCS
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Archive/File_Elf.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Archive/File_Gzip.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Archive/File_Iso9660.cpp
+  ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Archive/File_MachO.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Archive/File_Mz.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Archive/File_Rar.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Archive/File_Tar.cpp

--- a/Project/GNU/Library/Makefile.am
+++ b/Project/GNU/Library/Makefile.am
@@ -33,6 +33,7 @@ lib@MediaInfoLib_LibName@_la_SOURCES = \
                        ../../../Source/MediaInfo/Archive/File_Elf.cpp \
                        ../../../Source/MediaInfo/Archive/File_Gzip.cpp \
                        ../../../Source/MediaInfo/Archive/File_Iso9660.cpp \
+                       ../../../Source/MediaInfo/Archive/File_MachO.cpp \
                        ../../../Source/MediaInfo/Archive/File_Mz.cpp \
                        ../../../Source/MediaInfo/Archive/File_Rar.cpp \
                        ../../../Source/MediaInfo/Archive/File_Tar.cpp \

--- a/Project/GNU/Library/configure.ac
+++ b/Project/GNU/Library/configure.ac
@@ -80,6 +80,7 @@ AC_ARG_ENABLE(bzip2,   AC_HELP_STRING([--disable-bzip2],   [Disable Archive - Bz
 AC_ARG_ENABLE(elf,     AC_HELP_STRING([--disable-elf],     [Disable Archive - ELF]),                                      MediaInfoElf=$enableval,     MediaInfoElf=depend)
 AC_ARG_ENABLE(gzip,    AC_HELP_STRING([--disable-gzip],    [Disable Archive - GZip]),                                     MediaInfoGzip=$enableval,    MediaInfoGzip=depend)
 AC_ARG_ENABLE(iso9660, AC_HELP_STRING([--disable-iso9660], [Disable Archive - ISO 9660]),                                 MediaInfoIso9660=$enableval, MediaInfoIso9660=depend)
+AC_ARG_ENABLE(macho,   AC_HELP_STRING([--disable-macho],   [Disable Archive - Mach-O and Universal Binaries (MacOS)]),    MediaInfoMachO=$enableval,   MediaInfoMachO=depend)
 AC_ARG_ENABLE(mz,      AC_HELP_STRING([--disable-mz],      [Disable Archive - MZ (DOS) and PE (Windows)]),                MediaInfoMz=$enableval,      MediaInfoMz=depend)
 AC_ARG_ENABLE(rar,     AC_HELP_STRING([--disable-rar],     [Disable Archive - Rar]),                                      MediaInfoRar=$enableval,     MediaInfoRar=depend)
 AC_ARG_ENABLE(tar,     AC_HELP_STRING([--disable-tar],     [Disable Archive - Tar]),                                      MediaInfoTar=$enableval,     MediaInfoTar=depend)
@@ -253,6 +254,7 @@ if test "$MediaInfoBzip2"   = "no";  then AC_DEFINE(MEDIAINFO_BZIP2_NO)   fi; if
 if test "$MediaInfoElf"     = "no";  then AC_DEFINE(MEDIAINFO_ELF_NO)     fi; if test "$MediaInfoElf"     = "yes"; then AC_DEFINE(MEDIAINFO_ELF_YES)     fi
 if test "$MediaInfoGzip"    = "no";  then AC_DEFINE(MEDIAINFO_GZIP_NO)    fi; if test "$MediaInfoGzip"    = "yes"; then AC_DEFINE(MEDIAINFO_GZIP_YES)    fi
 if test "$MediaInfoIso9660" = "no";  then AC_DEFINE(MEDIAINFO_ISO9660_NO) fi; if test "$MediaInfoIso9660" = "yes"; then AC_DEFINE(MEDIAINFO_ISO9660_YES) fi
+if test "$MediaInfoMachO"   = "no";  then AC_DEFINE(MEDIAINFO_MACHO_NO)   fi; if test "$MediaInfoMachO"   = "yes"; then AC_DEFINE(MEDIAINFO_MACHO_YES)   fi
 if test "$MediaInfoMz"      = "no";  then AC_DEFINE(MEDIAINFO_MZ_NO)      fi; if test "$MediaInfoMz"      = "yes"; then AC_DEFINE(MEDIAINFO_MZ_YES)      fi
 if test "$MediaInfoRar"     = "no";  then AC_DEFINE(MEDIAINFO_RAR_NO)     fi; if test "$MediaInfoRar"     = "yes"; then AC_DEFINE(MEDIAINFO_RAR_YES)     fi
 if test "$MediaInfoTar"     = "no";  then AC_DEFINE(MEDIAINFO_TAR_NO)     fi; if test "$MediaInfoTar"     = "yes"; then AC_DEFINE(MEDIAINFO_TAR_YES)     fi
@@ -1018,6 +1020,7 @@ Mcho "Bzip2  " "$MediaInfoBzip2"
 Mcho "Elf    " "$MediaInfoElf"
 Mcho "Gzip   " "$MediaInfoGzip"
 Mcho "ISO9660" "$MediaInfoIso9660"
+Mcho "MachO  " "$MediaInfoMachO"
 Mcho "Mz     " "$MediaInfoMz"
 Mcho "Rar    " "$MediaInfoRar"
 Mcho "Tar    " "$MediaInfoTar"

--- a/Project/MSVC2022/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2022/Library/MediaInfoLib.vcxproj
@@ -326,6 +326,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Iso9660.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_MachO.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio_Sbr.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio_Sbr_Ps.cpp" />
@@ -724,6 +725,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_Iso9660.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_MachO.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio_Sbr.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio_Sbr_Ps.h" />

--- a/Project/MSVC2022/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2022/Library/MediaInfoLib.vcxproj
@@ -325,8 +325,6 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Iso9660.cpp" />
-    <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_MachO.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio_Sbr.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio_Sbr_Ps.cpp" />
@@ -397,6 +395,8 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Bzip2.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Elf.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Gzip.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Iso9660.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_MachO.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Mz.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Rar.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Tar.cpp" />
@@ -724,8 +724,6 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_Iso9660.h" />
-    <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_MachO.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio_Sbr.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio_Sbr_Ps.h" />
@@ -826,6 +824,8 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_Bzip2.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_Elf.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_Gzip.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_Iso9660.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_MachO.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_Mz.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_Rar.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_Tar.h" />

--- a/Project/MSVC2022/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2022/Library/MediaInfoLib.vcxproj.filters
@@ -860,6 +860,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Video\File_Avs3V.cpp">
       <Filter>Source Files\Video</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_MachO.cpp">
+      <Filter>Source Files\Archive</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\MediaInfo\File__Analyse_Automatic.h">
@@ -1617,6 +1620,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\Video\File_HdrVividMetadata.h">
       <Filter>Header Files\Video</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\Archive\File_MachO.h">
+      <Filter>Header Files\Archive</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Project/MSVC2022/Library/MediaInfoLib_UWP.vcxproj
+++ b/Project/MSVC2022/Library/MediaInfoLib_UWP.vcxproj
@@ -182,7 +182,6 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Iso9660.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio_Sbr.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Audio\File_Aac_GeneralAudio_Sbr_Ps.cpp" />
@@ -252,6 +251,8 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Bzip2.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Elf.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Gzip.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Iso9660.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_MachO.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Mz.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Rar.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Archive\File_Tar.cpp" />

--- a/Project/Qt/MediaInfoLib.pro
+++ b/Project/Qt/MediaInfoLib.pro
@@ -44,6 +44,7 @@ HEADERS += \
         ../../Source/MediaInfo/Archive/File_Elf.h \
         ../../Source/MediaInfo/Archive/File_Gzip.h \
         ../../Source/MediaInfo/Archive/File_Iso9660.h \
+        ../../Source/MediaInfo/Archive/File_MacO.h \
         ../../Source/MediaInfo/Archive/File_Mz.h \
         ../../Source/MediaInfo/Archive/File_Rar.h \
         ../../Source/MediaInfo/Archive/File_Tar.h \
@@ -271,6 +272,7 @@ SOURCES += \
         ../../Source/MediaInfo/Archive/File_Elf.cpp \
         ../../Source/MediaInfo/Archive/File_Gzip.cpp \
         ../../Source/MediaInfo/Archive/File_Iso9660.cpp \
+        ../../Source/MediaInfo/Archive/File_MacO.cpp \
         ../../Source/MediaInfo/Archive/File_Mz.cpp \
         ../../Source/MediaInfo/Archive/File_Rar.cpp \
         ../../Source/MediaInfo/Archive/File_Tar.cpp \

--- a/Source/MediaInfo/Archive/File_MachO.cpp
+++ b/Source/MediaInfo/Archive/File_MachO.cpp
@@ -33,11 +33,22 @@ namespace MediaInfoLib
 //***************************************************************************
 
 //---------------------------------------------------------------------------
+const char* MachO_Magic(int32u Magic) {
+    switch (Magic) {
+    case 0xCEFAEDFE: return "32-bit LE";
+    case 0xCFFAEDFE: return "64-bit LE";
+    case 0xFEEDFACE: return "32-bit BE";
+    case 0xFEEDFACF: return "64-bit BE";
+    case 0xCAFEBABE: return "Universal 32-bit";
+    case 0xCAFEBABF: return "Universal 64-bit";
+    default: return "";
+    }
+}
+
+//---------------------------------------------------------------------------
 // https://github.com/opensource-apple/cctools/blob/master/include/mach/machine.h
-const char* MachO_cputype(int32u cputype)
-{
-    switch (cputype)
-    {
+string MachO_cputype(int32u cputype) {
+    switch (cputype) {
     case 0x00000001: return "VAX";
     case 0x00000002: return "ROMP";
     case 0x00000004: return "NS32032";
@@ -55,39 +66,73 @@ const char* MachO_cputype(int32u cputype)
     case 0x0000000F: return "Intel i860 (big-endian)";
     case 0x00000010: return "Intel i860 (little-endian)";
     case 0x00000011: return "RS/6000";
-    case 0x00000012: return "PowerPC / MC98000";
+    case 0x00000012: return "PowerPC";
     case 0x01000012: return "PowerPC 64-bit";
-    default: return "";
+    default: return "0x" + Ztring().From_CC4(cputype).To_UTF8();
     }
 }
 
-// CPU type and binary size
 //---------------------------------------------------------------------------
-struct BinaryInfo {
-    int32u cputype;
-    int64u size;
-    int32u align;
-};
+// https://en.wikipedia.org/wiki/Mach-O#Mach-O_header
+string MachO_filetype(int32u filetype) {
+    switch (filetype) {
+    case 0x00000001: return "Relocatable object";
+    case 0x00000002: return "Demand paged executable";
+    case 0x00000003: return "Shared library";
+    case 0x00000004: return "Core";
+    case 0x00000005: return "Preloaded executable";
+    case 0x00000006: return "Dynamically bound shared library";
+    case 0x00000007: return "Dynamic link editor";
+    case 0x00000008: return "Dynamically bound bundle";
+    case 0x00000009: return "Shared library stub for static linking only";
+    case 0x0000000A: return "Companion file with only debug sections";
+    case 0x0000000B: return "x86_64 kexts";
+    default: return "0x" + Ztring().From_CC4(filetype).To_UTF8();
+    }
+}
+
+//---------------------------------------------------------------------------
+// Byte sizes
+static const char* Unit_Letters = "KMGTPEZY";
+string Power2_WithUnits(int32u Offset) {
+    int32u Quotient  = Offset / 10;
+    int32u Remainder = Offset % 10;
+    if (!Quotient) {
+        return std::to_string(Offset) + " B";
+    }
+    if (Quotient > 8) {
+        Quotient = 8;
+        Remainder = Offset / 80;
+    }
+    return std::to_string(1 << Remainder) + ' ' + Unit_Letters[Quotient - 1] + "iB";
+}
 
 //***************************************************************************
-// Static stuff
+// Buffer - File header
 //***************************************************************************
 
 //---------------------------------------------------------------------------
-bool File_MachO::FileHeader_Begin()
-{
+bool File_MachO::FileHeader_Begin() {
     //Element_Size
-    if (Buffer_Size<4)
+    if (File_Size < 32) {
+        Reject();
+        return false;
+    }
+    if (Buffer_Size < 4) {
         return false; //Must wait for more data
+    }
 
-    if (!((Buffer[0] == 0xCE && Buffer[1] == 0xFA && Buffer[2] == 0xED && Buffer[3] == 0xFE) || //feedface - 32-bit Mach-O (little-endian)
-          (Buffer[0] == 0xCF && Buffer[1] == 0xFA && Buffer[2] == 0xED && Buffer[3] == 0xFE) || //feedfacf - 64-bit Mach-O (little-endian)
-          (Buffer[0] == 0xFE && Buffer[1] == 0xED && Buffer[2] == 0xFA && Buffer[3] == 0xCE) || //feedface - 32-bit Mach-O (big-endian)
-          (Buffer[0] == 0xFE && Buffer[1] == 0xED && Buffer[2] == 0xFA && Buffer[3] == 0xCF) || //feedfacf - 64-bit Mach-O (big-endian)
-          (Buffer[0] == 0xCA && Buffer[1] == 0xFE && Buffer[2] == 0xBA && Buffer[3] == 0xBE) || //cafebabe - 32-bit Universal fat binary
-          (Buffer[0] == 0xCA && Buffer[1] == 0xFE && Buffer[2] == 0xBA && Buffer[3] == 0xBF)))  //cafebabf - 64-bit Universal fat binary
-    {
-        Reject("Mach-O");
+    auto MagicValue = CC4(Buffer);
+    switch (MagicValue) {
+    case 0xCEFAEDFE: // 32-bit Mach-O (little-endian)
+    case 0xCFFAEDFE: // 64-bit Mach-O (little-endian)
+    case 0xFEEDFACE: // 32-bit Mach-O (big-endian)
+    case 0xFEEDFACF: // 64-bit Mach-O (big-endian)
+    case 0xCAFEBABE: // 32-bit Universal fat binary
+    case 0xCAFEBABF: // 64-bit Universal fat binary
+        break;
+    default:
+        Reject();
         return false;
     }
 
@@ -100,91 +145,149 @@ bool File_MachO::FileHeader_Begin()
 //***************************************************************************
 
 //---------------------------------------------------------------------------
-void File_MachO::Read_Buffer_Continue()
-{
+void File_MachO::Read_Buffer_Continue() {
     //Parsing
-    bool isFat{};
-    int32u magic, cputype{}, nfat_arch{};
-    std::vector<BinaryInfo> binaries;
-    Peek_B4(magic);
-    if (magic == 0xcefaedfe || magic == 0xcffaedfe) {
-        isFat = false;
-        Element_Begin1("Mach-O");
-        Skip_L4(                                                "magic");
-        Get_L4(cputype,                                         "cputype"); Param_Info1(MachO_cputype(cputype));
+    if (File_Offset + Buffer_Offset != 0) {
+        Element_Begin1("arch");
+    }
+    int32u magic, cputype{}, filetype{}, nfat_arch{};
+    Element_Begin1("Header");
+    Get_B4 (magic,                                              "magic"); Param_Info1(MachO_Magic(magic)); Element_Info1(MachO_Magic(magic));
+    switch (magic) {
+    case 0xCEFAEDFE: // 32-bit Mach-O (little-endian)
+    case 0xCFFAEDFE: // 64-bit Mach-O (little-endian)
+        Get_L4 (cputype,                                        "cputype");
+        #if MEDIAINFO_TRACE
+        Param_Info1(MachO_cputype(cputype));
+        Element_Info1(MachO_cputype(cputype));
+        if (File_Offset + Buffer_Offset != 0) {
+            Element_Level--;
+            Param_Info1(MachO_Magic(magic));
+            Element_Info1(MachO_cputype(cputype));
+            Element_Level++;
+        }
+        #endif
         Skip_L4(                                                "cpusubtype");
-        Skip_L4(                                                "filetype");
+        Get_L4 (filetype,                                       "filetype");
         Skip_L4(                                                "ncmds");
         Skip_L4(                                                "sizeofcmds");
         Skip_L4(                                                "flags");
-        if (magic == 0xcffaedfe)
+        if (magic == 0xCFFAEDFE)
             Skip_L4(                                            "reserved");
-        Element_End0();
-    }
-    if (magic == 0xfeedface || magic == 0xfeedfacf) {
-        isFat = false;
-        Element_Begin1("Mach-O");
-        Skip_B4(                                                "magic");
-        Get_B4(cputype,                                         "cputype"); Param_Info1(MachO_cputype(cputype));
+        break;
+    case 0xFEEDFACE: // 32-bit Mach-O (big-endian)
+    case 0xFEEDFACF: // 64-bit Mach-O (big-endian)
+        Get_B4 (cputype,                                        "cputype"); Param_Info1(MachO_cputype(cputype)); Element_Info1(MachO_cputype(cputype));
+        #if MEDIAINFO_TRACE
+        Param_Info1(MachO_cputype(cputype));
+        Element_Info1(MachO_cputype(cputype));
+        if (File_Offset + Buffer_Offset != 0) {
+            Element_Level--;
+            Param_Info1(MachO_Magic(magic));
+            Element_Info1(MachO_cputype(cputype));
+            Element_Level++;
+        }
+        #endif
         Skip_B4(                                                "cpusubtype");
-        Skip_B4(                                                "filetype");
+        Get_B4 (filetype,                                       "filetype");
         Skip_B4(                                                "ncmds");
         Skip_B4(                                                "sizeofcmds");
         Skip_B4(                                                "flags");
-        if (magic == 0xfeedfacf)
+        if (magic == 0xFEEDFACF)
             Skip_B4(                                            "reserved");
-        Element_End0();
-    }
-    if (magic == 0xcafebabe || magic == 0xcafebabf) {
-        isFat = true;
-        Element_Begin1("Universal Binary");
-        Skip_B4(                                                "magic");
-        Get_B4(nfat_arch,                                       "nfat_arch");
+        break;
+    case 0xCAFEBABE: // 32-bit Universal fat binary
+    case 0xCAFEBABF: // 64-bit Universal fat binary
+        if (File_Offset + Buffer_Offset != 0) {
+            Reject();
+            Element_End0();
+            return;
+        }
+        Get_B4 (nfat_arch,                                      "nfat_arch");
+        if (!nfat_arch || nfat_arch > (File_Size - 4) / (magic == 0xCAFEBABE ? 12 : 24)) {
+            Reject();
+            Element_End0();
+            return;
+        }
         for (int32u i = 0; i < nfat_arch; ++i) {
-            Element_Begin1("Binary");
+            Element_Begin1("arch");
             BinaryInfo binary{};
-            Get_B4(binary.cputype,                              "cputype"); Param_Info1(MachO_cputype(binary.cputype));
+            int64u offset;
+            Get_B4 (binary.cputype,                             "cputype"); Param_Info1(MachO_cputype(binary.cputype)); Element_Info1(MachO_cputype(binary.cputype));
             Skip_B4(                                            "cpusubtype");
-            if (magic == 0xcafebabe) {
-                int32u size32{};
-                Skip_B4(                                        "offset");
-                Get_B4(size32,                                  "size");
-                Get_B4(binary.align,                            "align"); Param_Info1(std::pow(2, binary.align));
+            if (magic == 0xCAFEBABE) {
+                int32u offset32{}, size32{};
+                Get_B4 (offset32,                               "offset");
+                Get_B4 (size32,                                 "size");
+                offset = offset32;
                 binary.size = size32;
+                Get_B4 (binary.align,                           "align"); Param_Info1(Power2_WithUnits(binary.align));
             } else {
-                int64u size64{};
-                Skip_B8(                                        "offset");
-                Get_B8(size64,                                  "size");
-                Get_B4(binary.align,                            "align"); Param_Info1(std::pow(2, binary.align));
+                Get_B8 (offset,                                 "offset");
+                Get_B8 (binary.size,                            "size");
+                Get_B4 (binary.align,                           "align"); Param_Info1(Power2_WithUnits(binary.align));
                 Skip_B4(                                        "reserved");
-                binary.size = size64;
             }
-            binaries.push_back(binary);
+            if (binary.align >= 64 || binary.size < (magic == 0xCAFEBABE ? 28 : 32) || offset > File_Size || binary.size > File_Size - offset || Universal_Positions.find(offset) != Universal_Positions.end()) {
+                Reject();
+                Element_End0();
+                Element_End0();
+                return;
+            }
+            Universal_Positions[offset] = binary;
             Element_End0();
         }
+        break;
+    }
+    Element_End0();
+    #if MEDIAINFO_TRACE
+    if (File_Offset + Buffer_Offset == 0) {
+        if (!Universal_Positions.empty()) {
+            Skip_XX(Universal_Positions.begin()->first - Element_Offset, "Padding");
+        }
+    }
+    else {
+        Skip_XX(Universal_Current->second.size - Element_Offset, "(Note parsed)");
         Element_End0();
     }
+    #endif
 
     FILLING_BEGIN();
-        Accept("Mach-O");
-        if (!isFat) {
+        Accept();
+        if (Universal_Positions.empty()) {
             Fill(Stream_General, 0, General_Format, "Mach-O");
-            Fill(Stream_General, 0, General_Format_Profile, "Mach Object");
+            Fill(Stream_General, 0, General_Format_Profile, MachO_filetype(filetype));
             Fill(Stream_General, 0, General_Format_Profile, MachO_cputype(cputype));
+            Finish();
+        }
+        else if (File_Offset + Buffer_Offset == 0) {
+            Fill(Stream_General, 0, General_Format, "Mach-O Universal");
+            Universal_Current = Universal_Positions.begin();
+            GoTo(Universal_Current->first);
         }
         else {
-            Fill(Stream_General, 0, General_Format, "Mach-O Universal");
-            for (size_t i = 0; i < binaries.size(); ++i) {
-                Stream_Prepare(Stream_Other);
-                Fill(Stream_Other, i, Other_Type, "Binary");
-                Fill(Stream_Other, i, Other_Format, "Mach-O");
-                Fill(Stream_Other, i, Other_Format_Profile, "Mach Object");
-                Fill(Stream_Other, i, Other_Format_Profile, MachO_cputype(binaries[i].cputype));
-                Fill(Stream_Other, i, Other_StreamSize, binaries[i].size);
-                Fill(Stream_Other, i, "Alignment/String", Ztring::ToZtring(std::pow(2, binaries[i].align) / 1024, 0) + __T(" KiB"));
+            Stream_Prepare(Stream_Other);
+            Fill(Stream_Other, StreamPos_Last, Other_Type, "Binary");
+            Fill(Stream_Other, StreamPos_Last, Other_Format, "Mach-O");
+            Fill(Stream_Other, StreamPos_Last, Other_Format_Profile, MachO_filetype(filetype));
+            Fill(Stream_Other, StreamPos_Last, Other_Format_Profile, MachO_cputype(Universal_Current->second.cputype));
+            Fill(Stream_Other, StreamPos_Last, Other_StreamSize, Universal_Current->second.size);
+            Fill(Stream_Other, StreamPos_Last, "Alignment", 1 << Universal_Current->second.align);
+            Fill_SetOptions(Stream_Other, StreamPos_Last, "Alignment", "N NIY");
+            Fill(Stream_Other, StreamPos_Last, "Alignment/String", Power2_WithUnits(Universal_Current->second.align));
+            Fill_SetOptions(Stream_Other, StreamPos_Last, "Alignment/String", "Y NTN");
+            Universal_Current++;
+            if (Universal_Current == Universal_Positions.end()) {
+                if (File_Size != (int64u)-1) {
+                    Skip_XX(File_Size - (File_Offset + Buffer_Offset + Element_Offset), "Padding");
+                }
+                Finish();
             }
+            else {
+                GoTo(Universal_Current->first);
+            }
+
         }
-        Finish("Mach-O");
     FILLING_END();
 }
 

--- a/Source/MediaInfo/Archive/File_MachO.cpp
+++ b/Source/MediaInfo/Archive/File_MachO.cpp
@@ -1,0 +1,193 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//---------------------------------------------------------------------------
+// Pre-compilation
+#include "MediaInfo/PreComp.h"
+#ifdef __BORLANDC__
+    #pragma hdrstop
+#endif
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/Setup.h"
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#if defined(MEDIAINFO_MACHO_YES)
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/Archive/File_MachO.h"
+#include <cmath>
+//---------------------------------------------------------------------------
+
+namespace MediaInfoLib
+{
+
+//***************************************************************************
+// Infos
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+// https://github.com/opensource-apple/cctools/blob/master/include/mach/machine.h
+const char* MachO_cputype(int32u cputype)
+{
+    switch (cputype)
+    {
+    case 0x00000001: return "VAX";
+    case 0x00000002: return "ROMP";
+    case 0x00000004: return "NS32032";
+    case 0x00000005: return "NS32332";
+    case 0x00000006: return "MC680x0";
+    case 0x00000007: return "Intel i386";
+    case 0x01000007: return "AMD x86-64";
+    case 0x00000008: return "MIPS";
+    case 0x00000009: return "NS32352";
+    case 0x0000000B: return "HP-PA";
+    case 0x0000000C: return "ARM";
+    case 0x0100000C: return "ARM64";
+    case 0x0000000D: return "MC88000";
+    case 0x0000000E: return "SPARC";
+    case 0x0000000F: return "Intel i860 (big-endian)";
+    case 0x00000010: return "Intel i860 (little-endian)";
+    case 0x00000011: return "RS/6000";
+    case 0x00000012: return "PowerPC / MC98000";
+    case 0x01000012: return "PowerPC 64-bit";
+    default: return "";
+    }
+}
+
+// CPU type and binary size
+//---------------------------------------------------------------------------
+struct BinaryInfo {
+    int32u cputype;
+    int64u size;
+    int32u align;
+};
+
+//***************************************************************************
+// Static stuff
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+bool File_MachO::FileHeader_Begin()
+{
+    //Element_Size
+    if (Buffer_Size<4)
+        return false; //Must wait for more data
+
+    if (!((Buffer[0] == 0xCE && Buffer[1] == 0xFA && Buffer[2] == 0xED && Buffer[3] == 0xFE) || //feedface - 32-bit Mach-O (little-endian)
+          (Buffer[0] == 0xCF && Buffer[1] == 0xFA && Buffer[2] == 0xED && Buffer[3] == 0xFE) || //feedfacf - 64-bit Mach-O (little-endian)
+          (Buffer[0] == 0xFE && Buffer[1] == 0xED && Buffer[2] == 0xFA && Buffer[3] == 0xCE) || //feedface - 32-bit Mach-O (big-endian)
+          (Buffer[0] == 0xFE && Buffer[1] == 0xED && Buffer[2] == 0xFA && Buffer[3] == 0xCF) || //feedfacf - 64-bit Mach-O (big-endian)
+          (Buffer[0] == 0xCA && Buffer[1] == 0xFE && Buffer[2] == 0xBA && Buffer[3] == 0xBE) || //cafebabe - 32-bit Universal fat binary
+          (Buffer[0] == 0xCA && Buffer[1] == 0xFE && Buffer[2] == 0xBA && Buffer[3] == 0xBF)))  //cafebabf - 64-bit Universal fat binary
+    {
+        Reject("Mach-O");
+        return false;
+    }
+
+    //All should be OK...
+    return true;
+}
+
+//***************************************************************************
+// Buffer - Global
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+void File_MachO::Read_Buffer_Continue()
+{
+    //Parsing
+    bool isFat{};
+    int32u magic, cputype{}, nfat_arch{};
+    std::vector<BinaryInfo> binaries;
+    Peek_B4(magic);
+    if (magic == 0xcefaedfe || magic == 0xcffaedfe) {
+        isFat = false;
+        Element_Begin1("Mach-O");
+        Skip_L4(                                                "magic");
+        Get_L4(cputype,                                         "cputype"); Param_Info1(MachO_cputype(cputype));
+        Skip_L4(                                                "cpusubtype");
+        Skip_L4(                                                "filetype");
+        Skip_L4(                                                "ncmds");
+        Skip_L4(                                                "sizeofcmds");
+        Skip_L4(                                                "flags");
+        if (magic == 0xcffaedfe)
+            Skip_L4(                                            "reserved");
+        Element_End0();
+    }
+    if (magic == 0xfeedface || magic == 0xfeedfacf) {
+        isFat = false;
+        Element_Begin1("Mach-O");
+        Skip_B4(                                                "magic");
+        Get_B4(cputype,                                         "cputype"); Param_Info1(MachO_cputype(cputype));
+        Skip_B4(                                                "cpusubtype");
+        Skip_B4(                                                "filetype");
+        Skip_B4(                                                "ncmds");
+        Skip_B4(                                                "sizeofcmds");
+        Skip_B4(                                                "flags");
+        if (magic == 0xfeedfacf)
+            Skip_B4(                                            "reserved");
+        Element_End0();
+    }
+    if (magic == 0xcafebabe || magic == 0xcafebabf) {
+        isFat = true;
+        Element_Begin1("Universal Binary");
+        Skip_B4(                                                "magic");
+        Get_B4(nfat_arch,                                       "nfat_arch");
+        for (int32u i = 0; i < nfat_arch; ++i) {
+            Element_Begin1("Binary");
+            BinaryInfo binary{};
+            Get_B4(binary.cputype,                              "cputype"); Param_Info1(MachO_cputype(binary.cputype));
+            Skip_B4(                                            "cpusubtype");
+            if (magic == 0xcafebabe) {
+                int32u size32{};
+                Skip_B4(                                        "offset");
+                Get_B4(size32,                                  "size");
+                Get_B4(binary.align,                            "align"); Param_Info1(std::pow(2, binary.align));
+                binary.size = size32;
+            } else {
+                int64u size64{};
+                Skip_B8(                                        "offset");
+                Get_B8(size64,                                  "size");
+                Get_B4(binary.align,                            "align"); Param_Info1(std::pow(2, binary.align));
+                Skip_B4(                                        "reserved");
+                binary.size = size64;
+            }
+            binaries.push_back(binary);
+            Element_End0();
+        }
+        Element_End0();
+    }
+
+    FILLING_BEGIN();
+        Accept("Mach-O");
+        if (!isFat) {
+            Fill(Stream_General, 0, General_Format, "Mach-O");
+            Fill(Stream_General, 0, General_Format_Profile, "Mach Object");
+            Fill(Stream_General, 0, General_Format_Profile, MachO_cputype(cputype));
+        }
+        else {
+            Fill(Stream_General, 0, General_Format, "Universal Binary");
+            for (size_t i = 0; i < binaries.size(); ++i) {
+                Stream_Prepare(Stream_Other);
+                Fill(Stream_Other, i, Other_Type, "Binary");
+                Fill(Stream_Other, i, Other_Format, "Mach-O");
+                Fill(Stream_Other, i, Other_Format_Profile, "Mach Object");
+                Fill(Stream_Other, i, Other_Format_Profile, MachO_cputype(binaries[i].cputype));
+                Fill(Stream_Other, i, Other_StreamSize, binaries[i].size);
+                Fill(Stream_Other, i, "Alignment/String", Ztring::ToZtring(std::pow(2, binaries[i].align) / 1024, 0) + __T(" KiB"));
+            }
+        }
+        Finish("Mach-O");
+    FILLING_END();
+}
+
+} //NameSpace
+
+#endif //MEDIAINFO_MACHO_YES

--- a/Source/MediaInfo/Archive/File_MachO.cpp
+++ b/Source/MediaInfo/Archive/File_MachO.cpp
@@ -173,7 +173,7 @@ void File_MachO::Read_Buffer_Continue()
             Fill(Stream_General, 0, General_Format_Profile, MachO_cputype(cputype));
         }
         else {
-            Fill(Stream_General, 0, General_Format, "Universal Binary");
+            Fill(Stream_General, 0, General_Format, "Mach-O Universal");
             for (size_t i = 0; i < binaries.size(); ++i) {
                 Stream_Prepare(Stream_Other);
                 Fill(Stream_Other, i, Other_Type, "Binary");

--- a/Source/MediaInfo/Archive/File_MachO.h
+++ b/Source/MediaInfo/Archive/File_MachO.h
@@ -34,6 +34,15 @@ protected :
 
     //Buffer - Global
     void Read_Buffer_Continue ();
+
+    //Temp
+    struct BinaryInfo {
+        int64u size;
+        int32u cputype;
+        int32u align;
+    };
+    std::map<int64u, BinaryInfo> Universal_Positions; // Key is offset
+    std::map<int64u, BinaryInfo>::iterator Universal_Current;
 };
 
 } //NameSpace

--- a/Source/MediaInfo/Archive/File_MachO.h
+++ b/Source/MediaInfo/Archive/File_MachO.h
@@ -1,0 +1,41 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+//
+// Information about Mach-O and Universal Binary files
+//
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+//---------------------------------------------------------------------------
+#ifndef MediaInfo_File_MachOH
+#define MediaInfo_File_MachOH
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/File__Analyze.h"
+//---------------------------------------------------------------------------
+
+namespace MediaInfoLib
+{
+
+//***************************************************************************
+// Class File_MachO
+//***************************************************************************
+
+class File_MachO : public File__Analyze
+{
+protected :
+    //Buffer - File header
+    bool FileHeader_Begin();
+
+    //Buffer - Global
+    void Read_Buffer_Continue ();
+};
+
+} //NameSpace
+
+#endif

--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -958,10 +958,12 @@ void File__Analyze::Streams_Finish_StreamOnly_General(size_t StreamPos)
     {
         const Ztring& Name=Retrieve(Stream_General, StreamPos, General_FileName);
         const Ztring& Extension=Retrieve(Stream_General, StreamPos, General_FileExtension);
-        if (!Name.empty() || !Extension.empty())
+        const Ztring& FormatName=Retrieve(Stream_General, StreamPos, General_Format);
+        auto IsMachOAndEmptyExtension = Extension.empty() && FormatName.rfind(__T("Mach-O"), 0)==0;
+        if ((!Name.empty() && !IsMachOAndEmptyExtension) || !Extension.empty())
         {
             InfoMap &FormatList=MediaInfoLib::Config.Format_Get();
-            InfoMap::iterator Format=FormatList.find(Retrieve(Stream_General, StreamPos, General_Format));
+            InfoMap::iterator Format=FormatList.find(FormatName);
             if (Format!=FormatList.end())
             {
                 ZtringList ValidExtensions;

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -1515,6 +1515,7 @@ void MediaInfo_Config_Format (InfoMap &Info)
     "ELF;;;C;Elf;;so\n"
     "ISO 9660;;;C;Iso9660;;iso\n"
     "Mach-O;;;C;MachO;;o dylib kext;;;\n"
+    "Mach-O Universal;;;C;MachO;;o dylib kext;;;\n"
     "MZ;;;C;Mz;;exe dll\n"
     "RAR;;;C;Rar;From Rarlabs;rar;application/x-rar-compressed;http://rarlabs.com\n"
     "ZIP;;;C;Zip;;zip docx odt xlsx ods;application/zip;http://winzip.com\n"

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -1514,6 +1514,7 @@ void MediaInfo_Config_Format (InfoMap &Info)
     "ACE;;;C;Ace;;ace;;http://winace.com\n"
     "ELF;;;C;Elf;;so\n"
     "ISO 9660;;;C;Iso9660;;iso\n"
+    "Mach-O;;;C;MachO;;o dylib kext;;;\n"
     "MZ;;;C;Mz;;exe dll\n"
     "RAR;;;C;Rar;From Rarlabs;rar;application/x-rar-compressed;http://rarlabs.com\n"
     "ZIP;;;C;Zip;;zip docx odt xlsx ods;application/zip;http://winzip.com\n"

--- a/Source/MediaInfo/MediaInfo_File.cpp
+++ b/Source/MediaInfo/MediaInfo_File.cpp
@@ -417,6 +417,9 @@
 #if defined(MEDIAINFO_ISO9660_YES)
     #include "MediaInfo/Archive/File_Iso9660.h"
 #endif
+#if defined(MEDIAINFO_MACHO_YES)
+    #include "MediaInfo/Archive/File_MachO.h"
+#endif
 #if defined(MEDIAINFO_MZ_YES)
     #include "MediaInfo/Archive/File_Mz.h"
 #endif
@@ -831,6 +834,9 @@ static File__Analyze* SelectFromExtension(const String& Parser)
     #if defined(MEDIAINFO_MZ_YES)
         if (Parser==__T("Mz"))          return new File_Mz();
     #endif
+    #if defined(MEDIAINFO_MACHO_YES)
+        if (Parser==__T("MachO"))       return new File_MachO();
+    #endif
     #if defined(MEDIAINFO_RAR_YES)
         if (Parser==__T("Rar"))         return new File_Rar();
     #endif
@@ -1233,6 +1239,9 @@ int MediaInfo_Internal::ListFormats(const String &File_Name)
     #if defined(MEDIAINFO_ISO9660_YES)
         delete Info; Info=new File_Iso9660();            if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1;
     #endif
+    #if defined(MEDIAINFO_MACHO_YES)
+        delete Info; Info=new File_MachO();              if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1;
+    #endif
     #if defined(MEDIAINFO_MZ_YES)
         delete Info; Info=new File_Mz();                 if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1;
     #endif
@@ -1288,7 +1297,7 @@ bool MediaInfo_Internal::LibraryIsModified ()
      || defined(MEDIAINFO_AC3_NO) || defined(MEDIAINFO_AC4_NO) || defined(MEDIAINFO_ADIF_NO) || defined(MEDIAINFO_ADTS_NO) || defined(MEDIAINFO_SMPTEST0337_NO) || defined(MEDIAINFO_AMR_NO) || defined(MEDIAINFO_DTS_NO) || defined(MEDIAINFO_DOLBYE_NO) || defined(MEDIAINFO_FLAC_NO) || defined(MEDIAINFO_APE_NO) || defined(MEDIAINFO_MPC_NO) || defined(MEDIAINFO_MPCSV8_NO) || defined(MEDIAINFO_MPEGA_NO) || defined(MEDIAINFO_OPENMG_NO) || defined(MEDIAINFO_TWINVQ_NO) || defined(MEDIAINFO_XM_NO) || defined(MEDIAINFO_MOD_NO) || defined(MEDIAINFO_S3M_NO) || defined(MEDIAINFO_IT_NO) || defined(MEDIAINFO_SPEEX_NO) || defined(MEDIAINFO_TAK_NO) || defined(MEDIAINFO_PS2A_NO) \
      || defined(MEDIAINFO_CMML_NO)  || defined(MEDIAINFO_KATE_NO)  || defined(MEDIAINFO_PGS_NO) || defined(MEDIAINFO_OTHERTEXT_NO) \
      || defined(MEDIAINFO_ARRIRAW_NO) || defined(MEDIAINFO_BMP_NO) || defined(MEDIAINFO_DDS_NO) || defined(MEDIAINFO_DPX_NO) || defined(MEDIAINFO_EXR_NO) || defined(MEDIAINFO_GIF_NO) || defined(MEDIAINFO_ICO_NO) || defined(MEDIAINFO_JPEG_NO) || defined(MEDIAINFO_PNG_NO) || defined(MEDIAINFO_TGA_NO) || defined(MEDIAINFO_TIFF_NO) || defined(MEDIAINFO_WEBP_NO) \
-     || defined(MEDIAINFO_7Z_NO) || defined(MEDIAINFO_ZIP_NO) || defined(MEDIAINFO_RAR_NO) || defined(MEDIAINFO_ACE_NO) || defined(MEDIAINFO_ELF_NO) || defined(MEDIAINFO_MZ_NO) \
+     || defined(MEDIAINFO_7Z_NO) || defined(MEDIAINFO_ZIP_NO) || defined(MEDIAINFO_RAR_NO) || defined(MEDIAINFO_ACE_NO) || defined(MEDIAINFO_ELF_NO) || defined(MEDIAINFO_MACHO_NO) || defined(MEDIAINFO_MZ_NO) \
      || defined(MEDIAINFO_OTHER_NO) || defined(MEDIAINFO_DUMMY_NO)
         return true;
     #else

--- a/Source/MediaInfo/Setup.h
+++ b/Source/MediaInfo/Setup.h
@@ -981,6 +981,9 @@
 #if !defined(MEDIAINFO_ARCHIVE_NO) && !defined(MEDIAINFO_ISO9660_NO) && !defined(MEDIAINFO_ISO9660_YES)
     #define MEDIAINFO_ISO9660_YES
 #endif
+#if !defined(MEDIAINFO_ARCHIVE_NO) && !defined(MEDIAINFO_MACHO_NO) && !defined(MEDIAINFO_MACHO_YES)
+    #define MEDIAINFO_MACHO_YES
+#endif
 #if !defined(MEDIAINFO_ARCHIVE_NO) && !defined(MEDIAINFO_MZ_NO) && !defined(MEDIAINFO_MZ_YES)
     #define MEDIAINFO_MZ_YES
 #endif

--- a/Source/Resource/Text/DataBase/Format.csv
+++ b/Source/Resource/Text/DataBase/Format.csv
@@ -146,6 +146,7 @@ TGA;;;I;Tga;;tga;image/tga;;
 ACE;;;C;Ace;;ace;;http://winace.com;
 ELF;;;C;Elf;;so;;;
 ISO 9660;;;C;Iso9660;;iso;;;
+Mach-O;;;C;MachO;;o dylib kext;;;
 MZ;;;C;Mz;;exe dll;;;
 RAR;;;C;Rar;From Rarlabs;rar;application/x-rar-compressed;http://rarlabs.com;
 ZIP;;;C;Zip;;zip docx odt xlsx ods;application/zip;http://winzip.com;

--- a/Source/Resource/Text/DataBase/Format.csv
+++ b/Source/Resource/Text/DataBase/Format.csv
@@ -147,6 +147,7 @@ ACE;;;C;Ace;;ace;;http://winace.com;
 ELF;;;C;Elf;;so;;;
 ISO 9660;;;C;Iso9660;;iso;;;
 Mach-O;;;C;MachO;;o dylib kext;;;
+Mach-O Universal;;;C;MachO;;o dylib kext;;;
 MZ;;;C;Mz;;exe dll;;;
 RAR;;;C;Rar;From Rarlabs;rar;application/x-rar-compressed;http://rarlabs.com;
 ZIP;;;C;Zip;;zip docx odt xlsx ods;application/zip;http://winzip.com;


### PR DESCRIPTION
Although I do not have an Apple device, since MediaInfoLib already detects Windows and Linux binaries, I just gave it a try. Not sure what to name stuff or how to present the information.

```
General
Complete name                            : mediainfo
Format                                   : Mach-O
Format profile                           : Mach Object / ARM64
File size                                : 8.04 MiB
FileExtension_Invalid                    : o dylib kext

General
Complete name                            : libmediainfo.0.dylib
Format                                   : Universal Binary
File size                                : 16.9 MiB

Other #1
Type                                     : Binary
Format                                   : Mach-O
Format profile                           : Mach Object / AMD x86-64
Stream size                              : 8.79 MiB
Alignment                                : 16 KiB

Other #2
Type                                     : Binary
Format                                   : Mach-O
Format profile                           : Mach Object / ARM64
Stream size                              : 8.08 MiB
Alignment                                : 16 KiB
```

```
000000 Mach-O (32 bytes)
000000  magic:                                 4277009103 (0xFEEDFACF)
000004  cputype:                               16777228 (0x0100000C) - ARM64
000008  cpusubtype:                            0 (0x00000000)
00000C  filetype:                              2 (0x00000002)
000010  ncmds:                                 22 (0x00000016)
000014  sizeofcmds:                            2104 (0x00000838)
000018  flags:                                 2195589 (0x00218085)
00001C  reserved:                              0 (0x00000000)
000020 ----------------------------
000020 ---   Mach-O, accepted   ---
000020 ----------------------------
000020 ---------------------------
000020 ---   Mach-O, filling   ---
000020 ---------------------------
000020 ----------------------------
000020 ---   Mach-O, finished   ---
000020 ----------------------------
0000000 Universal Binary (48 bytes)
0000000  magic:                                 3405691582 (0xCAFEBABE)
0000004  nfat_arch:                             2 (0x00000002)
0000008  Binary (20 bytes)
0000008   cputype:                              16777223 (0x01000007) - AMD x86-64
000000C   cpusubtype:                           3 (0x00000003)
0000010   offset:                               16384 (0x00004000)
0000014   size:                                 9215568 (0x008C9E50)
0000018   align:                                14 (0x0000000E) - 16384.000
000001C  Binary (20 bytes)
000001C   cputype:                              16777228 (0x0100000C) - ARM64
0000020   cpusubtype:                           0 (0x00000000)
0000024   offset:                               9240576 (0x008D0000)
0000028   size:                                 8469408 (0x00813BA0)
000002C   align:                                14 (0x0000000E) - 16384.000
0000030 ----------------------------
0000030 ---   Mach-O, accepted   ---
0000030 ----------------------------
0000030 ---------------------------
0000030 ---   Mach-O, filling   ---
0000030 ---------------------------
0000030 ----------------------------
0000030 ---   Mach-O, finished   ---
0000030 ----------------------------
```
