### PR TITLE
XMP: Display `photoshop:Credit` + fix for PNG

### DIFF
--- a/Source/MediaInfo/Image/File_Png.cpp
+++ b/Source/MediaInfo/Image/File_Png.cpp
@@ -668,6 +668,7 @@ void File_Png::Textual(bitset8 Method)
             Open_Buffer_Init(&MI, Text_UTF8.size());
             Open_Buffer_Continue(&MI, (const int8u*)Text_UTF8.c_str(), Text_UTF8.size());
             Open_Buffer_Finalize(&MI);
+            Element_Show(); //TODO: why is it needed?
             Merge(MI, Stream_General, 0, 0);
             Text.clear();
             #endif

--- a/Source/MediaInfo/Tag/File_Xmp.cpp
+++ b/Source/MediaInfo/Tag/File_Xmp.cpp
@@ -130,6 +130,9 @@ bool File_Xmp::FileHeader_Begin()
 
                 Fill(Stream_General, 0, General_Format_Profile, Profile);
             }
+            const char* Credit = Rdf_Item->Attribute("photoshop:Credit");
+            if (Credit && *Credit != '\\') //TODO: support octal and UTF-16 ("\376\377")
+                Fill(Stream_General, 0, General_Copyright, Credit);
             const char* CreatorTool=Rdf_Item->Attribute("xmp:CreatorTool");
             if (CreatorTool && *CreatorTool!='\\') //TODO: support octal and UTF-16 ("\376\377")
                 Fill(Stream_General, 0, General_Encoded_Application, CreatorTool);


### PR DESCRIPTION
Field is used in images generated by Google Gemini/Imagen. A quick way to check if image is AI generated.

```
General
Complete name                            : Imagen.jpg
Format                                   : JPEG
File size                                : 474 KiB
Credit                                   : Made with Google AI

Image
Format                                   : JPEG
Width                                    : 2 048 pixels
Height                                   : 2 048 pixels
Color space                              : YUV
Chroma subsampling                       : 4:2:0
Bit depth                                : 8 bits
Compression mode                         : Lossy
Stream size                              : 474 KiB (100%)
```
