### PR TITLE
When outputting JSON, return an array of objects…

### DIFF
--- a/Source/MediaInfo/MediaInfo_Internal.cpp
+++ b/Source/MediaInfo/MediaInfo_Internal.cpp
@@ -2714,8 +2714,7 @@ Ztring MediaInfo_Internal::Inform(std::vector<MediaInfo_Internal*>& Info)
     #if defined(MEDIAINFO_JSON_YES)
     if (MediaInfoLib::Config.Inform_Get()==__T("JSON"))
     {
-        if (Info.size() > 1)
-            Result+=__T("[")+MediaInfoLib::Config.LineSeparator_Get();
+        Result+=__T("[")+MediaInfoLib::Config.LineSeparator_Get();
         for (size_t FilePos=0; FilePos<Info.size(); FilePos++)
         {
             Result+=Info[FilePos]->Inform();
@@ -2725,8 +2724,7 @@ Ztring MediaInfo_Internal::Inform(std::vector<MediaInfo_Internal*>& Info)
 
             Result+=MediaInfoLib::Config.LineSeparator_Get();
         }
-        if (Info.size() > 1)
-            Result+=__T("]")+MediaInfoLib::Config.LineSeparator_Get();
+        Result+=__T("]")+MediaInfoLib::Config.LineSeparator_Get();
     }
     else
     #endif //defined(MEDIAINFO_JSON_YES)


### PR DESCRIPTION
…even if only one file is requested.

This allows for consistent handling of JSON output in cases of arbitrary numbers of input files.

Fixes MediaArea/MediaInfo#1103