### PR TITLE
JPEG: Parse Extended XMP

### DIFF
--- a/Source/MediaInfo/Image/File_Jpeg.h
+++ b/Source/MediaInfo/Image/File_Jpeg.h
@@ -162,6 +162,7 @@ private :
     void APP1();
     void APP1_EXIF();
     void APP1_XMP();
+    void APP1_XMP_Extension();
     void APP2();
     void APP2_ICC_PROFILE();
     void APP3() {Skip_XX(Element_Size, "Data");}
@@ -206,6 +207,12 @@ private :
     bool  SOS_SOD_Parsed;
     bool  CME_Text_Parsed;
     File__Analyze* ICC_Parser=nullptr;
+    struct xmpext
+    {
+        File__Analyze* Parser = nullptr;
+        int32u LastOffset = 0;
+    };
+    std::map<std::string, xmpext> XmpExt_List;
     struct jpegxtext
     {
         File__Analyze* Parser = nullptr;

--- a/Source/MediaInfo/Tag/File_Xmp.cpp
+++ b/Source/MediaInfo/Tag/File_Xmp.cpp
@@ -56,6 +56,11 @@ static char* strnstr(const char* Str, size_t Size, const char* ToSearch)
 //---------------------------------------------------------------------------
 bool File_Xmp::FileHeader_Begin()
 {
+    if (Wait) {
+        Element_WaitForMoreData();
+        return false;
+    }
+
     auto Buffer_Size_Save=Buffer_Size;
     if (Buffer_Size>=32)
     {
@@ -170,6 +175,14 @@ bool File_Xmp::FileHeader_Begin()
                     CreateDate=Ztring().From_UTF8(Description_Item->GetText());
                     if (CreateDate>ModifyDate)
                         Fill(Stream_General, 0, General_Encoded_Date, CreateDate, true);
+                }
+                else if (!strcmp(Description_Item->Value(), "GDepth:Data"))
+                {
+                    Fill(Stream_General, 0, "GDepth:Data", Description_Item->GetText());
+                }
+                else if (!strcmp(Description_Item->Value(), "GImage:Data"))
+                {
+                    Fill(Stream_General, 0, "GImage:Data", Description_Item->GetText());
                 }
             }
         }

--- a/Source/MediaInfo/Tag/File_Xmp.cpp
+++ b/Source/MediaInfo/Tag/File_Xmp.cpp
@@ -22,6 +22,7 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/Tag/File_Xmp.h"
+#include "ThirdParty/base64/base64.h"
 #include <cstring>
 #include "tinyxml2.h"
 using namespace tinyxml2;
@@ -108,6 +109,29 @@ bool File_Xmp::FileHeader_Begin()
         //RDF item
         if (!strcmp(Rdf_Item->Value(), (NameSpace+"Description").c_str()))
         {
+            const char* RelitInputImageData = Rdf_Item->Attribute("GCamera:RelitInputImageData");
+            if (RelitInputImageData) {
+                std::string Data_Raw(Base64::decode(RelitInputImageData));
+                auto Buffer_Save = Buffer;
+                auto Buffer_Offset_Save = Buffer_Offset;
+                auto Buffer_Size_Save = Buffer_Size;
+                auto Element_Offset_Save = Element_Offset;
+                auto Element_Size_Save = Element_Size;
+                Buffer = (const int8u*)Data_Raw.c_str();
+                Buffer_Offset = 0;
+                Buffer_Size = Data_Raw.size();
+                Element_Offset = 0;
+                Element_Size = Buffer_Size;
+
+                //Filling
+                Attachment("Extended XMP / GCamera", Ztring(), "Relit Input Image");
+
+                Buffer = Buffer_Save;
+                Buffer_Offset = Buffer_Offset_Save;
+                Buffer_Size = Buffer_Size_Save;
+                Element_Offset = Element_Offset_Save;
+                Element_Size = Element_Size_Save;
+            }
             const char* Description=Rdf_Item->Attribute("xmp:Description");
             if (!Description)
                 Description=Rdf_Item->Attribute("pdf:Description");

--- a/Source/MediaInfo/Tag/File_Xmp.h
+++ b/Source/MediaInfo/Tag/File_Xmp.h
@@ -28,6 +28,9 @@ namespace MediaInfoLib
 
 class File_Xmp : public File__Analyze
 {
+public:
+    bool Wait = false;
+
 private :
     //Buffer - File header
     bool FileHeader_Begin();


### PR DESCRIPTION
Extended XMP spans multiple APP1 sections and is used to contain original image and depth map for portrait mode on Android devices.

This PR adds initial parsing, showing the XMP data in trace but does not extract anything from it.
