### PR TITLE
MP4/MOV/HEVC: Ambient viewing environment

### DIFF
--- a/Source/MediaInfo/File__Analyze.h
+++ b/Source/MediaInfo/File__Analyze.h
@@ -915,13 +915,16 @@ public :
     void Get_MasteringDisplayColorVolume(Ztring& MasteringDisplay_ColorPrimaries, Ztring& MasteringDisplay_Luminance, bool FromAV1=false);
     void Get_LightLevel(Ztring &MaxCLL, Ztring &MaxFALL, int32u Divisor=1);
     #endif
-    #if defined(MEDIAINFO_AV1_YES) || defined(MEDIAINFO_AVC_YES) || defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MATROSKA_YES) || defined(MEDIAINFO_MXF_YES) || defined(MEDIAINFO_MPEGTS_YES)
+    #if defined(MEDIAINFO_AV1_YES) || defined(MEDIAINFO_AVC_YES) || defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MK_YES) || defined(MEDIAINFO_MXF_YES) || defined(MEDIAINFO_MPEGTS_YES)
     struct mastering_metadata_2086
     {
         int16u Primaries[8];
         int32u Luminance[2];
     };
     void Get_MasteringDisplayColorVolume(Ztring &MasteringDisplay_ColorPrimaries, Ztring &MasteringDisplay_Luminance, mastering_metadata_2086 &Meta, bool FromAV1=false);
+    #endif
+    #if defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES)
+    void Get_AmbientViewingEnvironment(float64& AmbientViewingEnvironment_Illuminance, Ztring& AmbientViewingEnvironment_Illuminance_string, Ztring& AmbientViewingEnvironment_Chromaticity);
     #endif
     #if defined(MEDIAINFO_MPEGPS_YES) || defined(MEDIAINFO_MPEGTS_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MK_YES)
     void dvcC(bool has_dependency_pid=false, std::map<std::string, Ztring>* Infos=NULL);

--- a/Source/MediaInfo/File__Analyze_MinimizeSize.h
+++ b/Source/MediaInfo/File__Analyze_MinimizeSize.h
@@ -791,6 +791,9 @@ public :
     };
     void Get_MasteringDisplayColorVolume(Ztring &MasteringDisplay_ColorPrimaries, Ztring &MasteringDisplay_Luminance, mastering_metadata_2086 &Meta, bool FromAV1=false);
     #endif
+    #if defined(MEDIAINFO_HEVC_YES) || defined(MEDIAINFO_MPEG4_YES)
+    void Get_AmbientViewingEnvironment(float64& AmbientViewingEnvironment_Illuminance, Ztring& AmbientViewingEnvironment_Illuminance_string, Ztring& AmbientViewingEnvironment_Chromaticity);
+    #endif
     #if defined(MEDIAINFO_MPEGPS_YES) || defined(MEDIAINFO_MPEGTS_YES) || defined(MEDIAINFO_MPEG4_YES) || defined(MEDIAINFO_MK_YES)
     void dvcC(bool has_dependency_pid=false, std::map<std::string, Ztring>* Infos=NULL);
     #endif

--- a/Source/MediaInfo/Multiple/File_Mpeg4.h
+++ b/Source/MediaInfo/Multiple/File_Mpeg4.h
@@ -222,6 +222,7 @@ private :
     void moov_trak_mdia_minf_stbl_stsd_xxxxVideo();
     void moov_trak_mdia_minf_stbl_stsd_xxxxOthers(const string& CodecIDAddition);
     void moov_trak_mdia_minf_stbl_stsd_xxxx_alac();
+    void moov_trak_mdia_minf_stbl_stsd_xxxx_amve();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_AALP();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_ACLR();
     void moov_trak_mdia_minf_stbl_stsd_xxxx_APRG();

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -854,8 +854,8 @@ namespace Elements
     const int64u moov_trak_mdia_minf_stbl_stsd_mebx_keys=0x6B657973;
     const int64u moov_trak_mdia_minf_stbl_stsd_mebx_keys_PHDR=0x50484452;
     const int64u moov_trak_mdia_minf_stbl_stsd_mebx_keys_PHDR_keyd=0x6B657964;
-    const int64u moov_trak_mdia_minf_stbl_stsd_mebx_keys_xxxx_keyd = 0x6B657964;
-    const int64u moov_trak_mdia_minf_stbl_stsd_mebx_keys_xxxx_dtyp = 0x64747970;
+    const int64u moov_trak_mdia_minf_stbl_stsd_mebx_keys_xxxx_keyd=0x6B657964;
+    const int64u moov_trak_mdia_minf_stbl_stsd_mebx_keys_xxxx_dtyp=0x64747970;
     const int64u moov_trak_mdia_minf_stbl_stsd_mett=0x6D657474;
     const int64u moov_trak_mdia_minf_stbl_stsd_mp4a=0x6D703461;
     const int64u moov_trak_mdia_minf_stbl_stsd_mp4s=0x6D703473;
@@ -871,6 +871,7 @@ namespace Elements
     const int64u moov_trak_mdia_minf_stbl_stsd_xxxx_alac=0x616C6163;
     const int64u moov_trak_mdia_minf_stbl_stsd_xxxx_AALP=0x41414C50;
     const int64u moov_trak_mdia_minf_stbl_stsd_xxxx_ACLR=0x41434C52;
+    const int64u moov_trak_mdia_minf_stbl_stsd_xxxx_amve=0x616D7665;
     const int64u moov_trak_mdia_minf_stbl_stsd_xxxx_APRG=0x41505247;
     const int64u moov_trak_mdia_minf_stbl_stsd_xxxx_ARES=0x41524553;
     const int64u moov_trak_mdia_minf_stbl_stsd_xxxx_AORD=0x414F5244;
@@ -1321,6 +1322,7 @@ void File_Mpeg4::Data_Parse()
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_xxxx_alac)
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_xxxx_AALP)
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_xxxx_ACLR)
+                                ATOM(moov_trak_mdia_minf_stbl_stsd_xxxx_amve)
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_xxxx_APRG)
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_xxxx_ARES)
                                 ATOM(moov_trak_mdia_minf_stbl_stsd_xxxx_AORD)
@@ -6975,6 +6977,27 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxx_alac()
         if (samplerate)
             Fill(Stream_Audio, StreamPos_Last, Audio_SamplingRate, samplerate, 10, true);
     FILLING_END();
+}
+
+//---------------------------------------------------------------------------
+void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxx_amve()
+{
+    Element_Name("Ambient Viewing Environment");
+
+    //Parsing
+    float64 ambient_viewing_environment_illuminance;
+    Ztring ambient_viewing_environment_illuminance_string, ambient_viewing_environment_chromaticity;
+    Get_AmbientViewingEnvironment(ambient_viewing_environment_illuminance, ambient_viewing_environment_illuminance_string, ambient_viewing_environment_chromaticity);
+
+    //Filling
+    if (ambient_viewing_environment_illuminance && !ambient_viewing_environment_illuminance_string.empty()) {
+        Fill(Stream_Video, 0, "AmbientViewingEnvironment_Illuminance", ambient_viewing_environment_illuminance);
+        Fill_SetOptions(Stream_Video, 0, "AmbientViewingEnvironment_Illuminance", "N NF");
+        Fill(Stream_Video, 0, "AmbientViewingEnvironment_Illuminance/String", ambient_viewing_environment_illuminance_string);
+    }
+    if (!ambient_viewing_environment_chromaticity.empty()) {
+        Fill(Stream_Video, 0, "AmbientViewingEnvironment_Chromaticity", ambient_viewing_environment_chromaticity);
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Video/File_Hevc.cpp
+++ b/Source/MediaInfo/Video/File_Hevc.cpp
@@ -364,6 +364,14 @@ void File_Hevc::Streams_Fill()
     if (chroma_sample_loc_type_bottom_field != (int32u)-1 && chroma_sample_loc_type_bottom_field != chroma_sample_loc_type_top_field)
         Fill(Stream_Video, 0, "ChromaSubsampling_Position", __T("Type ") + Ztring::ToZtring(chroma_sample_loc_type_bottom_field));
     }
+    if (ambient_viewing_environment_illuminance && !ambient_viewing_environment_illuminance_string.empty()) {
+        Fill(Stream_Video, 0, "AmbientViewingEnvironment_Illuminance", ambient_viewing_environment_illuminance);
+        Fill_SetOptions(Stream_Video, 0, "AmbientViewingEnvironment_Illuminance", "N NF");
+        Fill(Stream_Video, 0, "AmbientViewingEnvironment_Illuminance/String", ambient_viewing_environment_illuminance_string);
+    }
+    if (!ambient_viewing_environment_chromaticity.empty()) {
+        Fill(Stream_Video, 0, "AmbientViewingEnvironment_Chromaticity", ambient_viewing_environment_chromaticity);
+    }
 }
 
 //---------------------------------------------------------------------------
@@ -2562,6 +2570,7 @@ void File_Hevc::sei_message(int32u &seq_parameter_set_id)
         case 137 :   sei_message_mastering_display_colour_volume(); break;
         case 144 :   sei_message_light_level(); break;
         case 147 :   sei_alternative_transfer_characteristics(); break;
+        case 148 :   sei_ambient_viewing_environment(); break;
         case 176 :   three_dimensional_reference_displays_info(payloadSize); break;
         default :
                     Element_Info1("unknown");
@@ -3729,6 +3738,15 @@ void File_Hevc::sei_alternative_transfer_characteristics()
 
     //Parsing
     Get_B1(preferred_transfer_characteristics,                  "preferred_transfer_characteristics"); Param_Info1(Mpegv_transfer_characteristics(preferred_transfer_characteristics));
+}
+
+//---------------------------------------------------------------------------
+void File_Hevc::sei_ambient_viewing_environment()
+{
+    Element_Info1("ambient_viewing_environment");
+
+    //Parsing
+    Get_AmbientViewingEnvironment(ambient_viewing_environment_illuminance, ambient_viewing_environment_illuminance_string, ambient_viewing_environment_chromaticity);
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Video/File_Hevc.h
+++ b/Source/MediaInfo/Video/File_Hevc.h
@@ -410,6 +410,7 @@ private :
     void sei_message_mastering_display_colour_volume();
     void sei_message_light_level();
     void sei_alternative_transfer_characteristics();
+    void sei_ambient_viewing_environment();
     void three_dimensional_reference_displays_info(int32u payloadSize);
 
     //Packets - SubElements
@@ -524,6 +525,9 @@ private :
     Ztring  maximum_frame_average_light_level;
     int8u   nuh_layer_id;
     int8u   preferred_transfer_characteristics;
+    float64 ambient_viewing_environment_illuminance{};
+    Ztring  ambient_viewing_environment_illuminance_string;
+    Ztring  ambient_viewing_environment_chromaticity;
     bool    RapPicFlag;
     bool    first_slice_segment_in_pic_flag;
 };


### PR DESCRIPTION
Parse Ambient viewing environment `amve` box.

> ```
> class AmbientViewingEnvironmentBox extends Box('amve') { 
>     unsigned int(32) ambient_illuminance;
>     unsigned int(16) ambient_light_x;
>     unsigned int(16) ambient_light_y;
> }
> ```

> **ambient_illuminance** specifies the environmental illluminance of the ambient viewing environment in units of 0.0001
lux. ambient_illuminance shall not be equal to 0.

> **ambient_light_x** and **ambient_light_y** specify the normalized x and y chromaticity coordinates, respectively, of the
environmental ambient light in the nominal viewing environment, according to the CIE 1931 definition of x and y as
specified in ISO 11664-1 (see also ISO 11664-3 and CIE 15), in normalized increments of 0.00002. The values of
ambient_light_x and ambient_light_y shall be in the range of 0 to 50 000, inclusive.
NOTE – For example, the conditions identified in Rec. ITU-R BT.2035 can be expressed using ambient_illuminance equal to 100 000 with background chromaticity indicating D65 (ambient_light_x equal to 15 635, ambient_light_y equal to 16 450), or optionally in some regions, background chromaticity indicating D93 (ambient_light_x equal to 14 155, ambient_light_y equal to 14 855)

Reference:
https://developer.apple.com/documentation/technotes/tn3145-hdr-video-metadata#Dolby-Vision-Profile-84
https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-H.265-202407-I!!PDF-E&type=items

Sample:
https://img.photographyblog.com/reviews/apple_iphone_13_pro/sample_images/4K60p.mov
