### PR TITLE
MP4: Handle `iinf` version > 0

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -2513,7 +2513,10 @@ void File_Mpeg4::meta_iinf()
     NAME_VERSION_FLAG("Item Information");
 
     //Parsing
-    Skip_B2(                                                    "entry-count");
+    if (Version == 0)
+        Skip_B2(                                                "entry-count");
+    else
+        Skip_B4(                                                "entry-count");
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Parse correctly to fix false conformance errors for test files at https://github.com/AOMediaCodec/av1-avif/tree/master/testFiles/Link-U
