### PR TITLE
update DVB descriptors and service types for NGVC and NGA

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
@@ -141,6 +141,9 @@ static void Mpeg_Descriptors_video_properties_tag(std::map<std::string, Ztring>&
     Infos["colour_range"].From_UTF8(Data[3]?"Full":"Limited");
 }
 
+const char* RESERVED_FUTURE_USE = "reserved for future use";
+const char* USER_DEFINED = "user defined";
+
 //---------------------------------------------------------------------------
 const char* Mpeg_Descriptors_audio_type(int8u ID)
 {
@@ -509,6 +512,13 @@ const char* Mpeg_Descriptors_dvb_service_type(int8u service_type)
         case 0x19 : return "advanced codec HD digital television";
         case 0x1A : return "advanced codec HD NVOD time-shifted";
         case 0x1B : return "advanced codec HD NVOD reference";
+        case 0x1C : return "advanced codec frame compatible plano-stereoscopic HD";
+        case 0x1D : return "advanced codec frame compatible plano-stereoscopic HD NVOD time-shifted";
+        case 0x1E : return "advanced codec frame compatible plano-stereoscopic HD NVOD reference";
+        case 0x1F : return "HEVC digital television";
+        case 0x20 : return "HEVC UHD";
+        case 0x21 : return "VVC digital television";
+        case 0x22 : return "AVS3 digital television";
         case 0xFF : return "reserved for future use";
         default   :
             if (service_type>=0x80)
@@ -529,6 +539,9 @@ const char* Mpeg_Descriptors_stream_content(int8u stream_content)
         case 0x05 : return "AVC";
         case 0x06 : return "HE-AAC";
         case 0x07 : return "DTS";
+        case 0x08 : return "DVB SRM and CPCM";
+        case 0x09 : return "UHD Video and NGA";
+        case 0x0B : return "HDR flags";
         default   :
             if (stream_content>=0x0C)
                     return "user defined";
@@ -662,6 +675,170 @@ const char* Mpeg_Descriptors_component_type_O7(int8u)
     return "Defined by DTS";
 }
 
+const char* Mpeg_Descriptors_component_type_O8(int8u component_type)
+{
+    switch (component_type)
+    {
+        case 0x00 : return "reserved for future use";
+        case 0x01 : return "DVB System Renewability Message (SRM)";
+        default :
+            return "reserved for future use for DVB Content Protection Copy Management (CPCM)";
+    }
+}
+
+
+const char* Mpeg_Descriptors_component_type_O9_ext_00(int8u component_type)
+{
+    switch (component_type)
+    {
+        case 0x00: return "HEVC Main Profile HD (50hz)";
+        case 0x01: return "HEVC Main 10 Profile HD (50Hz)";
+        case 0x02: return "HEVC Main Profile HD (60hz)";
+        case 0x03: return "HEVC Main 10 Profile HD (60Hz)";
+        case 0x04: return "HEVC UHD (4k)";
+        case 0x05: return "HEVC UHD (4k) PQ10";
+        case 0x06: return "HEVC UHD (4k) HLG10";
+        case 0x07: return "HEVC UHD (4k) PQ10";
+        case 0x08: return "HEVC UHD (8k)";
+        case 0x10: return "VVC Main 10 UHD (4k)";
+        case 0x11: return "VVC Main 10 UHD (4k) HFR";
+        case 0x12: return "VVC Main 10 UHD (8k)";
+        case 0x13: return "VVC Main 10 UHD (8k) HFR";
+
+        case 0x20: return "AVS3 High 10 UHD (4k)";
+        case 0x21: return "AVS3 High 10 UHD (4k) HFR";
+        case 0x22: return "AVS3 High 10 UHD (8k)";
+        case 0x23: return "AVS3 High 10 UHD (8k) HFR";
+        default : 
+            if (component_type >= 0x09 && component_type <= 0x0F)
+                return "reserved for future use for HEVC";
+            else if (component_type >= 0x14 && component_type <= 0x1F)
+                return "reserved for future use for VVC";
+            else if (component_type >= 0x24 && component_type <= 0x2F)
+                return "reserved for future use for AVS3";
+            else 
+                return RESERVED_FUTURE_USE;
+    }
+
+}
+
+const char* Mpeg_Descriptors_component_type_O9_ext_01(int8u component_type)
+{
+    switch (component_type)
+    {
+        case 0x00 : return "AC-4 main audio, mono";
+        case 0x01 : return "AC-4 main audio, mono, dialogue enhancement enabled";
+        case 0x02 : return "AC-4 main audio, stereo";
+        case 0x03 : return "AC-4 main audio, stereo, dialogue enhancement enabled";
+        case 0x04 : return "AC-4 main audio, multichannel";
+        case 0x05 : return "AC-4 main audio, multichannel, dialogue enhancement enabled";
+        case 0x06 : return "AC-4 broadcast-mix audio description, mono, for the visually impaired";
+        case 0x07 : return "AC-4 broadcast-mix audio description, mono, for the visually impaired, dialogue enhancement enabled";
+        case 0x08 : return "AC-4 broadcast-mix audio description, stereo, for the visually impaired";
+        case 0x09 : return "AC-4 broadcast-mix audio description, stereo, for the visually impaired, dialogue enhancement enabled";
+        case 0x0A : return "AC-4 broadcast-mix audio description, multichannel, for the visually impaired";
+        case 0x0B : return "AC-4 broadcast-mix audio description, multichannel, for the visually impaired, dialogue enhancement enabled";
+        case 0x0C : return "AC-4 receiver-mix audio description, mono, for the visually impaired";
+        case 0x0D : return "AC-4 receiver-mix audio description, stereo, for the visually impaired";
+        case 0x0E : return "AC-4 Part-2";
+        case 0x0F : return "MPEG-H Audio Low Complexity (LC) Profile";
+        case 0x10 : return "DTS-UHD main audio, mono";
+        case 0x11 : return "DTS-UHD main audio, mono, dialogue enhancement enabled";
+        case 0x12 : return "DTS-UHD main audio, stereo";
+        case 0x13 : return "DTS-UHD main audio, stereo, dialogue enhancement enabled";
+        case 0x14 : return "DTS-UHD main audio, multichannel";
+        case 0x15 : return "DTS-UHD main audio, multichannel, dialogue enhancement enabled";
+        case 0x16 : return "DTS-UHD broadcast-mix audio description, mono, for the visually impaired";
+        case 0x17 : return "DTS-UHD broadcast-mix audio description, mono, for the visually impaired, dialogue enhancement enabled";
+        case 0x18 : return "DTS-UHD broadcast-mix audio description, stereo, for the visually impaired";
+        case 0x19 : return "DTS-UHD broadcast-mix audio description, stereo, for the visually impaired, dialogue enhancement enabled";
+        case 0x1A : return "DTS-UHD broadcast-mix audio description, multichannel, for the visually impaired";
+        case 0x1B : return "DTS-UHD broadcast-mix audio description, multichannel, for the visually impaired, dialogue enhancement enabled";
+        case 0x1C : return "DTS-UHD receiver-mix audio description, mono, for the visually impaired";
+        case 0x1D : return "DTS-UHD receiver-mix audio description, stereo, for the visually impaired";
+        case 0x1E : return "DTS-UHD Next Generation Audio (NGA) Audio";
+        case 0x20 : return "AVS3-P3 Next Generation Audio (NGA)";
+        case 0x21 : return "AVS3-P3 broadcast-mix accessibility components";
+        case 0x22 : return "AVS3-P3 receiver-mix accessibility components";
+        default:
+            return RESERVED_FUTURE_USE;
+    }
+}
+
+const char* Mpeg_Descriptors_component_type_O9(int8u stream_content_ext, int8u component_type)
+{
+    switch (stream_content_ext)
+    {
+        case 0x00 : return Mpeg_Descriptors_component_type_O9_ext_00(component_type);
+        case 0x01 : return Mpeg_Descriptors_component_type_O9_ext_01(component_type);
+        case 0x02 : return "Timed Text Markup Language (TTML) subtitles";
+        default :
+            return RESERVED_FUTURE_USE;
+    }
+}
+
+const char* Mpeg_Descriptors_component_type_OB_ext_0E(int8u component_type)
+{
+    vector<string> evals;
+    if (component_type & 0b01000000)
+        evals.push_back("pre-rendered for headphones");
+    if (component_type & 0b00100000)
+        evals.push_back("enables interactivity");
+    if (component_type & 0b00010000)
+        evals.push_back("enables dialogue enhancement");
+    if (component_type & 0b00001000)
+        evals.push_back("contains spoken subtitles");
+    if (component_type & 0b00000100)
+        evals.push_back("contains audio description");
+
+    switch (component_type & 0b00000011) {
+        case 0b00000001 : evals.push_back("stereo"); break;
+        case 0b00000010 : evals.push_back("2D"); break;
+        case 0b00000011 : evals.push_back("3B"); break;
+    }
+
+    string ret = "";
+    for (unsigned int i = 0; i < evals.size(); i++) {
+        ret += evals[i];
+        if (i >= (evals.size() - 1)) {
+            break; // escaping in the last iteration
+        }
+        ret += ", "; // concatenating string
+    }
+    return ret.c_str();
+}
+
+const char* Mpeg_Descriptors_component_type_OB_ext_0F(int8u component_type)
+{
+    switch (component_type)
+    {
+        case 0x00 : return "less than 16:9 aspect ratio";
+        case 0x01 : return "16:9 aspect ratio";
+        case 0x02 : return "greater than 16:9 aspect ratio";
+        case 0x03 : return "plano-stereoscopic top and bottom (TaB) frame-packing";
+        case 0x04 : return "HLG10 HDR";
+        case 0x05 : return "HEVC HFR temporal video subset";
+        case 0x06 : return "SMPTE ST 2094-10 DMI (Dolvy Vision)";
+        case 0x07 : return "SL-HDR2 DMI";
+        case 0x08 : return "SMPTE ST 2094-40 DMI (HDR10+)";
+        case 0x09 : return "PQ10 HDR";
+        case 0x0A : return "T/UWA 005 DMI (HDR Vivid)";
+        default:
+            return RESERVED_FUTURE_USE;
+    }
+}
+
+const char* Mpeg_Descriptors_component_type_OB(int8u stream_content_ext, int8u component_type)
+{
+    switch(stream_content_ext)
+    {
+        case 0x0E : return Mpeg_Descriptors_component_type_OB_ext_0E(component_type);
+        case 0x0F : return Mpeg_Descriptors_component_type_OB_ext_0F(component_type);
+        default:
+            return RESERVED_FUTURE_USE;
+    }
+}
+
 const char* Mpeg_Descriptors_codepage_1(int8u codepage)
 {
     switch (codepage)
@@ -686,7 +863,7 @@ const char* Mpeg_Descriptors_codepage_1(int8u codepage)
     }
 }
 
-const char* Mpeg_Descriptors_component_type(int8u stream_content, int8u component_type)
+const char* Mpeg_Descriptors_component_type(int8u stream_content, int8u stream_content_ext, int8u component_type)
 {
     switch (stream_content)
     {
@@ -697,6 +874,10 @@ const char* Mpeg_Descriptors_component_type(int8u stream_content, int8u componen
         case 0x05 : return Mpeg_Descriptors_component_type_O5(component_type);
         case 0x06 : return Mpeg_Descriptors_component_type_O6(component_type);
         case 0x07 : return Mpeg_Descriptors_component_type_O7(component_type);
+        case 0x08 : return Mpeg_Descriptors_component_type_O8(component_type);
+        case 0x09 : return Mpeg_Descriptors_component_type_O9(stream_content_ext, component_type);
+        case 0x0B : return Mpeg_Descriptors_component_type_OB(stream_content_ext, component_type);
+
         default   :
             if (component_type>=0xB0 && component_type<=0xFE)
                     return "user defined";
@@ -1770,8 +1951,8 @@ void File_Mpeg_Descriptors::Data_Parse()
             ELEMENT_CASE(7A, "DVB - enhanced_AC-3_descriptor");
             ELEMENT_CASE(7B, "DVB - DTS descriptor");
             ELEMENT_CASE(7C, "DVB - AAC descriptor");
-            ELEMENT_CASE(7D, "DVB - reserved for future use");
-            ELEMENT_CASE(7E, "DVB - reserved for future use");
+            ELEMENT_CASE(7D, "DVB - XAIT_location_descriptor");
+            ELEMENT_CASE(7E, "DVB - FTA_content_management_descriptor");
             ELEMENT_CASE(7F, "DVB - extension descriptor");
             default: if (Element_Code>=0x40)
                         Element_Info1("user private");
@@ -2766,12 +2947,12 @@ void File_Mpeg_Descriptors::Descriptor_50()
 {
     //Parsing
     int32u ISO_639_language_code;
-    int8u stream_content;
+    int8u stream_content_ext, stream_content;
     BS_Begin();
-    Skip_S1(4,                                                  "reserved_future_use");
+    Get_S1 (4, stream_content_ext,                              "stream_content");
     Get_S1 (4, stream_content,                                  "stream_content"); Param_Info1(Mpeg_Descriptors_stream_content(stream_content)); Element_Info1(Mpeg_Descriptors_stream_content(stream_content));
     BS_End();
-    Info_B1(component_type,                                     "component_type"); Param_Info1(Mpeg_Descriptors_component_type(stream_content, component_type)); Element_Info1(Mpeg_Descriptors_component_type(stream_content, component_type));
+    Info_B1(component_type,                                     "component_type"); Param_Info1(Mpeg_Descriptors_component_type(stream_content, stream_content_ext, component_type)); Element_Info1(Mpeg_Descriptors_component_type(stream_content, stream_content_ext, component_type));
     Info_B1(component_tag,                                      "component_tag");
     Get_C3 (ISO_639_language_code,                              "ISO_639_language_code");
     Skip_DVB_Text(Element_Size-Element_Offset, ISO_639_language_code, "text");


### PR DESCRIPTION
- see [DVBA038r18](https://dvb.org/wp-content/uploads/2024/09/A038r18_Specification-for-Service-Information-SI-in-DVB-Systems_Interim-draft_EN_300-468-v1-20-1_February-2025.pdf)
DVB has added new values to the `component_descriptor` and `service_type` to reflect Next Generation Audio (NGA - AC-4, MPEG-H, DTS-UHD, AVS3) and Next Generation Video (HEVC 8K, VVC, AVS3)