### PR TITLE
Fix crashes with glibc's avx2 implementation of wcsncpy

### DIFF
--- a/Source/MediaInfo/Text/File_OtherText.cpp
+++ b/Source/MediaInfo/Text/File_OtherText.cpp
@@ -55,7 +55,7 @@ void File_OtherText::Read_Buffer_Continue()
         #endif //WINDOWS
     if (File.size()<0x100)
     {
-        File.From_Unicode((wchar_t*)Buffer, 0, (Buffer_Size/sizeof(wchar_t))>16384?16384:(Buffer_Size/sizeof(wchar_t))); //Unicode with BOM
+        File.From_UTF16((const char*)Buffer, 0, Buffer_Size>16384?16384:Buffer_Size); //Unicode with BOM
         //TODO: Order of bytes (big or Little endian)
         if (File.size()<0x100)
         {


### PR DESCRIPTION
This is a workaround.