### PR TITLE
Fix parssing of `video_properties_tag` in MPEG `VVC_video_descriptor`

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
@@ -2392,8 +2392,8 @@ void File_Mpeg_Descriptors::Descriptor_39()
     Skip_SB(                                                    "VVC_24hr_picture_present_flag");
     Skip_S1(5,                                                  "reserved");
     Get_S1 (2, HDR_WCG_idc,                                     "HDR_WCG_idc");
-    Skip_S1(4,                                                  "reserved");
-    Get_S1 (2, video_properties_tag,                            "video_properties_tag");
+    Skip_S1(2,                                                  "reserved");
+    Get_S1 (4, video_properties_tag,                            "video_properties_tag");
     if (temporal_layer_subset_flag)
     {
         Skip_S1(5,                                              "reserved");


### PR DESCRIPTION
The number of bits read for `video_properties_tag` was incorrect.

Updated to align with ISO/IEC 13818-1 and H.266
<img width="1352" height="1224" alt="image" src="https://github.com/user-attachments/assets/e6dd9d1c-1c5b-4f1a-afa3-a8ae6b3a7e7b" />
