### PR TITLE
PAC: skip '\0' prefix in content

### DIFF
--- a/Source/MediaInfo/Text/File_Pac.cpp
+++ b/Source/MediaInfo/Text/File_Pac.cpp
@@ -349,6 +349,14 @@ void File_Pac::Data_Parse()
         switch (Format) {
         case Format_8bit: {
             Ztring Value;
+            if (Size) {
+                int8u Probe;
+                Peek_B1(Probe);
+                if (!Probe) {
+                    Skip_B1(                                    "Null?");
+                    Size--;
+                }
+            }
             Get_ISO_8859_1(Size, Value,                         "Content");
             bool Is8bit = false;
             for (const auto& Character : Value) {


### PR DESCRIPTION
Fix https://github.com/MediaArea/MediaInfoLib/issues/2452.