### PR TITLE
RIFF: add support for WAVE_FORMAT_MPEG_HEAAC (0x1610)

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac.h
+++ b/Source/MediaInfo/Audio/File_Aac.h
@@ -97,6 +97,7 @@ public :
         Mode_ADIF,
         Mode_ADTS,
         Mode_LATM,
+        Mode_HEAACWAVEFORMAT,
     };
     mode   Mode;
     bool   FromIamf;
@@ -128,6 +129,7 @@ protected :
     void Read_Buffer_Init();
     void Read_Buffer_Continue ();
     void Read_Buffer_Continue_AudioSpecificConfig();
+    void Read_Buffer_Continue_HEAACWAVEFORMAT();
     void Read_Buffer_Continue_payload();
     void Read_Buffer_Unsynched();
 

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -2982,6 +2982,7 @@ void MediaInfo_Config_CodecID_Audio_Riff (InfoMap &Info)
     "1400;Norris;;Norris Communications, Inc.\n"
     "1401;ISIAudio\n"
     "1500;MUSICOMPRESS;;Soundspace Music Compression\n"
+    "1610;AAC;Microsoft;MPEG-2 AAC or MPEG-4 HE-AAC v1/v2\n"
     "181C;RT24;VoxWare\n"
     "181E;AX24000P;Lucent elemedia\n"
     "1971;SonicFoundry;;Lossless\n"

--- a/Source/MediaInfo/Multiple/File_Riff.h
+++ b/Source/MediaInfo/Multiple/File_Riff.h
@@ -237,7 +237,7 @@ private :
     void AVI__hdlr_strl_strf ();
     void AVI__hdlr_strl_strf_auds ();
     void AVI__hdlr_strl_strf_auds_Mpega();
-    void AVI__hdlr_strl_strf_auds_Aac();
+    void AVI__hdlr_strl_strf_auds_Aac(bool IsHEAACWAVEFORMAT=false);
     void AVI__hdlr_strl_strf_auds_Vorbis();
     void AVI__hdlr_strl_strf_auds_Vorbis2();
     void AVI__hdlr_strl_strf_auds_ExtensibleWave(int16u BitsPerSample);

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -1444,6 +1444,8 @@ void File_Riff::AVI__hdlr_strl_strf_auds()
         }
         else if (Codec==__T("AAC") || Codec==__T("FF") || Codec==__T("8180"))
             AVI__hdlr_strl_strf_auds_Aac();
+        else if (FormatTag==0x1610) // HEAACWAVEFORMAT
+            AVI__hdlr_strl_strf_auds_Aac(true);
         else if (FormatTag==0x566F) //Vorbis with Config in this chunk
             AVI__hdlr_strl_strf_auds_Vorbis();
         else if (FormatTag==0x6750) //Vorbis with Config in this chunk
@@ -1484,18 +1486,16 @@ void File_Riff::AVI__hdlr_strl_strf_auds_Mpega()
 }
 
 //---------------------------------------------------------------------------
-void File_Riff::AVI__hdlr_strl_strf_auds_Aac()
+void File_Riff::AVI__hdlr_strl_strf_auds_Aac(bool IsHEAACWAVEFORMAT)
 {
     //Parsing
     Element_Begin1("AAC options");
     #if defined(MEDIAINFO_AAC_YES)
         File_Aac* MI=new File_Aac();
-        MI->Mode=File_Aac::Mode_AudioSpecificConfig;
+        MI->Mode=IsHEAACWAVEFORMAT?File_Aac::Mode_HEAACWAVEFORMAT:File_Aac::Mode_AudioSpecificConfig;
         Open_Buffer_Init(MI);
         Open_Buffer_Continue(MI);
-        Finish(MI);
-        Merge(*MI, StreamKind_Last, 0, StreamPos_Last);
-        delete MI; //MI=NULL;
+        Stream[Stream_ID].Parsers.push_back(MI);
     #else //MEDIAINFO_MPEG4_YES
         Skip_XX(Element_Size-Element_Offset,                    "(AudioSpecificConfig)");
     #endif

--- a/Source/MediaInfo/Multiple/File_Wm.cpp
+++ b/Source/MediaInfo/Multiple/File_Wm.cpp
@@ -236,6 +236,10 @@ void File_Wm::Header_Parse()
         Get_GUID(Name,                                              "Name");
         Get_L8 (Size,                                               "Size");
 
+        //Handling buggy streams
+        if (Size<0x100 && Name.hi==0x3626B2758E66CF11 && Name.lo==0xA6d900AA0062CE6C) // Data
+            Size=File_Size-File_Offset;
+
         //Filling
         Header_Fill_Code(Name.hi, Ztring().From_GUID(Name));
         Header_Fill_Size(Size);

--- a/Source/MediaInfo/Multiple/File_Wm.h
+++ b/Source/MediaInfo/Multiple/File_Wm.h
@@ -41,6 +41,7 @@ private :
     void Header_StreamProperties();
     void Header_StreamProperties_Audio();
     void Header_StreamProperties_Audio_WMA();
+    void Header_StreamProperties_Audio_HEAac();
     void Header_StreamProperties_Audio_AMR();
     void Header_StreamProperties_Video();
     void Header_StreamProperties_JFIF();

--- a/Source/MediaInfo/Multiple/File_Wm_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Wm_Elements.cpp
@@ -40,6 +40,9 @@
 #if defined(MEDIAINFO_MPEGA_YES)
     #include "MediaInfo/Audio/File_Mpega.h"
 #endif
+#if defined(MEDIAINFO_AAC_YES)
+    #include "MediaInfo/Audio/File_Aac.h"
+#endif
 #include "MediaInfo/MediaInfo_Config_MediaInfo.h"
 #if MEDIAINFO_DEMUX
     #include "ThirdParty/base64/base64.h"
@@ -391,6 +394,7 @@ void File_Wm::Header_StreamProperties_Audio ()
             case 0x0161 :
             case 0x0162 :
             case 0x0163 : Header_StreamProperties_Audio_WMA(); break;
+            case 0x1610 : Header_StreamProperties_Audio_HEAac(); break;
             case 0x7A21 :
             case 0x7A22 : Header_StreamProperties_Audio_AMR(); break;
             default     : Skip_XX(Data_Size,                    "Unknown");
@@ -428,6 +432,21 @@ void File_Wm::Header_StreamProperties_Audio_WMA ()
     Skip_L4(                                                    "SamplesPerBlock");
     Skip_L2(                                                    "EncodeOptions");
     Skip_L4(                                                    "SuperBlockAlign");
+}
+
+//---------------------------------------------------------------------------
+void File_Wm::Header_StreamProperties_Audio_HEAac()
+{
+    //Parsing
+    #if defined(MEDIAINFO_AAC_YES)
+        File_Aac* MI=new File_Aac();
+        MI->Mode=File_Aac::Mode_HEAACWAVEFORMAT;
+        Open_Buffer_Init(MI);
+        Open_Buffer_Continue(MI);
+        Stream[Stream_Number].Parser=MI;
+    #else //MEDIAINFO_AAC_YES
+        Skip_XX(Element_Size-Element_Offset,                    "HEAACWAVEFORMAT");
+    #endif
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Resource/Text/DataBase/CodecID_Audio_Riff.csv
+++ b/Source/Resource/Text/DataBase/CodecID_Audio_Riff.csv
@@ -189,6 +189,7 @@ AAC;AAC;;;;
 1400;Norris;;Norris Communications, Inc.;;
 1401;ISIAudio;;;;
 1500;MUSICOMPRESS;;Soundspace Music Compression;;
+1610;AAC;Microsoft;MPEG-2 AAC or MPEG-4 HE-AAC v1/v2;;
 181C;RT24;VoxWare;;;
 181E;AX24000P;Lucent elemedia;;;
 1971;SonicFoundry;;Lossless


### PR DESCRIPTION
Including the format block HEAACWAVEFORMAT, which is an extension of WAVEFORMATEX, as used in some ASF files like https://code.ffmpeg.org/attachments/9583d24b-9227-40a8-a3cf-ca2201693426

Before:

```
General
Complete name                            : 2025-11-08--16-02-13.asf
Format                                   : Windows Media
File size                                : 1.88 MiB
Overall bit rate mode                    : Constant
Maximum Overall bit rate                 : 15.1 Mb/s
Frame rate                               : 20.000 FPS
Encoded date                             : 2025-11-08 21:02:14 UTC
MediaFoundationVersion                   : 2.112

Video
ID                                       : 2
Format                                   : AV1
Format/Info                              : AOMedia Video 1
Codec ID                                 : AV01
Bit rate mode                            : Constant
Bit rate                                 : 15.0 Mb/s
Width                                    : 6 400 pixels
Height                                   : 2 160 pixels
Display aspect ratio                     : 2.963
Frame rate                               : 20.000 FPS
Bits/(Pixel*Frame)                       : 0.054
Language                                 : English (United States)

Audio
ID                                       : 1
Format                                   : 1610
Codec ID                                 : 1610
Bit rate mode                            : Constant
Bit rate                                 : 96.0 kb/s
Channel(s)                               : 2 channels
Sampling rate                            : 48.0 kHz
Bit depth                                : 16 bits
Language                                 : English (United States)
```

After:

```
General
Complete name                            : 2025-11-08--16-02-13.asf
Format                                   : Windows Media
File size                                : 1.88 MiB
Overall bit rate mode                    : Constant
Maximum Overall bit rate                 : 15.1 Mb/s
Frame rate                               : 20.000 FPS
Encoded date                             : 2025-11-08 21:02:14 UTC
MediaFoundationVersion                   : 2.112

Video
ID                                       : 2
Format                                   : AV1
Format/Info                              : AOMedia Video 1
Codec ID                                 : AV01
Bit rate mode                            : Constant
Bit rate                                 : 15.0 Mb/s
Width                                    : 6 400 pixels
Height                                   : 2 160 pixels
Display aspect ratio                     : 2.963
Frame rate                               : 20.000 FPS
Bits/(Pixel*Frame)                       : 0.054
Language                                 : English (United States)

Audio
ID                                       : 1
Format                                   : AAC LC
Format/Info                              : Advanced Audio Codec Low Complexity
Codec ID                                 : 1610-2
Codec ID/Info                            : MPEG-2 AAC or MPEG-4 HE-AAC v1/v2
Codec ID/Hint                            : Microsoft
Bit rate mode                            : Constant
Bit rate                                 : 96.0 kb/s
Channel(s)                               : 2 channels
Channel layout                           : L R
Sampling rate                            : 48.0 kHz
Frame rate                               : 46.875 FPS (1024 SPF)
Bit depth                                : 16 bits
Compression mode                         : Lossy
Language                                 : English (United States)
```