### PR TITLE
Matroska: Add timecode label readout

### DIFF
--- a/Source/MediaInfo/MediaInfo_Inform.cpp
+++ b/Source/MediaInfo/MediaInfo_Inform.cpp
@@ -189,12 +189,43 @@ Ztring MediaInfo_Internal::Inform()
                 Result+=TimeCode_Dump.second.Attributes_First;
                 if (TimeCode_Dump.second.Attributes_First.find(" frame_rate=\"")==string::npos && Count_Get(Stream_Video)==1)
                 {
+                    auto FrameRate_Num=Get(Stream_Video, 0, Video_FrameRate_Num);
+                    auto FrameRate_Den=Get(Stream_Video, 0, Video_FrameRate_Den);
                     auto FrameRate=Get(Stream_Video, 0, Video_FrameRate);
+                    if (!FrameRate_Num.empty() && !FrameRate_Den.empty())
+                        FrameRate=FrameRate_Num+__T('/')+FrameRate_Den;
                     if (!FrameRate.empty())
                     {
                         Result += " frame_rate=\"";
                         Result += XML_Encode(FrameRate).To_UTF8();
                         Result += '"';
+                    }
+                }
+                if (TimeCode_Dump.second.Attributes_First.find(" source=\"")==string::npos)
+                {
+                    auto ID_Pos=TimeCode_Dump.second.Attributes_First.find(" id=\"");
+                    if (ID_Pos!=string::npos)
+                    {
+                        ID_Pos+=5;
+                        auto ID_Pos2=TimeCode_Dump.second.Attributes_First.find("\"", ID_Pos);
+                        if (ID_Pos2!=string::npos)
+                        {
+                            Ztring ID;
+                            ID.From_UTF8(TimeCode_Dump.second.Attributes_First.substr(ID_Pos, ID_Pos2-ID_Pos));
+                            auto Count = Count_Get(Stream_Other);
+                            for (size_t i = 0; i < Count; i++)
+                            {
+                                if (Get(Stream_Other, i, Other_ID) != ID)
+                                    continue;
+                                auto Source = Get(Stream_Other, i, Other_TimeCode_Source);
+                                if (!Source.empty())
+                                {
+                                    Result += " source=\"";
+                                    Result += Source.To_UTF8();
+                                    Result += '"';
+                                }
+                            }
+                        }
                     }
                 }
                 Result+=" frame_count=\""+std::to_string(TimeCode_Dump.second.FrameCount)+'\"';

--- a/Source/MediaInfo/Multiple/File_Gxf_TimeCode.cpp
+++ b/Source/MediaInfo/Multiple/File_Gxf_TimeCode.cpp
@@ -108,6 +108,7 @@ File_Gxf_TimeCode::~File_Gxf_TimeCode()
 void File_Gxf_TimeCode::Streams_Fill()
 {
     Stream_Prepare(Stream_Other);
+    Fill(Stream_Other, 0, Other_Format, Format);
     Fill(Stream_Other, 0, Other_TimeCode_FirstFrame, TimeCode_FirstFrame);
     if (IsTimeCodeTrack)
         return;
@@ -380,7 +381,7 @@ void File_Gxf_TimeCode::Read_Buffer_Continue()
                         auto& TimeCode_Dump = (*Config->TimeCode_Dumps)[id];
                         if (TimeCode_Dump.List.empty())
                         {
-                            TimeCode_Dump.Attributes_First += " id=\"" + id + "\" format=\"matroska_blockadditional\"";
+                            TimeCode_Dump.Attributes_First += " id=\"" + id + "\" format=\"SMPTE ST12-1\"";
                             TimeCode_Dump.FramesMax = 99;
                         }
                         auto Frames = Frames_Tens * 10 + Frames_Units;

--- a/Source/MediaInfo/Multiple/File_Gxf_TimeCode.h
+++ b/Source/MediaInfo/Multiple/File_Gxf_TimeCode.h
@@ -41,6 +41,7 @@ public :
     bool   IsAtc; // SMPTE ST 12-2
     bool   IsBigEndian;
     bool   IsTimeCodeTrack;
+    string Format;
     #if MEDIAINFO_ADVANCED
     string id;
     #endif //MEDIAINFO_ADVANCED


### PR DESCRIPTION
Fix https://github.com/MediaArea/timecodexml/issues/15 and more.

```
Other #1
ID                                       : 1-Add-101
Format                                   : SMPTE ST 12-1
Muxing mode                              : BlockAddition
Time code of first frame                 : 00:00:42;26
Time code source                         : VITC

Other #2
ID                                       : 1-Add-102
Format                                   : SMPTE ST 12-1
Muxing mode                              : BlockAddition
Time code of first frame                 : 00:00:42;26
Time code source                         : VITC2
```

```
  <timecode_stream id="1-Add-101" format="SMPTE ST12-1" frame_rate="30000/1001" source="VITC" frame_count="4">
    <tc v="00:00:42;26"/>
    <tc v="00:00:42;27"/>
    <tc v="00:00:42;28"/>
    <tc v="00:00:42;29"/>
  </timecode_stream>
  <timecode_stream id="1-Add-102" format="SMPTE ST12-1" frame_rate="30000/1001" source="VITC2" frame_count="4">
    <tc v="00:00:42;26"/>
    <tc v="00:00:42;27"/>
    <tc v="00:00:42;28"/>
    <tc v="00:00:42;29"/>
  </timecode_stream>
```
