### PR TITLE
Fix MediaInfoList state when file close while parsing

### DIFF
--- a/Source/MediaInfo/MediaInfoList_Internal.cpp
+++ b/Source/MediaInfo/MediaInfoList_Internal.cpp
@@ -367,6 +367,7 @@ void MediaInfoList_Internal::Close(size_t FilePos)
         Info.erase(Info.begin()+FilePos);
     }
 
+    ToParse = {};
     ToParse_AlreadyDone=0;
     ToParse_Total=0;
 }


### PR DESCRIPTION
Ensure parsing state is completely reset by clearing the ToParse queue when close is called.

Fixes #2497 