### PR TITLE
XML: --Output=XmlWithAttr for more parseable conformance report

### DIFF
--- a/Source/MediaInfo/File__Analyze.h
+++ b/Source/MediaInfo/File__Analyze.h
@@ -1555,6 +1555,7 @@ public :
         void                Merge_Conformance(bool FromConfig = false);
         void                Streams_Finish_Conformance();
         virtual string      CreateElementName();
+        string              BuildConformanceName(const string& ParserName, const char* Prefix, const char* Suffix);
         void                IsTruncated(int64u ExpectedSize = (int64u)-1, bool MoreThan = false, const char* Prefix = nullptr);
         void                RanOutOfData(const char* Prefix = nullptr);
         void                SynchLost(const char* Prefix = nullptr);

--- a/Source/MediaInfo/File__Analyze_MinimizeSize.h
+++ b/Source/MediaInfo/File__Analyze_MinimizeSize.h
@@ -1456,6 +1456,7 @@ public :
         void                Merge_Conformance(bool FromConfig = false);
         void                Streams_Finish_Conformance();
         virtual string      CreateElementName();
+        string              BuildConformanceName(const string& ParserName, const char* Prefix, const char* Suffix);
         void                IsTruncated(int64u ExpectedSize = (int64u)-1, bool MoreThan = false, const char* Prefix = nullptr);
         void                RanOutOfData(const char* Prefix = nullptr);
         void                SynchLost(const char* Prefix = nullptr);

--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -3038,6 +3038,12 @@ void File__Analyze::Streams_Finish_StreamOnly_General(size_t StreamPos)
         }
     }
 
+    const auto& FileExtension_Invalid = Retrieve(Stream_General, StreamPos, "FileExtension_Invalid");
+    if (!FileExtension_Invalid.empty()) {
+        Fill(Stream_General, StreamPos, "ConformanceWarnings", "Yes", Unlimited, true, true);
+        Fill(Stream_General, StreamPos, "ConformanceWarnings GeneralCompliance", "File name extension is not expected for this file format (actual " + Retrieve(Stream_General, StreamPos, General_FileExtension).To_UTF8() + ", expected " + FileExtension_Invalid.To_UTF8() + ")", true, true);
+    }
+
     //Audio_Channels_Total
     if (Retrieve_Const(Stream_General, StreamPos, General_Audio_Channels_Total).empty())
     {


### PR DESCRIPTION
This permits an easier integration in some workflows, including MediaConch (to be implemented).

Before:
```
<GeneralCompliance>File size 8585 is less than expected size at least 8589 (offset 0x20BD)</GeneralCompliance>
```

After
```
<GeneralCompliance>File size is less than expected size (actual 8585, expected &gt;=8589, offset 0x20BD)</GeneralCompliance>
```

With ` --Output=XMLWitAttr` :
```
<GeneralCompliance actual="8585" expected="&gt;=8589" offset="0x20BD">File size is less than expected size<GeneralCompliance>
```

Also add percentage of the actual file size compared to the expected file size of a better estimation of what was lost:

```
<GeneralCompliance actual="7820" actual_percent="99.99%" expected="7821" offset="0x1AEE">File size is less than expected size</GeneralCompliance>
```

File extension mismatch is now also a conformance warning instead of a basic MediaInfo field:

```
<GeneralCompliance actual="mp3" expected="act at9 wav">File name extension is not expected for this file format</GeneralCompliance>
```