### PR TITLE
AV2: update

### DIFF
--- a/Source/MediaInfo/File__MultipleParsing.cpp
+++ b/Source/MediaInfo/File__MultipleParsing.cpp
@@ -603,7 +603,7 @@ File__MultipleParsing::File__MultipleParsing()
         Parser.push_back(new File_Av1());
     #endif
     #if defined(MEDIAINFO_AV2_YES)
-        Parser.push_back(new File_Av2());
+        {auto Temp=new File_Av2(); Temp->IsAnnexB=true; Parser.push_back(Temp);}
     #endif
     #if defined(MEDIAINFO_AVS3V_YES)
         Parser.push_back(new File_Avs3V());

--- a/Source/MediaInfo/MediaInfo_File.cpp
+++ b/Source/MediaInfo/MediaInfo_File.cpp
@@ -605,7 +605,7 @@ static File__Analyze* SelectFromExtension(const String& Parser)
         if (Parser==__T("Av1"))         return new File_Av1();
     #endif
     #if defined(MEDIAINFO_AV2_YES)
-        if (Parser==__T("Av2"))         return new File_Av2();
+        if (Parser==__T("Av2"))         {auto Parser=new File_Av2(); Parser->IsAnnexB=true; return Parser;}
     #endif
     #if defined(MEDIAINFO_AVC_YES)
         if (Parser==__T("Avc"))         return new File_Avc();
@@ -1037,7 +1037,7 @@ int MediaInfo_Internal::ListFormats(const String &File_Name)
         SAFE_DELETE(Info); Info=new File_Av1();                if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1;
     #endif
     #if defined(MEDIAINFO_AV2_YES)
-        SAFE_DELETE(Info); Info=new File_Av2();                if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1;
+        SAFE_DELETE(Info); Info=new File_Av2(); ((File_Av2*)Info)->IsAnnexB=true; if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1;
     #endif
     #if defined(MEDIAINFO_AVC_YES)
         SAFE_DELETE(Info); Info=new File_Avc();                if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1;

--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -4914,6 +4914,7 @@ void File_Mk::CodecID_Manage()
     {
         File_Av2* Parser=new File_Av2;
         Parser->FrameIsAlwaysComplete=true;
+        Parser->IsAnnexB=true;
         streamItem.Parser=Parser;
     }
     #endif

--- a/Source/MediaInfo/Video/File_Av2.h
+++ b/Source/MediaInfo/Video/File_Av2.h
@@ -27,7 +27,7 @@ class File_Av2 : public File__Analyze
 public :
     //In
     int64u  Frame_Count_Valid{};
-    bool    IsAnnexB{ true };
+    bool    IsAnnexB{};
 
     //Constructor/Destructor
     File_Av2();
@@ -41,6 +41,7 @@ private :
 
     //Buffer - Global
     void Read_Buffer_OutOfBand() override;
+    void Read_Buffer_Init() override;
 
     //Buffer - Per element
     void Header_Parse() override;


### PR DESCRIPTION
Update after https://github.com/MediaArea/MediaInfoLib/pull/2508 cc @cjee21 .
Annex B is surprising when in a container, I guess it will change in the future, we'll see.
Too many false positive when only one frame header is parsed before flagging the stream as accepted.