### PR TITLE
MXF: fixed infinite loop in malformed files

### DIFF
--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -2923,6 +2923,12 @@ bool File__Analyze::Data_Manage()
             GoTo(File_Offset+Buffer_Offset+Element_Offset);
         else
             Buffer_Offset+=(size_t)Element_Offset;
+        if (Element_Size == 0 && Element_Offset == 0)
+        {
+            Clear();
+            Status[IsFinished] = true;
+            return false;
+        }
     }
     Header_Size=0;
     Element_Size=0;


### PR DESCRIPTION
While processing malformed MXF files, we observed that MediaInfo enters an infinite loop, repeatedly re-reading the same byte range and never returning from the query operation. This results in the calling application blocking indefinitely.

The issue was reproduced using the current 25.10 master branch. After investigation, we identified the root cause and implemented a fix in our fork. 

In addition to resolving the infinite loop condition, we modified the query logic to return false when a malformed MXF structure is detected, allowing the caller to handle the error gracefully instead of hanging.