### PR TITLE
fix stream size MediaArea/MediaInfo#505

### DIFF
--- a/Source/MediaInfo/Audio/File_Ac3.cpp
+++ b/Source/MediaInfo/Audio/File_Ac3.cpp
@@ -1086,6 +1086,7 @@ File_Ac3::File_Ac3()
     TimeStamp_IsParsing=false;
     TimeStamp_Parsed=false;
     TimeStamp_Count=0;
+    Stream_Size_Total=0;
     BigEndian=true;
     IgnoreCrc_Done=false;
 }
@@ -1772,6 +1773,8 @@ void File_Ac3::Streams_Finish()
             }
         }
     }
+    if (IsSub && Stream_Size_Total && Core_IsPresent)
+        Fill(Stream_Audio, 0, Audio_StreamSize, Stream_Size_Total);
     else if (FrameInfo.PTS!=(int64u)-1 && FrameInfo.PTS>PTS_Begin)
     {
         Fill(Stream_Audio, 0, Audio_Duration, float64_int64s(((float64)(FrameInfo.PTS-PTS_Begin))/1000000));
@@ -2265,6 +2268,8 @@ void File_Ac3::Data_Parse()
         Buffer_Size=Save_Buffer_Size;
         File_Offset-=Buffer_Offset;
     }
+    if (IsSub)
+        Stream_Size_Total+=Element_Size;
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Audio/File_Ac3.h
+++ b/Source/MediaInfo/Audio/File_Ac3.h
@@ -200,6 +200,7 @@ private :
     TimeCode TimeStamp_FirstFrame;
     int16u   TimeStamp_FirstFrame_SampleNumber;
     size_t TimeStamp_Count;
+    int64u   Stream_Size_Total;
 };
 
 } //NameSpace


### PR DESCRIPTION
Fix: Stream size for TrueHD+AC3 in M2TS
Problem: For M2TS streams that carry both Dolby TrueHD and an embedded AC‑3 core in one PID, Stream size was reported for the AC‑3 part only instead of the full stream.
Solution: When the AC‑3 parser is used as a sub‑parser, the total number of bytes passed to it is accumulated. That value is used for Stream size only when an AC‑3 core is present (TrueHD+AC3). For TrueHD‑only tracks (e.g. in MKV), Stream size is left to the container so it stays correct.
Result: Stream size for TrueHD+AC3 in M2TS now matches the demuxed track size; TrueHD‑only streams are unchanged.