### PR TITLE
Add image/x-amiga-icon format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ MediaInfoLib.VC.db
 
 # Visual Studio 2015+ cache/options directory
 .vs/
+
+# Temporary files
+*~

--- a/Project/BCB/Library/MediaInfoLib.cbproj
+++ b/Project/BCB/Library/MediaInfoLib.cbproj
@@ -402,6 +402,9 @@
         <None Include="..\..\..\Source\MediaInfo\HashWrapper.h">
             <BuildOrder>209</BuildOrder>
         </None>
+        <CppCompile Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.cpp">
+            <BuildOrder>70</BuildOrder>
+        </CppCompile>
         <CppCompile Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.cpp">
             <BuildOrder>71</BuildOrder>
         </CppCompile>

--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -221,6 +221,7 @@ set(MediaInfoLib_SRCS
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Export/Export_PBCore.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Export/Export_PBCore2.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Export/Export_reVTMD.cpp
+  ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Image/File_AmigaIcon.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Image/File_ArriRaw.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Image/File_Bmp.cpp
   ${MediaInfoLib_SOURCES_PATH}/MediaInfo/Image/File_Bpg.cpp

--- a/Project/GNU/Library/Makefile.am
+++ b/Project/GNU/Library/Makefile.am
@@ -107,6 +107,7 @@ lib@MediaInfoLib_LibName@_la_SOURCES = \
                        ../../../Source/MediaInfo/Export/Export_reVTMD.cpp \
                        ../../../Source/MediaInfo/Export/Export_Niso.cpp \
                        ../../../Source/MediaInfo/Export/Export_Graph.cpp \
+                       ../../../Source/MediaInfo/Image/File_AmigaIcon.cpp \
                        ../../../Source/MediaInfo/Image/File_ArriRaw.cpp \
                        ../../../Source/MediaInfo/Image/File_Bmp.cpp \
                        ../../../Source/MediaInfo/Image/File_Bpg.cpp \

--- a/Project/GNU/Library/configure.ac
+++ b/Project/GNU/Library/configure.ac
@@ -119,6 +119,7 @@ AC_ARG_ENABLE(tta,     AC_HELP_STRING([--disable-tta],     [Disable Audio - True
 AC_ARG_ENABLE(twinvq,  AC_HELP_STRING([--disable-twinvq],  [Disable Audio - TwinVQ]),                                     MediaInfoTwinVQ=$enableval,  MediaInfoTwinVQ=depend)
 AC_ARG_ENABLE(vorbis,  AC_HELP_STRING([--disable-vorbis],  [Disable Audio - Vorbis]),                                     MediaInfovorbis=$enableval,  MediaInfovorbis=depend)
 AC_ARG_ENABLE(wvpk,    AC_HELP_STRING([--disable-wvpk],    [Disable Audio - Wavepack]),                                   MediaInfoWvpk=$enableval,    MediaInfoWvpk=depend)
+AC_ARG_ENABLE(amigaicon, AC_HELP_STRING([--disable-amigaicon], [Disable Image - Amiga Icon]),                              MediaInfoAmigaIcon=$enableval, MediaInfoAmigaIcon=depend)
 AC_ARG_ENABLE(arriraw, AC_HELP_STRING([--disable-arriraw], [Disable Image - Arri Raw]),                                   MediaInfoArriRaw=$enableval, MediaInfoArriRaw=depend)
 AC_ARG_ENABLE(bmp,     AC_HELP_STRING([--disable-bmp],     [Disable Image - Bitmap]),                                     MediaInfoBmp=$enableval,     MediaInfoBmp=depend)
 AC_ARG_ENABLE(bpg,     AC_HELP_STRING([--disable-bpg],     [Disable Image - BPG]),                                        MediaInfoBpg=$enableval,     MediaInfoBpg=depend)
@@ -300,6 +301,7 @@ if test "$MediaInfoTta"     = "no";  then AC_DEFINE(MEDIAINFO_TTA_NO)     fi; if
 if test "$MediaInfoTwinVQ"  = "no";  then AC_DEFINE(MEDIAINFO_TWINVQ_NO)  fi; if test "$MediaInfoTwinVQ"  = "yes"; then AC_DEFINE(MEDIAINFO_TWINVQ_YES)  fi
 if test "$MediaInfoVorbis"  = "no";  then AC_DEFINE(MEDIAINFO_VORBIS_NO)  fi; if test "$MediaInfoVorbis"  = "yes"; then AC_DEFINE(MEDIAINFO_VORBIS_YES)  fi
 if test "$MediaInfoWvpk"    = "no";  then AC_DEFINE(MEDIAINFO_WVPK_NO)    fi; if test "$MediaInfoWvpk"    = "yes"; then AC_DEFINE(MEDIAINFO_WVPK_YES)    fi
+if test "$MediaInfoAmigaIcon" = "no";  then AC_DEFINE(MEDIAINFO_AMIGAICON_NO) fi; if test "$MediaInfoAmigaIcon" = "yes"; then AC_DEFINE(MEDIAINFO_AMIGAICON_YES) fi
 if test "$MediaInfoArriRaw" = "no";  then AC_DEFINE(MEDIAINFO_ARRIRAW_NO) fi; if test "$MediaInfoArriRaw" = "yes"; then AC_DEFINE(MEDIAINFO_ARRIRAW_YES) fi
 if test "$MediaInfoBmp"     = "no";  then AC_DEFINE(MEDIAINFO_BMP_NO)     fi; if test "$MediaInfoBmp"     = "yes"; then AC_DEFINE(MEDIAINFO_BMP_YES)     fi
 if test "$MediaInfoBpg"     = "no";  then AC_DEFINE(MEDIAINFO_BPG_NO)     fi; if test "$MediaInfoBpg"     = "yes"; then AC_DEFINE(MEDIAINFO_BPG_YES)     fi
@@ -1076,6 +1078,7 @@ Mcho "Tta    " "$MediaInfoTta"
 Mcho "TwinVQ " "$MediaInfoTwinVQ"
 Mcho "Vorbis " "$MediaInfoVorbis"
 Mcho "Wvpk   " "$MediaInfoWvpk"
+Mcho "AmigaIcon" "$MediaInfoAmigaIcon"
 Mcho "ArriRaw" "$MediaInfoArriRaw"
 Mcho "Bmp    " "$MediaInfoBmp"
 Mcho "Bpg    " "$MediaInfoBpg"

--- a/Project/MSVC2022/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2022/Library/MediaInfoLib.vcxproj
@@ -404,6 +404,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Other.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Unknown.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\HashWrapper.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Bpg.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Dds.cpp" />
@@ -823,6 +824,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Other.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Unknown.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\HashWrapper.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_Bpg.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_Dds.h" />

--- a/Project/MSVC2022/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2022/Library/MediaInfoLib.vcxproj.filters
@@ -713,6 +713,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\MediaInfo_Config_PerPackage.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.cpp">
+      <Filter>Source Files\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.cpp">
       <Filter>Source Files\Image</Filter>
     </ClCompile>
@@ -1488,6 +1491,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\MediaInfo_Config_PerPackage.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.h">
+      <Filter>Header Files\Image</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.h">
       <Filter>Header Files\Image</Filter>

--- a/Project/MSVC2022/Library/MediaInfoLib_UWP.vcxproj
+++ b/Project/MSVC2022/Library/MediaInfoLib_UWP.vcxproj
@@ -229,6 +229,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Other.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Unknown.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\HashWrapper.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Bpg.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Dds.cpp" />
@@ -563,6 +564,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Other.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Unknown.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\HashWrapper.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_Bpg.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_Dds.h" />

--- a/Project/MSVC2026/Library/MediaInfoLib.vcxproj
+++ b/Project/MSVC2026/Library/MediaInfoLib.vcxproj
@@ -404,6 +404,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Other.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Unknown.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\HashWrapper.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Bpg.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Dds.cpp" />
@@ -823,6 +824,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Other.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Unknown.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\HashWrapper.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_Bpg.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_Dds.h" />

--- a/Project/MSVC2026/Library/MediaInfoLib.vcxproj.filters
+++ b/Project/MSVC2026/Library/MediaInfoLib.vcxproj.filters
@@ -713,6 +713,9 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\MediaInfo_Config_PerPackage.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.cpp">
+      <Filter>Source Files\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.cpp">
       <Filter>Source Files\Image</Filter>
     </ClCompile>
@@ -1488,6 +1491,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\MediaInfo_Config_PerPackage.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.h">
+      <Filter>Header Files\Image</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.h">
       <Filter>Header Files\Image</Filter>

--- a/Project/MSVC2026/Library/MediaInfoLib_UWP.vcxproj
+++ b/Project/MSVC2026/Library/MediaInfoLib_UWP.vcxproj
@@ -229,6 +229,7 @@
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Other.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\File_Unknown.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\HashWrapper.cpp" />
+    <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Bpg.cpp" />
     <ClCompile Include="..\..\..\Source\MediaInfo\Image\File_Dds.cpp" />
@@ -563,6 +564,7 @@
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Other.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\File_Unknown.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\HashWrapper.h" />
+    <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_AmigaIcon.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_ArriRaw.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_Bpg.h" />
     <ClInclude Include="..\..\..\Source\MediaInfo\Image\File_Dds.h" />

--- a/Project/Qt/MediaInfoLib.pro
+++ b/Project/Qt/MediaInfoLib.pro
@@ -122,6 +122,7 @@ HEADERS += \
         ../../Source/MediaInfo/File_Other.h \
         ../../Source/MediaInfo/File_Unknown.h \
         ../../Source/MediaInfo/HashWrapper.h \
+        ../../Source/MediaInfo/Image/File_AmigaIcon.h \
         ../../Source/MediaInfo/Image/File_ArriRaw.h \
         ../../Source/MediaInfo/Image/File_Bmp.h \
         ../../Source/MediaInfo/Image/File_Bpg.h \
@@ -368,6 +369,7 @@ SOURCES += \
         ../../Source/MediaInfo/File_Other.cpp \
         ../../Source/MediaInfo/File_Unknown.cpp \
         ../../Source/MediaInfo/HashWrapper.cpp \
+        ../../Source/MediaInfo/Image/File_AmigaIcon.cpp \
         ../../Source/MediaInfo/Image/File_ArriRaw.cpp \
         ../../Source/MediaInfo/Image/File_Bmp.cpp \
         ../../Source/MediaInfo/Image/File_Bpg.cpp \

--- a/Source/MediaInfo/File__MultipleParsing.cpp
+++ b/Source/MediaInfo/File__MultipleParsing.cpp
@@ -335,6 +335,9 @@
 #if defined(MEDIAINFO_BPG_YES)
     #include "MediaInfo/Image/File_Bpg.h"
 #endif
+#if defined(MEDIAINFO_AMIGAICON_YES)
+    #include "MediaInfo/Image/File_AmigaIcon.h"
+#endif
 #if defined(MEDIAINFO_DDS_YES)
     #include "MediaInfo/Image/File_Dds.h"
 #endif
@@ -776,6 +779,9 @@ File__MultipleParsing::File__MultipleParsing()
     #endif
     #if defined(MEDIAINFO_BPG_YES)
         Parser.push_back(new File_Bpg());
+    #endif
+    #if defined(MEDIAINFO_AMIGAICON_YES)
+        Parser.push_back(new File_AmigaIcon());
     #endif
     #if defined(MEDIAINFO_DDS_YES)
         Parser.push_back(new File_Dds());

--- a/Source/MediaInfo/Image/File_AmigaIcon.cpp
+++ b/Source/MediaInfo/Image/File_AmigaIcon.cpp
@@ -154,8 +154,9 @@ void File_AmigaIcon::Read_Buffer_Continue()
             Skip_B1(                                                "im_PlaneOnOff");
             Skip_B4(                                                "im_Next");
 
-            int32u PlaneDataSize=((int32u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
-            Skip_XX(PlaneDataSize,                                  "Plane data");
+            int64u PlaneDataSize=((int64u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
+            if (Element_Offset+PlaneDataSize<=Element_Size)
+                Skip_XX(PlaneDataSize,                              "Plane data");
         Element_End0();
 
         ClassicWidth=ImgWidth;
@@ -178,8 +179,9 @@ void File_AmigaIcon::Read_Buffer_Continue()
             Skip_B1(                                                "im_PlaneOnOff");
             Skip_B4(                                                "im_Next");
 
-            int32u PlaneDataSize=((int32u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
-            Skip_XX(PlaneDataSize,                                  "Plane data");
+            int64u PlaneDataSize=((int64u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
+            if (Element_Offset+PlaneDataSize<=Element_Size)
+                Skip_XX(PlaneDataSize,                              "Plane data");
         Element_End0();
     }
 
@@ -202,11 +204,14 @@ void File_AmigaIcon::Read_Buffer_Continue()
         Element_Begin1("ToolTypes");
             Get_B4 (CountField,                                     "Count");
 
-            if (CountField)
+            if (CountField>=8)
             {
                 int32u NumEntries=CountField/4-1;
                 for (int32u i=0; i<NumEntries; i++)
                 {
+                    if (Element_Offset>=Element_Size)
+                        break;
+
                     int32u Length;
                     Get_B4 (Length,                                  "Length");
 
@@ -217,7 +222,9 @@ void File_AmigaIcon::Read_Buffer_Continue()
                         {
                             HasNewIcon=true;
                             //Parse NewIcon header: transparency(1) + width(1) + height(1) + colors_hi(1) + colors_lo(1)
-                            if (Element_Offset+9<=(int64u)Buffer_Size)
+                            if (Element_Offset+9<=(int64u)Buffer_Size
+                             && Buffer[(size_t)Element_Offset+5]>=0x21
+                             && Buffer[(size_t)Element_Offset+6]>=0x21)
                             {
                                 NewIconWidth=Buffer[(size_t)Element_Offset+5]-0x21;
                                 NewIconHeight=Buffer[(size_t)Element_Offset+6]-0x21;
@@ -294,11 +301,11 @@ void File_AmigaIcon::Read_Buffer_Continue()
                     Get_B4 (FormSize,                               "Size");
                     Skip_B4(                                        "ICON");
 
-                    int64u FormEnd=Element_Offset+FormSize-4;
                     int16u FaceWidth=0, FaceHeight=0;
                     bool HasIMAG=false, HasARGB=false;
                     int8u  IMAGDepth=0;
 
+                    int64u FormEnd=FormSize>=4?Element_Offset+FormSize-4:Element_Offset;
                     while (Element_Offset+8<=FormEnd && Element_Offset+8<=Element_Size)
                     {
                         int32u ChunkSize;

--- a/Source/MediaInfo/Image/File_AmigaIcon.cpp
+++ b/Source/MediaInfo/Image/File_AmigaIcon.cpp
@@ -267,7 +267,8 @@ void File_AmigaIcon::Read_Buffer_Continue()
         Fill(Stream_Image, StreamPos_Last, Image_Width, ClassicWidth);
         Fill(Stream_Image, StreamPos_Last, Image_Height, ClassicHeight);
         Fill(Stream_Image, StreamPos_Last, Image_BitDepth, ClassicDepth);
-        Fill(Stream_Image, StreamPos_Last, Image_Format, "Classic planar");
+        Fill(Stream_Image, StreamPos_Last, Image_Format, "Raw");
+        Fill(Stream_Image, StreamPos_Last, Image_Format_Profile, "Classic");
         Fill(Stream_Image, StreamPos_Last, Image_ColorSpace, "RGB");
     }
 
@@ -277,7 +278,8 @@ void File_AmigaIcon::Read_Buffer_Continue()
         Stream_Prepare(Stream_Image);
         Fill(Stream_Image, StreamPos_Last, Image_Width, NewIconWidth);
         Fill(Stream_Image, StreamPos_Last, Image_Height, NewIconHeight);
-        Fill(Stream_Image, StreamPos_Last, Image_Format, "NewIcon");
+        Fill(Stream_Image, StreamPos_Last, Image_Format, "Raw");
+        Fill(Stream_Image, StreamPos_Last, Image_Format_Profile, "NewIcon");
         Fill(Stream_Image, StreamPos_Last, Image_ColorSpace, "RGB");
     }
 
@@ -303,7 +305,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
 
                     int16u FaceWidth=0, FaceHeight=0;
                     bool HasIMAG=false, HasARGB=false;
-                    int8u  IMAGDepth=0;
+                    int8u  IMAGDepth=0, IMAGFormat=0;
 
                     int64u FormEnd=FormSize>=4?Element_Offset+FormSize-4:Element_Offset;
                     while (Element_Offset+8<=FormEnd && Element_Offset+8<=Element_Size)
@@ -326,6 +328,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
                         {
                             if (!HasIMAG && ChunkSize>=10 && Element_Offset+6<=Element_Size)
                             {
+                                IMAGFormat=Buffer[(size_t)Element_Offset+3];
                                 IMAGDepth=Buffer[(size_t)Element_Offset+5];
                                 HasIMAG=true;
                             }
@@ -354,7 +357,8 @@ void File_AmigaIcon::Read_Buffer_Continue()
                     Fill(Stream_Image, StreamPos_Last, Image_Width, FaceWidth);
                     Fill(Stream_Image, StreamPos_Last, Image_Height, FaceHeight);
                     Fill(Stream_Image, StreamPos_Last, Image_BitDepth, IMAGDepth);
-                    Fill(Stream_Image, StreamPos_Last, Image_Format, "GlowIcon");
+                    Fill(Stream_Image, StreamPos_Last, Image_Format, IMAGFormat==1?"RLE":"Raw");
+                    Fill(Stream_Image, StreamPos_Last, Image_Format_Profile, "GlowIcon");
                     Fill(Stream_Image, StreamPos_Last, Image_ColorSpace, "RGB");
                 }
 
@@ -365,7 +369,8 @@ void File_AmigaIcon::Read_Buffer_Continue()
                     Fill(Stream_Image, StreamPos_Last, Image_Width, FaceWidth);
                     Fill(Stream_Image, StreamPos_Last, Image_Height, FaceHeight);
                     Fill(Stream_Image, StreamPos_Last, Image_BitDepth, 32);
-                    Fill(Stream_Image, StreamPos_Last, Image_Format, "ARGB");
+                    Fill(Stream_Image, StreamPos_Last, Image_Format, "Raw");
+                    Fill(Stream_Image, StreamPos_Last, Image_Format_Profile, "ARGB");
                     Fill(Stream_Image, StreamPos_Last, Image_ColorSpace, "RGBA");
                 }
 

--- a/Source/MediaInfo/Image/File_AmigaIcon.cpp
+++ b/Source/MediaInfo/Image/File_AmigaIcon.cpp
@@ -133,7 +133,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
     //DrawerData
     if (HasDrawerData)
     {
-        if (Element_Offset+56<=Element_Size)
+        if (56<=Element_Size-Element_Offset)
         {
             Element_Begin1("DrawerData");
                 Skip_XX(56,                                         "DrawerData");
@@ -143,7 +143,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
 
     //Classic image (normal)
     int16u ClassicWidth=0, ClassicHeight=0, ClassicDepth=0;
-    if (GadgetRender && Element_Offset+20<=Element_Size)
+    if (GadgetRender && 20<=Element_Size-Element_Offset)
     {
         int16u ImgWidth, ImgHeight, ImgDepth;
         Element_Begin1("Classic image");
@@ -160,7 +160,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
             if (ImgWidth>0 && ImgHeight>0 && ImgDepth>0 && ImgDepth<=8)
             {
                 int64u PlaneDataSize=((int64u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
-                if (Element_Offset+PlaneDataSize<=Element_Size)
+                if (PlaneDataSize<=Element_Size-Element_Offset)
                     Skip_XX(PlaneDataSize,                          "Plane data");
             }
         Element_End0();
@@ -171,7 +171,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
     }
 
     //Classic image (selected)
-    if (SelectRender && Element_Offset+20<=Element_Size)
+    if (SelectRender && 20<=Element_Size-Element_Offset)
     {
         int16u ImgWidth, ImgHeight, ImgDepth;
         Element_Begin1("Classic image (selected)");
@@ -188,19 +188,19 @@ void File_AmigaIcon::Read_Buffer_Continue()
             if (ImgWidth>0 && ImgHeight>0 && ImgDepth>0 && ImgDepth<=8)
             {
                 int64u PlaneDataSize=((int64u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
-                if (Element_Offset+PlaneDataSize<=Element_Size)
+                if (PlaneDataSize<=Element_Size-Element_Offset)
                     Skip_XX(PlaneDataSize,                          "Plane data");
             }
         Element_End0();
     }
 
     //DefaultTool
-    if (HasDefaultTool && Element_Offset+4<=Element_Size)
+    if (HasDefaultTool && 4<=Element_Size-Element_Offset)
     {
         int32u Length;
         Element_Begin1("DefaultTool");
             Get_B4 (Length,                                         "Length");
-            if (Element_Offset+Length<=Element_Size)
+            if (Length<=Element_Size-Element_Offset)
                 Skip_XX(Length,                                     "Text");
         Element_End0();
     }
@@ -208,7 +208,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
     //ToolTypes
     bool HasNewIcon=false;
     int16u NewIconWidth=0, NewIconHeight=0;
-    if (HasToolTypes && Element_Offset+4<=Element_Size)
+    if (HasToolTypes && 4<=Element_Size-Element_Offset)
     {
         int32u CountField;
         Element_Begin1("ToolTypes");
@@ -217,22 +217,24 @@ void File_AmigaIcon::Read_Buffer_Continue()
             if (CountField>=8)
             {
                 int32u NumEntries=CountField/4-1;
+                if (NumEntries>(int32u)((Element_Size-Element_Offset)/4))
+                    NumEntries=(int32u)((Element_Size-Element_Offset)/4);
                 for (int32u i=0; i<NumEntries; i++)
                 {
-                    if (Element_Offset+4>Element_Size)
+                    if (4>Element_Size-Element_Offset)
                         break;
 
                     int32u Length;
                     Get_B4 (Length,                                  "Length");
 
                     //Check for IM1= prefix to detect NewIcon
-                    if (!HasNewIcon && Length>=5 && Element_Offset+4<=(int64u)Buffer_Size)
+                    if (!HasNewIcon && Length>=5 && 4<=(int64u)Buffer_Size-Element_Offset)
                     {
                         if (Buffer[(size_t)Element_Offset]=='I' && Buffer[(size_t)Element_Offset+1]=='M' && Buffer[(size_t)Element_Offset+2]=='1' && Buffer[(size_t)Element_Offset+3]=='=')
                         {
                             HasNewIcon=true;
                             //Parse NewIcon header: transparency(1) + width(1) + height(1) + colors_hi(1) + colors_lo(1)
-                            if (Element_Offset+9<=(int64u)Buffer_Size
+                            if (9<=(int64u)Buffer_Size-Element_Offset
                              && Buffer[(size_t)Element_Offset+5]>=0x21
                              && Buffer[(size_t)Element_Offset+6]>=0x21)
                             {
@@ -242,7 +244,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
                         }
                     }
 
-                    if (Element_Offset+Length>Element_Size)
+                    if (Length>Element_Size-Element_Offset)
                         break;
                     Skip_XX(Length,                                  "ToolType");
                 }
@@ -251,12 +253,12 @@ void File_AmigaIcon::Read_Buffer_Continue()
     }
 
     //ToolWindow
-    if (HasToolWindow && Element_Offset+4<=Element_Size)
+    if (HasToolWindow && 4<=Element_Size-Element_Offset)
     {
         int32u Length;
         Element_Begin1("ToolWindow");
             Get_B4 (Length,                                         "Length");
-            if (Element_Offset+Length<=Element_Size)
+            if (Length<=Element_Size-Element_Offset)
                 Skip_XX(Length,                                     "Text");
         Element_End0();
     }
@@ -264,7 +266,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
     //DrawerData2
     if (HasDrawerData && (UserData&0xFF))
     {
-        if (Element_Offset+6<=Element_Size)
+        if (6<=Element_Size-Element_Offset)
         {
             Element_Begin1("DrawerData2");
                 Skip_B4(                                            "dd_Flags");
@@ -297,11 +299,11 @@ void File_AmigaIcon::Read_Buffer_Continue()
     }
 
     //FORM ICON (GlowIcons / ARGB)
-    if (Element_Offset+12<=Element_Size)
+    if (12<=Element_Size-Element_Offset)
     {
         //Search for "FORM" + "ICON"
         int64u SearchPos=Element_Offset;
-        while (SearchPos+12<=Element_Size)
+        while (12<=Element_Size-SearchPos)
         {
             if (Buffer[(size_t)SearchPos]=='F' && Buffer[(size_t)SearchPos+1]=='O' && Buffer[(size_t)SearchPos+2]=='R' && Buffer[(size_t)SearchPos+3]=='M'
              && Buffer[(size_t)SearchPos+8]=='I' && Buffer[(size_t)SearchPos+9]=='C' && Buffer[(size_t)SearchPos+10]=='O' && Buffer[(size_t)SearchPos+11]=='N')
@@ -320,8 +322,10 @@ void File_AmigaIcon::Read_Buffer_Continue()
                     bool HasIMAG=false, HasARGB=false;
                     int8u  IMAGDepth=0, IMAGFormat=0;
 
-                    int64u FormEnd=FormSize>=4?Element_Offset+FormSize-4:Element_Offset;
-                    while (Element_Offset+8<=FormEnd && Element_Offset+8<=Element_Size)
+                    int64u FormEnd=Element_Offset+(FormSize>=4?FormSize-4:0);
+                    if (FormEnd>Element_Size)
+                        FormEnd=Element_Size;
+                    while (Element_Offset<=FormEnd && 8<=FormEnd-Element_Offset && 8<=Element_Size-Element_Offset)
                     {
                         int32u ChunkSize;
                         int32u ChunkName;
@@ -331,7 +335,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
 
                         if (ChunkName==0x46414345) //"FACE"
                         {
-                            if (ChunkSize>=4 && Element_Offset+4<=Element_Size)
+                            if (ChunkSize>=4 && 4<=Element_Size-Element_Offset)
                             {
                                 FaceWidth=Buffer[(size_t)Element_Offset]+1;
                                 FaceHeight=Buffer[(size_t)Element_Offset+1]+1;
@@ -339,7 +343,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
                         }
                         else if (ChunkName==0x494D4147) //"IMAG"
                         {
-                            if (!HasIMAG && ChunkSize>=10 && Element_Offset+6<=Element_Size)
+                            if (!HasIMAG && ChunkSize>=10 && 6<=Element_Size-Element_Offset)
                             {
                                 IMAGFormat=Buffer[(size_t)Element_Offset+3];
                                 IMAGDepth=Buffer[(size_t)Element_Offset+5];
@@ -352,10 +356,16 @@ void File_AmigaIcon::Read_Buffer_Continue()
                         }
 
                         //Skip chunk data (padded to even)
+                        if (ChunkSize==0)
+                            break;
                         int32u SkipSize=ChunkSize;
                         if (SkipSize%2)
+                        {
+                            if (SkipSize==0xFFFFFFFF)
+                                break;
                             SkipSize++;
-                        if (Element_Offset+SkipSize<=Element_Size)
+                        }
+                        if (SkipSize<=Element_Size-Element_Offset)
                             Skip_XX(SkipSize,                       "Chunk data");
                         else
                             break;

--- a/Source/MediaInfo/Image/File_AmigaIcon.cpp
+++ b/Source/MediaInfo/Image/File_AmigaIcon.cpp
@@ -1,0 +1,385 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Amiga Icon - Format
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+//
+// Amiga .info (Workbench icon) files
+// Supports Classic, NewIcon, GlowIcon/ColorIcon, and ARGB image layers
+//
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+//---------------------------------------------------------------------------
+// Pre-compilation
+#include "MediaInfo/PreComp.h"
+#ifdef __BORLANDC__
+    #pragma hdrstop
+#endif
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/Setup.h"
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#if defined(MEDIAINFO_AMIGAICON_YES)
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/Image/File_AmigaIcon.h"
+//---------------------------------------------------------------------------
+
+namespace MediaInfoLib
+{
+
+//***************************************************************************
+// Infos
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+static const char* AmigaIcon_Type(int8u Type)
+{
+    switch (Type)
+    {
+        case  1 : return "Disk";
+        case  2 : return "Drawer";
+        case  3 : return "Tool";
+        case  4 : return "Project";
+        case  5 : return "Garbage";
+        case  6 : return "Kick";
+        case  8 : return "AppIcon";
+        default : return "";
+    }
+}
+
+//***************************************************************************
+// Static stuff
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+bool File_AmigaIcon::FileHeader_Begin()
+{
+    //Element_Size
+    if (Buffer_Size<4)
+        return false; //Must wait for more data
+
+    if (CC2(Buffer)!=0xE310)
+    {
+        Reject("Amiga Icon");
+        return false;
+    }
+
+    //All should be OK...
+    return true;
+}
+
+//***************************************************************************
+// Buffer - Global
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+void File_AmigaIcon::Read_Buffer_Continue()
+{
+    //Parsing
+    int32u GadgetRender, SelectRender, UserData;
+    int32u HasDefaultTool, HasToolTypes, HasDrawerData, HasToolWindow;
+    int16u Width, Height;
+    int8u  IconType;
+
+    Element_Begin1("DiskObject header");
+        Skip_B2(                                                    "Magic");
+        Skip_B2(                                                    "Version");
+
+        Element_Begin1("Gadget");
+            Skip_B4(                                                "ga_Next");
+            Skip_B2(                                                "ga_LeftEdge");
+            Skip_B2(                                                "ga_TopEdge");
+            Get_B2 (Width,                                          "ga_Width");
+            Get_B2 (Height,                                         "ga_Height");
+            Skip_B2(                                                "ga_Flags");
+            Skip_B2(                                                "ga_Activation");
+            Skip_B2(                                                "ga_GadgetType");
+            Get_B4 (GadgetRender,                                   "ga_GadgetRender");
+            Get_B4 (SelectRender,                                   "ga_SelectRender");
+            Skip_B4(                                                "ga_GadgetText");
+            Skip_B4(                                                "ga_MutualExclude");
+            Skip_B4(                                                "ga_SpecialInfo");
+            Skip_B2(                                                "ga_GadgetID");
+            Get_B4 (UserData,                                       "ga_UserData");
+        Element_End0();
+
+        Get_B1 (IconType,                                           "do_Type");
+        Skip_B1(                                                    "do_Pad");
+        Get_B4 (HasDefaultTool,                                     "do_DefaultTool");
+        Get_B4 (HasToolTypes,                                       "do_ToolTypes");
+        Skip_B4(                                                    "do_CurrentX");
+        Skip_B4(                                                    "do_CurrentY");
+        Get_B4 (HasDrawerData,                                      "do_DrawerData");
+        Get_B4 (HasToolWindow,                                      "do_ToolWindow");
+        Skip_B4(                                                    "do_StackSize");
+    Element_End0();
+
+    FILLING_BEGIN();
+        Accept("Amiga Icon");
+
+        Fill(Stream_General, 0, General_Format, "Amiga Icon");
+        Fill(Stream_General, 0, General_Format_Profile, AmigaIcon_Type(IconType));
+    FILLING_END();
+
+    //DrawerData
+    if (HasDrawerData)
+    {
+        Element_Begin1("DrawerData");
+            Skip_XX(56,                                             "DrawerData");
+        Element_End0();
+    }
+
+    //Classic image (normal)
+    int16u ClassicWidth=0, ClassicHeight=0, ClassicDepth=0;
+    if (GadgetRender)
+    {
+        int16u ImgWidth, ImgHeight, ImgDepth;
+        Element_Begin1("Classic image");
+            Skip_B2(                                                "im_LeftEdge");
+            Skip_B2(                                                "im_TopEdge");
+            Get_B2 (ImgWidth,                                       "im_Width");
+            Get_B2 (ImgHeight,                                      "im_Height");
+            Get_B2 (ImgDepth,                                       "im_Depth");
+            Skip_B4(                                                "im_ImageData");
+            Skip_B1(                                                "im_PlanePick");
+            Skip_B1(                                                "im_PlaneOnOff");
+            Skip_B4(                                                "im_Next");
+
+            int32u PlaneDataSize=((int32u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
+            Skip_XX(PlaneDataSize,                                  "Plane data");
+        Element_End0();
+
+        ClassicWidth=ImgWidth;
+        ClassicHeight=ImgHeight;
+        ClassicDepth=ImgDepth;
+    }
+
+    //Classic image (selected)
+    if (SelectRender)
+    {
+        int16u ImgWidth, ImgHeight, ImgDepth;
+        Element_Begin1("Classic image (selected)");
+            Skip_B2(                                                "im_LeftEdge");
+            Skip_B2(                                                "im_TopEdge");
+            Get_B2 (ImgWidth,                                       "im_Width");
+            Get_B2 (ImgHeight,                                      "im_Height");
+            Get_B2 (ImgDepth,                                       "im_Depth");
+            Skip_B4(                                                "im_ImageData");
+            Skip_B1(                                                "im_PlanePick");
+            Skip_B1(                                                "im_PlaneOnOff");
+            Skip_B4(                                                "im_Next");
+
+            int32u PlaneDataSize=((int32u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
+            Skip_XX(PlaneDataSize,                                  "Plane data");
+        Element_End0();
+    }
+
+    //DefaultTool
+    if (HasDefaultTool)
+    {
+        int32u Length;
+        Element_Begin1("DefaultTool");
+            Get_B4 (Length,                                         "Length");
+            Skip_XX(Length,                                         "Text");
+        Element_End0();
+    }
+
+    //ToolTypes
+    bool HasNewIcon=false;
+    int16u NewIconWidth=0, NewIconHeight=0;
+    if (HasToolTypes)
+    {
+        int32u CountField;
+        Element_Begin1("ToolTypes");
+            Get_B4 (CountField,                                     "Count");
+
+            if (CountField)
+            {
+                int32u NumEntries=CountField/4-1;
+                for (int32u i=0; i<NumEntries; i++)
+                {
+                    int32u Length;
+                    Get_B4 (Length,                                  "Length");
+
+                    //Check for IM1= prefix to detect NewIcon
+                    if (!HasNewIcon && Length>=5 && Element_Offset+4<=(int64u)Buffer_Size)
+                    {
+                        if (Buffer[(size_t)Element_Offset]=='I' && Buffer[(size_t)Element_Offset+1]=='M' && Buffer[(size_t)Element_Offset+2]=='1' && Buffer[(size_t)Element_Offset+3]=='=')
+                        {
+                            HasNewIcon=true;
+                            //Parse NewIcon header: transparency(1) + width(1) + height(1) + colors_hi(1) + colors_lo(1)
+                            if (Element_Offset+9<=(int64u)Buffer_Size)
+                            {
+                                NewIconWidth=Buffer[(size_t)Element_Offset+5]-0x21;
+                                NewIconHeight=Buffer[(size_t)Element_Offset+6]-0x21;
+                            }
+                        }
+                    }
+
+                    Skip_XX(Length,                                  "ToolType");
+                }
+            }
+        Element_End0();
+    }
+
+    //ToolWindow
+    if (HasToolWindow)
+    {
+        int32u Length;
+        Element_Begin1("ToolWindow");
+            Get_B4 (Length,                                         "Length");
+            Skip_XX(Length,                                         "Text");
+        Element_End0();
+    }
+
+    //DrawerData2
+    if (HasDrawerData && (UserData&0xFF))
+    {
+        if (Element_Offset+6<=Element_Size)
+        {
+            Element_Begin1("DrawerData2");
+                Skip_B4(                                            "dd_Flags");
+                Skip_B2(                                            "dd_ViewModes");
+            Element_End0();
+        }
+    }
+
+    //Fill Classic image stream
+    if (GadgetRender && ClassicWidth && ClassicHeight)
+    {
+        Stream_Prepare(Stream_Image);
+        Fill(Stream_Image, StreamPos_Last, Image_Width, ClassicWidth);
+        Fill(Stream_Image, StreamPos_Last, Image_Height, ClassicHeight);
+        Fill(Stream_Image, StreamPos_Last, Image_BitDepth, ClassicDepth);
+        Fill(Stream_Image, StreamPos_Last, Image_Format, "Classic planar");
+        Fill(Stream_Image, StreamPos_Last, Image_ColorSpace, "RGB");
+    }
+
+    //Fill NewIcon stream
+    if (HasNewIcon && NewIconWidth && NewIconHeight)
+    {
+        Stream_Prepare(Stream_Image);
+        Fill(Stream_Image, StreamPos_Last, Image_Width, NewIconWidth);
+        Fill(Stream_Image, StreamPos_Last, Image_Height, NewIconHeight);
+        Fill(Stream_Image, StreamPos_Last, Image_Format, "NewIcon");
+        Fill(Stream_Image, StreamPos_Last, Image_ColorSpace, "RGB");
+    }
+
+    //FORM ICON (GlowIcons / ARGB)
+    if (Element_Offset+12<=Element_Size)
+    {
+        //Search for "FORM" + "ICON"
+        int64u SearchPos=Element_Offset;
+        while (SearchPos+12<=Element_Size)
+        {
+            if (Buffer[(size_t)SearchPos]=='F' && Buffer[(size_t)SearchPos+1]=='O' && Buffer[(size_t)SearchPos+2]=='R' && Buffer[(size_t)SearchPos+3]=='M'
+             && Buffer[(size_t)SearchPos+8]=='I' && Buffer[(size_t)SearchPos+9]=='C' && Buffer[(size_t)SearchPos+10]=='O' && Buffer[(size_t)SearchPos+11]=='N')
+            {
+                //Found FORM ICON
+                if (SearchPos>Element_Offset)
+                    Skip_XX(SearchPos-Element_Offset,               "Padding");
+
+                int32u FormSize;
+                Element_Begin1("FORM ICON");
+                    Skip_B4(                                        "FORM");
+                    Get_B4 (FormSize,                               "Size");
+                    Skip_B4(                                        "ICON");
+
+                    int64u FormEnd=Element_Offset+FormSize-4;
+                    int16u FaceWidth=0, FaceHeight=0;
+                    bool HasIMAG=false, HasARGB=false;
+                    int8u  IMAGDepth=0;
+
+                    while (Element_Offset+8<=FormEnd && Element_Offset+8<=Element_Size)
+                    {
+                        int32u ChunkSize;
+                        int32u ChunkName;
+                        Peek_B4(ChunkName);
+                        Skip_B4(                                    "Chunk name");
+                        Get_B4 (ChunkSize,                          "Chunk size");
+
+                        if (ChunkName==0x46414345) //"FACE"
+                        {
+                            if (ChunkSize>=4 && Element_Offset+4<=Element_Size)
+                            {
+                                FaceWidth=Buffer[(size_t)Element_Offset]+1;
+                                FaceHeight=Buffer[(size_t)Element_Offset+1]+1;
+                            }
+                        }
+                        else if (ChunkName==0x494D4147) //"IMAG"
+                        {
+                            if (!HasIMAG && ChunkSize>=10 && Element_Offset+6<=Element_Size)
+                            {
+                                IMAGDepth=Buffer[(size_t)Element_Offset+5];
+                                HasIMAG=true;
+                            }
+                        }
+                        else if (ChunkName==0x41524742) //"ARGB"
+                        {
+                            HasARGB=true;
+                        }
+
+                        //Skip chunk data (padded to even)
+                        int32u SkipSize=ChunkSize;
+                        if (SkipSize%2)
+                            SkipSize++;
+                        if (Element_Offset+SkipSize<=Element_Size)
+                            Skip_XX(SkipSize,                       "Chunk data");
+                        else
+                            break;
+                    }
+
+                Element_End0();
+
+                //Fill GlowIcon stream
+                if (HasIMAG && FaceWidth && FaceHeight)
+                {
+                    Stream_Prepare(Stream_Image);
+                    Fill(Stream_Image, StreamPos_Last, Image_Width, FaceWidth);
+                    Fill(Stream_Image, StreamPos_Last, Image_Height, FaceHeight);
+                    Fill(Stream_Image, StreamPos_Last, Image_BitDepth, IMAGDepth);
+                    Fill(Stream_Image, StreamPos_Last, Image_Format, "GlowIcon");
+                    Fill(Stream_Image, StreamPos_Last, Image_ColorSpace, "RGB");
+                }
+
+                //Fill ARGB stream
+                if (HasARGB && FaceWidth && FaceHeight)
+                {
+                    Stream_Prepare(Stream_Image);
+                    Fill(Stream_Image, StreamPos_Last, Image_Width, FaceWidth);
+                    Fill(Stream_Image, StreamPos_Last, Image_Height, FaceHeight);
+                    Fill(Stream_Image, StreamPos_Last, Image_BitDepth, 32);
+                    Fill(Stream_Image, StreamPos_Last, Image_Format, "ARGB");
+                    Fill(Stream_Image, StreamPos_Last, Image_ColorSpace, "RGBA");
+                }
+
+                break;
+            }
+            SearchPos++;
+        }
+    }
+
+    //Skip any remaining data
+    if (Element_Offset<Element_Size)
+        Skip_XX(Element_Size-Element_Offset,                        "Unknown");
+
+    //No need of more
+    Finish("Amiga Icon");
+}
+
+//***************************************************************************
+//
+//***************************************************************************
+
+} //NameSpace
+
+#endif

--- a/Source/MediaInfo/Image/File_AmigaIcon.cpp
+++ b/Source/MediaInfo/Image/File_AmigaIcon.cpp
@@ -202,6 +202,8 @@ void File_AmigaIcon::Read_Buffer_Continue()
             Get_B4 (Length,                                         "Length");
             if (Length<=Element_Size-Element_Offset)
                 Skip_XX(Length,                                     "Text");
+            else
+                Skip_XX(Element_Size-Element_Offset,               "(Problem)");
         Element_End0();
     }
 
@@ -228,13 +230,13 @@ void File_AmigaIcon::Read_Buffer_Continue()
                     Get_B4 (Length,                                  "Length");
 
                     //Check for IM1= prefix to detect NewIcon
-                    if (!HasNewIcon && Length>=5 && 4<=(int64u)Buffer_Size-Element_Offset)
+                    if (!HasNewIcon && Length>=5 && 4<=Element_Size-Element_Offset)
                     {
                         if (Buffer[(size_t)Element_Offset]=='I' && Buffer[(size_t)Element_Offset+1]=='M' && Buffer[(size_t)Element_Offset+2]=='1' && Buffer[(size_t)Element_Offset+3]=='=')
                         {
                             HasNewIcon=true;
                             //Parse NewIcon header: transparency(1) + width(1) + height(1) + colors_hi(1) + colors_lo(1)
-                            if (9<=(int64u)Buffer_Size-Element_Offset
+                            if (Length>=9 && 9<=Element_Size-Element_Offset
                              && Buffer[(size_t)Element_Offset+5]>=0x21
                              && Buffer[(size_t)Element_Offset+6]>=0x21)
                             {
@@ -260,6 +262,8 @@ void File_AmigaIcon::Read_Buffer_Continue()
             Get_B4 (Length,                                         "Length");
             if (Length<=Element_Size-Element_Offset)
                 Skip_XX(Length,                                     "Text");
+            else
+                Skip_XX(Element_Size-Element_Offset,               "(Problem)");
         Element_End0();
     }
 

--- a/Source/MediaInfo/Image/File_AmigaIcon.cpp
+++ b/Source/MediaInfo/Image/File_AmigaIcon.cpp
@@ -133,14 +133,17 @@ void File_AmigaIcon::Read_Buffer_Continue()
     //DrawerData
     if (HasDrawerData)
     {
-        Element_Begin1("DrawerData");
-            Skip_XX(56,                                             "DrawerData");
-        Element_End0();
+        if (Element_Offset+56<=Element_Size)
+        {
+            Element_Begin1("DrawerData");
+                Skip_XX(56,                                         "DrawerData");
+            Element_End0();
+        }
     }
 
     //Classic image (normal)
     int16u ClassicWidth=0, ClassicHeight=0, ClassicDepth=0;
-    if (GadgetRender)
+    if (GadgetRender && Element_Offset+20<=Element_Size)
     {
         int16u ImgWidth, ImgHeight, ImgDepth;
         Element_Begin1("Classic image");
@@ -154,9 +157,12 @@ void File_AmigaIcon::Read_Buffer_Continue()
             Skip_B1(                                                "im_PlaneOnOff");
             Skip_B4(                                                "im_Next");
 
-            int64u PlaneDataSize=((int64u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
-            if (Element_Offset+PlaneDataSize<=Element_Size)
-                Skip_XX(PlaneDataSize,                              "Plane data");
+            if (ImgWidth>0 && ImgHeight>0 && ImgDepth>0 && ImgDepth<=8)
+            {
+                int64u PlaneDataSize=((int64u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
+                if (Element_Offset+PlaneDataSize<=Element_Size)
+                    Skip_XX(PlaneDataSize,                          "Plane data");
+            }
         Element_End0();
 
         ClassicWidth=ImgWidth;
@@ -165,7 +171,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
     }
 
     //Classic image (selected)
-    if (SelectRender)
+    if (SelectRender && Element_Offset+20<=Element_Size)
     {
         int16u ImgWidth, ImgHeight, ImgDepth;
         Element_Begin1("Classic image (selected)");
@@ -179,26 +185,30 @@ void File_AmigaIcon::Read_Buffer_Continue()
             Skip_B1(                                                "im_PlaneOnOff");
             Skip_B4(                                                "im_Next");
 
-            int64u PlaneDataSize=((int64u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
-            if (Element_Offset+PlaneDataSize<=Element_Size)
-                Skip_XX(PlaneDataSize,                              "Plane data");
+            if (ImgWidth>0 && ImgHeight>0 && ImgDepth>0 && ImgDepth<=8)
+            {
+                int64u PlaneDataSize=((int64u)((ImgWidth+15)/16)*2)*ImgHeight*ImgDepth;
+                if (Element_Offset+PlaneDataSize<=Element_Size)
+                    Skip_XX(PlaneDataSize,                          "Plane data");
+            }
         Element_End0();
     }
 
     //DefaultTool
-    if (HasDefaultTool)
+    if (HasDefaultTool && Element_Offset+4<=Element_Size)
     {
         int32u Length;
         Element_Begin1("DefaultTool");
             Get_B4 (Length,                                         "Length");
-            Skip_XX(Length,                                         "Text");
+            if (Element_Offset+Length<=Element_Size)
+                Skip_XX(Length,                                     "Text");
         Element_End0();
     }
 
     //ToolTypes
     bool HasNewIcon=false;
     int16u NewIconWidth=0, NewIconHeight=0;
-    if (HasToolTypes)
+    if (HasToolTypes && Element_Offset+4<=Element_Size)
     {
         int32u CountField;
         Element_Begin1("ToolTypes");
@@ -209,7 +219,7 @@ void File_AmigaIcon::Read_Buffer_Continue()
                 int32u NumEntries=CountField/4-1;
                 for (int32u i=0; i<NumEntries; i++)
                 {
-                    if (Element_Offset>=Element_Size)
+                    if (Element_Offset+4>Element_Size)
                         break;
 
                     int32u Length;
@@ -232,6 +242,8 @@ void File_AmigaIcon::Read_Buffer_Continue()
                         }
                     }
 
+                    if (Element_Offset+Length>Element_Size)
+                        break;
                     Skip_XX(Length,                                  "ToolType");
                 }
             }
@@ -239,12 +251,13 @@ void File_AmigaIcon::Read_Buffer_Continue()
     }
 
     //ToolWindow
-    if (HasToolWindow)
+    if (HasToolWindow && Element_Offset+4<=Element_Size)
     {
         int32u Length;
         Element_Begin1("ToolWindow");
             Get_B4 (Length,                                         "Length");
-            Skip_XX(Length,                                         "Text");
+            if (Element_Offset+Length<=Element_Size)
+                Skip_XX(Length,                                     "Text");
         Element_End0();
     }
 

--- a/Source/MediaInfo/Image/File_AmigaIcon.h
+++ b/Source/MediaInfo/Image/File_AmigaIcon.h
@@ -1,0 +1,41 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+//
+// Information about Amiga Icon files
+//
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+//---------------------------------------------------------------------------
+#ifndef MediaInfo_File_AmigaIconH
+#define MediaInfo_File_AmigaIconH
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "MediaInfo/File__Analyze.h"
+//---------------------------------------------------------------------------
+
+namespace MediaInfoLib
+{
+
+//***************************************************************************
+// Class File_AmigaIcon
+//***************************************************************************
+
+class File_AmigaIcon : public File__Analyze
+{
+protected :
+    //Buffer - File header
+    bool FileHeader_Begin();
+
+    //Buffer - Global
+    void Read_Buffer_Continue ();
+};
+
+} //NameSpace
+
+#endif

--- a/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
+++ b/Source/MediaInfo/MediaInfo_Config_Automatic.cpp
@@ -1520,6 +1520,7 @@ void MediaInfo_Config_Format (InfoMap &Info)
     "Wave;;;A;Riff;;act at9 wav;audio/vnd.wave\n"
     "Wave64;;;A;Riff;;w64\n"
     "WavPack;;;A;Wvpk;;wv wvc;;http://www.wavpack.com\n"
+    "Amiga Icon;;;I;AmigaIcon;Amiga Workbench Icon;info;image/x-amiga-icon;;Lossless\n"
     "APNG;;;I;Png;Animated Portable Network Graphic;apng png pns;image/apng;http://www.w3.org/TR/png/;Lossless\n"
     "Arri Raw;;;I;ArriRaw;;ari\n"
     "ARW;;;I;Tiff;Sony Alpha RAW;arw;image/x-sony-arw;http://www.sony.com/\n"

--- a/Source/MediaInfo/MediaInfo_File.cpp
+++ b/Source/MediaInfo/MediaInfo_File.cpp
@@ -364,6 +364,9 @@
 #if defined(MEDIAINFO_BPG_YES)
     #include "MediaInfo/Image/File_Bpg.h"
 #endif
+#if defined(MEDIAINFO_AMIGAICON_YES)
+    #include "MediaInfo/Image/File_AmigaIcon.h"
+#endif
 #if defined(MEDIAINFO_DDS_YES)
     #include "MediaInfo/Image/File_Dds.h"
 #endif
@@ -795,6 +798,9 @@ static File__Analyze* SelectFromExtension(const String& Parser)
     #if defined(MEDIAINFO_BPG_YES)
         if (Parser==__T("Bpg"))         return new File_Bpg();
     #endif
+    #if defined(MEDIAINFO_AMIGAICON_YES)
+        if (Parser==__T("AmigaIcon"))   return new File_AmigaIcon();
+    #endif
     #if defined(MEDIAINFO_DDS_YES)
         if (Parser==__T("Dds"))         return new File_Dds();
     #endif
@@ -1218,6 +1224,9 @@ int MediaInfo_Internal::ListFormats(const String &File_Name)
     #if defined(MEDIAINFO_BMP_YES)
         SAFE_DELETE(Info); Info=new File_Bmp();                if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1;
     #endif
+    #if defined(MEDIAINFO_AMIGAICON_YES)
+        SAFE_DELETE(Info); Info=new File_AmigaIcon();          if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1;
+    #endif
     #if defined(MEDIAINFO_BPG_YES)
         SAFE_DELETE(Info); Info=new File_Bpg();                if (((Reader_File*)Reader)->Format_Test_PerParser(this, File_Name)>0) return 1;
     #endif
@@ -1334,7 +1343,7 @@ bool MediaInfo_Internal::LibraryIsModified ()
      || defined(MEDIAINFO_AV1_NO) || defined(MEDIAINFO_AV2_NO) || defined(MEDIAINFO_AVC_NO) || defined(MEDIAINFO_AVS3V_NO) || defined(MEDIAINFO_AVSV_NO) || defined(MEDIAINFO_HEVC_NO) || defined(MEDIAINFO_MPEG4V_NO) || defined(MEDIAINFO_MPEGV_NO) || defined(MEDIAINFO_FLIC_NO) || defined(MEDIAINFO_THEORA_NO) || defined(MEDIAINFO_Y4M_NO) \
      || defined(MEDIAINFO_AC3_NO) || defined(MEDIAINFO_AC4_NO) || defined(MEDIAINFO_ADIF_NO) || defined(MEDIAINFO_ADTS_NO) || defined(MEDIAINFO_SMPTEST0337_NO) || defined(MEDIAINFO_AMR_NO) || defined(MEDIAINFO_DTS_NO) || defined(MEDIAINFO_DOLBYE_NO) || defined(MEDIAINFO_FLAC_NO) || defined(MEDIAINFO_IAMF_NO) || defined(MEDIAINFO_APE_NO) || defined(MEDIAINFO_MPC_NO) || defined(MEDIAINFO_MPCSV8_NO) || defined(MEDIAINFO_MPEGA_NO) || defined(MEDIAINFO_OPENMG_NO) || defined(MEDIAINFO_TWINVQ_NO) || defined(MEDIAINFO_XM_NO) || defined(MEDIAINFO_MOD_NO) || defined(MEDIAINFO_S3M_NO) || defined(MEDIAINFO_IT_NO) || defined(MEDIAINFO_SPEEX_NO) || defined(MEDIAINFO_TAK_NO) || defined(MEDIAINFO_PS2A_NO) \
      || defined(MEDIAINFO_CMML_NO)  || defined(MEDIAINFO_KATE_NO)  || defined(MEDIAINFO_PGS_NO) || defined(MEDIAINFO_OTHERTEXT_NO) \
-     || defined(MEDIAINFO_ARRIRAW_NO) || defined(MEDIAINFO_BMP_NO) || defined(MEDIAINFO_DDS_NO) || defined(MEDIAINFO_DPX_NO) || defined(MEDIAINFO_EXR_NO) || defined(MEDIAINFO_GIF_NO) || defined(MEDIAINFO_ICO_NO) || defined(MEDIAINFO_JPEG_NO) || defined(MEDIAINFO_PNG_NO) || defined(MEDIAINFO_TGA_NO) || defined(MEDIAINFO_TIFF_NO) || defined(MEDIAINFO_WEBP_NO) \
+     || defined(MEDIAINFO_AMIGAICON_NO) || defined(MEDIAINFO_ARRIRAW_NO) || defined(MEDIAINFO_BMP_NO) || defined(MEDIAINFO_DDS_NO) || defined(MEDIAINFO_DPX_NO) || defined(MEDIAINFO_EXR_NO) || defined(MEDIAINFO_GIF_NO) || defined(MEDIAINFO_ICO_NO) || defined(MEDIAINFO_JPEG_NO) || defined(MEDIAINFO_PNG_NO) || defined(MEDIAINFO_TGA_NO) || defined(MEDIAINFO_TIFF_NO) || defined(MEDIAINFO_WEBP_NO) \
      || defined(MEDIAINFO_7Z_NO) || defined(MEDIAINFO_ZIP_NO) || defined(MEDIAINFO_RAR_NO) || defined(MEDIAINFO_ACE_NO) || defined(MEDIAINFO_ELF_NO) || defined(MEDIAINFO_MACHO_NO) || defined(MEDIAINFO_MZ_NO) \
      || defined(MEDIAINFO_OTHER_NO) || defined(MEDIAINFO_DUMMY_NO)
         return true;

--- a/Source/MediaInfo/Setup.h
+++ b/Source/MediaInfo/Setup.h
@@ -915,6 +915,9 @@
 #if !defined(MEDIAINFO_IMAGE_NO) && !defined(MEDIAINFO_ARRIRAW_NO) && !defined(MEDIAINFO_ARRIRAW_YES)
     #define MEDIAINFO_ARRIRAW_YES
 #endif
+#if !defined(MEDIAINFO_IMAGE_NO) && !defined(MEDIAINFO_AMIGAICON_NO) && !defined(MEDIAINFO_AMIGAICON_YES)
+    #define MEDIAINFO_AMIGAICON_YES
+#endif
 #if !defined(MEDIAINFO_IMAGE_NO) && !defined(MEDIAINFO_BMP_NO) && !defined(MEDIAINFO_BMP_YES)
     #define MEDIAINFO_BMP_YES
 #endif


### PR DESCRIPTION
This PR adds support for 4 (of 5) different Amiga `.info` formats, as documented here:

http://www.evillabs.net/index.php/Amiga_Icon_Formats

The 5th type are concatenated PNG files with icon metadata inside the first image, they aren't included as part of this patch.

The code was tested first with basic icons here:

https://github.com/steffest/Amiga-Icon-converter/tree/master/test-icons

Then against 300k files extracted from Aminet's archives. MediaInfoLib is pretty robust, bad files detect in the latest version even if they're truncated. The command line doesn't like some of the file names though, which is a separate bug. The full suite of test data is available here:

https://github.com/bitplane/amiga-info-test-files

This was done as part of writing [this Python conversion library](https://github.com/bitplane/amigainfo); I wanted mediainfo to help me identify files for coverage purposes, and wrote this patch to help me.