### PR TITLE
Fixes for gcc 4.8.5 compatibility.

### DIFF
--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -420,8 +420,8 @@ struct FindReplaceCompany_struct {
 };
 
 static const FindReplaceCompany_struct Model_Replace[] = {
-    { "Canon", Model_Replace_Canon, {} },
-    { "OpenCube", Model_Replace_OpenCube, {} },
+    { "Canon", Model_Replace_Canon, nullptr },
+    { "OpenCube", Model_Replace_OpenCube, nullptr },
 }; 
 
 //---------------------------------------------------------------------------
@@ -2098,7 +2098,7 @@ static const FindReplaceCompany_struct Model_Name[] = {
     { "Sony", Model_Name_Sony, "Xperia " },
     { "Sony Ericsson", Model_Name_Sony_Ericsson, "Xperia " },
     { "Samsung", Model_Name_Samsung, "Galaxy " },
-    { "Xiaomi", Model_Name_Xiaomi, {} },
+    { "Xiaomi", Model_Name_Xiaomi, nullptr },
 };
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Trying to compile for legacy CentOS7/RHEL7 which is still in extended support for the latter with the stock gcc 4.8.5 compiler.

C++ 11 support of the compiler looks pretty complete to me so it _should_ work with this code:
https://en.cppreference.com/w/cpp/compiler_support/11.html
(only "Compiler support for type traits" seems to have partial support and got there with gcc version 5)

I fixed two minor issues that caused the following errors:
```
$ build_libmediainfo.sh |& grep error -A1
../../../Source/MediaInfo/File__Analyze_Streams_Finish.cpp:425:1: error: braces around scalar initializer for type ‘const char*’
 }; 
--
../../../Source/MediaInfo/File__Analyze_Streams_Finish.cpp:2102:1: error: braces around scalar initializer for type ‘const char*’
 };
--
../../../Source/ThirdParty/fmt/format.h:4108:16: error: missing space between ‘""’ and suffix identifier
 constexpr auto operator""_a(const char* s, size_t) -> detail::udl_arg<char> {
```

However there are still issues with some operator overloading stuff:
```
$ build_libmediainfo.sh |& grep error -A1
../../../Source/MediaInfo/Audio/File_Iamf.cpp:221:76: error: no match for ‘operator/’ (operand types are ‘std::initializer_list<long long unsigned int>’ and ‘ZenLib::float64 {aka double}’)
             Fill(Stream_Audio, 0, Audio_Duration, SamplesCountPerSubstream / (static_cast<float64>(SamplingRate) / 1000), 0);
--
../../../Source/MediaInfo/Audio/File_Iamf.cpp:223:88: error: no match for ‘operator/’ (operand types are ‘std::initializer_list<long long unsigned int>’ and ‘ZenLib::float64 {aka double}’)
             Fill(Stream_Audio, 0, Audio_BitRate, File_Size / (SamplesCountPerSubstream / static_cast<float64>(SamplingRate)) * 8, 0);
--
../../../Source/MediaInfo/Image/File_Png.cpp:1008:75: error: no match for call to ‘(std::initializer_list<MediaInfoLib::File_Png::Decode_RawProfile(const char*, size_t, const string&)::__lambda0>) (char*&, long unsigned int, long unsigned int&)’
     auto data = HexStringToBytes(end, in_len - (end - in), expected_length);
--
../../../Source/MediaInfo/Image/File_GainMap.cpp:81:25: error: no match for ‘operator<’ (operand types are ‘int’ and ‘std::initializer_list<int>’)
     for (int ch = 0; ch < channel_count; ++ch) {
--
../../../Source/MediaInfo/Image/File_GainMap.cpp:108:29: error: no match for ‘operator<’ (operand types are ‘int’ and ‘std::initializer_list<int>’)
         for (int ch = 0; ch < channel_count; ++ch) {
--
../../../Source/MediaInfo/Tag/File_Exif.cpp:1703:35: error: no match for ‘operator<’ (operand types are ‘const std::initializer_list<const double>’ and ‘double’)
                 if (exposure_time < 0.25001 && exposure_time > 0) {
--
../../../Source/MediaInfo/Tag/File_Exif.cpp:1703:62: error: no match for ‘operator>’ (operand types are ‘const std::initializer_list<const double>’ and ‘int’)
                 if (exposure_time < 0.25001 && exposure_time > 0) {
--
../../../Source/MediaInfo/Tag/File_Exif.cpp:1704:88: error: no match for ‘operator/’ (operand types are ‘int’ and ‘const std::initializer_list<const double>’)
                     ShutterSpeed_Time = "1/" + std::to_string(static_cast<int>(round(1 / exposure_time)));
--
../../../Source/MediaInfo/Tag/File_Exif.cpp:1707:69: error: no matching function for call to ‘to_string(const std::initializer_list<const double>&)’
                     ShutterSpeed_Time = std::to_string(exposure_time);
```

Is this something that could be looked at for improving portability? I wouldn't know how to fix the rest.