### PR TITLE
Avoid unintended initializer_list/auto deduction

### DIFF
--- a/Source/MediaInfo/Audio/File_Iamf.cpp
+++ b/Source/MediaInfo/Audio/File_Iamf.cpp
@@ -327,7 +327,7 @@ void File_Iamf::Streams_Finish()
         int32u SamplesPerFrame = Retrieve_Const(Stream_Audio, 0, Audio_SamplesPerFrame).To_int32u();
         if (SamplingRate && SamplesPerFrame)
         {
-            auto SamplesCountPerSubstream{ SamplesPerFrame * Frame_Count / substreams.size() };
+            int64u SamplesCountPerSubstream{ SamplesPerFrame * Frame_Count / substreams.size() };
             Fill(Stream_Audio, 0, Audio_Duration, SamplesCountPerSubstream / (static_cast<float64>(SamplingRate) / 1000), 0);
             Fill(Stream_Audio, 0, Audio_SamplingCount, SamplesPerFrame * Frame_Count);
             Fill(Stream_Audio, 0, Audio_BitRate, File_Size / (SamplesCountPerSubstream / static_cast<float64>(SamplingRate)) * 8, 0);

--- a/Source/MediaInfo/Image/File_GainMap.cpp
+++ b/Source/MediaInfo/Image/File_GainMap.cpp
@@ -69,7 +69,7 @@ void File_GainMap::Data_Parse()
     Get_B1(flags,                                               "flags");
     Get_Flags(flags, 6, use_base_colour_space,                  "use_base_colour_space");
     Get_Flags(flags, 7, is_multichannel,                        "is_multichannel");
-    auto channel_count{ is_multichannel ? 3 : 1 };
+    int channel_count{ is_multichannel ? 3 : 1 };
 
     int32u base_hdr_headroom_numerator, alternate_hdr_headroom_numerator, base_hdr_headroom_denominator{}, alternate_hdr_headroom_denominator{};
     int32s gain_map_min_numerator[3]{}, gain_map_max_numerator[3]{}, base_offset_n[3]{}, alternate_offset_n[3]{};

--- a/Source/MediaInfo/Image/File_Png.cpp
+++ b/Source/MediaInfo/Image/File_Png.cpp
@@ -1047,7 +1047,7 @@ void File_Png::Textual(bitset8 Method)
 void File_Png::Decode_RawProfile(const char* in, size_t in_len, const string& type)
 {
 #if defined(MEDIAINFO_EXIF_YES) || defined(MEDIAINFO_ICC_YES) || defined(MEDIAINFO_IIM_YES)
-    auto HexStringToBytes{
+    auto HexStringToBytes =
         [](const char* src, size_t len, size_t expected_length) -> string {
             string to_return;
             auto end = src + len;
@@ -1079,8 +1079,7 @@ void File_Png::Decode_RawProfile(const char* in, size_t in_len, const string& ty
                 return {};
             }
             return to_return;
-        }
-    };
+        };
 
     if (!in || !in_len) {
         return;

--- a/Source/MediaInfo/Tag/File_Exif.cpp
+++ b/Source/MediaInfo/Tag/File_Exif.cpp
@@ -1698,7 +1698,7 @@ void File_Exif::Streams_Finish()
             switch (Item.first) {
             case IFDExif::ExposureTime: {
                 ParameterC = "ShutterSpeed_Time";
-                const auto exposure_time{ Item.second.Read().To_float64() };
+                const float64 exposure_time{ Item.second.Read().To_float64() };
                 string ShutterSpeed_Time;
                 if (exposure_time < 0.25001 && exposure_time > 0) {
                     ShutterSpeed_Time = "1/" + std::to_string(static_cast<int>(round(1 / exposure_time)));


### PR DESCRIPTION
Some early C++11 implementations assume these are all std::initializer_lists which these are not.

Reported at: https://github.com/MediaArea/MediaInfoLib/pull/2559
