### PR TITLE
Integrity and other fixes

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac.cpp
+++ b/Source/MediaInfo/Audio/File_Aac.cpp
@@ -199,7 +199,6 @@ void File_Aac::Streams_Update()
 //---------------------------------------------------------------------------
 void File_Aac::Streams_Finish()
 {
-    std::bitset<32> sect_cb_used;
     for (int g = 0; g < num_window_groups; g++)
     {
         for (int8u i = 0; i < num_sec[g]; i++)

--- a/Source/MediaInfo/Audio/File_DtsUhd.cpp
+++ b/Source/MediaInfo/Audio/File_DtsUhd.cpp
@@ -627,8 +627,6 @@ int File_DtsUhd::ParseStaticMDParams(MD01* MD01, bool OnlyFirst)
         bool CustomDRCSmoothMDPresent;
         Get_SB (CustomDRCSmoothMDPresent,                       "CustomDRCSmoothMDPresent");
         if (CustomDRCSmoothMDPresent)
-            Skip_BS(6*6,                                        "CDRCProfiles");
-        if (CustomDRCSmoothMDPresent)
         {
             Skip_S1(6,                                          "FastAttack");
             Skip_S1(6,                                          "SlowAttack");

--- a/Source/MediaInfo/Audio/File_Usac.cpp
+++ b/Source/MediaInfo/Audio/File_Usac.cpp
@@ -2867,7 +2867,6 @@ void File_Usac::uniDrcConfigExtension()
                     #if MEDIAINFO_CONFORMANCE
                         if (C.drcSetEffect && (C.drcSetEffect & 0x27) != 0x27) // If one of the 8 first bits is set, bits (1 is LSB) 1, 2, 3, 6 must be set
                         {
-                            string Value;
                             for (int8u i = 0; i < 6; i++)
                             {
                                 if (!(C.drcSetEffect & (1 << i)))

--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -892,8 +892,7 @@ void File__Analyze::Open_Buffer_OutOfBand (File__Analyze* Sub, size_t Size)
     }
 
     //Sub
-    if (Sub->File_GoTo!=(int64u)-1)
-        Sub->File_GoTo=(int64u)-1;
+    Sub->File_GoTo=(int64u)-1;
     Sub->File_Offset=File_Offset+Buffer_Offset+Element_Offset;
     if (Sub->File_Size!=File_Size)
     {
@@ -1356,8 +1355,7 @@ void File__Analyze::Open_Buffer_Continue (File__Analyze* Sub, const int8u* ToAdd
         return;
 
     //Sub
-    if (Sub->File_GoTo!=(int64u)-1)
-        Sub->File_GoTo=(int64u)-1;
+    Sub->File_GoTo=(int64u)-1;
     if (Sub->MustAdaptSubOffsets) {
         auto NewOffset = File_Offset + Buffer_Offset + Element_Offset;
         auto OldOffset = Sub->File_Offset + Sub->Buffer_Size;

--- a/Source/MediaInfo/File__Analyze_Buffer.cpp
+++ b/Source/MediaInfo/File__Analyze_Buffer.cpp
@@ -49,14 +49,14 @@ extern MediaInfo_Config Config;
     } \
 
 #define INTEGRITY_SIZE_ATLEAST(_BYTES) \
-    if (Element_Offset+_BYTES>Element_Size) \
+    if (Element_Offset>Element_Size || _BYTES>Element_Size-Element_Offset) \
     { \
         Trusted_IsNot("Size is wrong"); \
         return; \
     } \
 
 #define INTEGRITY_SIZE_ATLEAST_STRING(_BYTES) \
-    if (Element_Offset+_BYTES>Element_Size) \
+    if (Element_Offset>Element_Size || _BYTES>Element_Size-Element_Offset) \
     { \
         Trusted_IsNot("Size is wrong"); \
         Info.clear(); \
@@ -64,7 +64,7 @@ extern MediaInfo_Config Config;
     } \
 
 #define INTEGRITY_SIZE_ATLEAST_INT(_BYTES) \
-    if (Element_Offset+_BYTES>Element_Size) \
+    if (Element_Offset>Element_Size || _BYTES>Element_Size-Element_Offset) \
     { \
         Trusted_IsNot("Size is wrong"); \
         Info=0; \
@@ -2069,7 +2069,7 @@ void File__Analyze::Skip_XX(int64u Bytes, const char* Name)
 {
     if (Element_Offset+Bytes!=Element_TotalSize_Get()) //Exception for seek to end of the element
     {
-        //INTEGRITY_SIZE_ATLEAST(Bytes);
+        INTEGRITY_SIZE_ATLEAST(Bytes);
     }
     if (Trace_Activated && Bytes) Param(Name, Ztring("(")+Ztring::ToZtring(Bytes)+Ztring(" bytes)"));
     Element_Offset+=Bytes;

--- a/Source/MediaInfo/File__Analyze_Buffer_MinimizeSize.cpp
+++ b/Source/MediaInfo/File__Analyze_Buffer_MinimizeSize.cpp
@@ -57,14 +57,14 @@ extern MediaInfo_Config Config;
     } \
 
 #define INTEGRITY_SIZE_ATLEAST(_BYTES) \
-    if (Element_Offset+_BYTES>Element_Size) \
+    if (Element_Offset>Element_Size || _BYTES>Element_Size-Element_Offset) \
     { \
         Trusted_IsNot(); \
         return; \
     } \
 
 #define INTEGRITY_SIZE_ATLEAST_STRING(_BYTES) \
-    if (Element_Offset+_BYTES>Element_Size) \
+    if (Element_Offset>Element_Size || _BYTES>Element_Size-Element_Offset) \
     { \
         Trusted_IsNot(); \
         Info.clear(); \
@@ -72,7 +72,7 @@ extern MediaInfo_Config Config;
     } \
 
 #define INTEGRITY_SIZE_ATLEAST_INT(_BYTES) \
-    if (Element_Offset+_BYTES>Element_Size) \
+    if (Element_Offset>Element_Size || _BYTES>Element_Size-Element_Offset) \
     { \
         Trusted_IsNot(); \
         Info=0; \

--- a/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams_Finish.cpp
@@ -4967,8 +4967,7 @@ void File__Analyze::Streams_Finish_InterStreams()
                 continue;
             for (size_t StreamPos=0; StreamPos<Count_Get((stream_t)StreamKind); StreamPos++)
             {
-                if (!IsValid)
-                    IsValid=true;
+                IsValid=true;
                 if (Retrieve((stream_t)StreamKind, StreamPos, Fill_Parameter((stream_t)StreamKind, Generic_BitRate_Mode))!=__T("CBR"))
                     IsCBR=false;
                 if (Retrieve((stream_t)StreamKind, StreamPos, Fill_Parameter((stream_t)StreamKind, Generic_BitRate_Mode))==__T("VBR"))

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -2517,6 +2517,8 @@ void File_Mpeg4::meta_idat()
     Element_Name("Item data");
 
     for (auto& item : idat_items) {
+        if (item.second.offset > Element_Size)
+            continue;
         Element_Begin1(Ztring().From_Number(item.first));
         Element_Offset = item.second.offset;
         Open_Buffer_Continue(item.second.parser.get(), item.second.length);
@@ -2596,7 +2598,7 @@ void File_Mpeg4::meta_iinf_infe()
     {
         case 0x6D696D65:    // mime
                             Get_String(SizeUpTo0(), content_type, "content_type");
-                            ++Element_Offset; //null
+                            Skip_B1(                            "zero");
                             if (Element_Offset<Element_Size)
                                 Skip_NulString(                 "content_encoding");
                             break;

--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -6025,7 +6025,6 @@ void File_Mpeg4::moov_trak_mdia_minf_stbl_stsd_xxxx()
         {
         case Elements::moov_trak_mdia_minf_stbl_stsd_mett:
         {
-            string mime_format;
             Element_Name("Metadata");
             Skip_String(SizeUpTo0(),                            "content_encoding");
             Skip_B1(                                            "zero");

--- a/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
@@ -106,7 +106,7 @@ static tag_struct Mpeg_Descriptors_video_properties_tag_1=
     {  9, 14,  0, 1},
     { 12,  1,  6, 1},
 };
-static int8u Mpeg_Descriptors_video_properties_tag_1_Size=sizeof(Mpeg_Descriptors_video_properties_tag_0)/sizeof(Mpeg_Descriptors_video_properties_tag_0[0]);
+static int8u Mpeg_Descriptors_video_properties_tag_1_Size=sizeof(Mpeg_Descriptors_video_properties_tag_1)/sizeof(Mpeg_Descriptors_video_properties_tag_1[0]);
 static tag_struct Mpeg_Descriptors_video_properties_tag_2=
 {
     {  9, 16,  9, 0},
@@ -115,7 +115,7 @@ static tag_struct Mpeg_Descriptors_video_properties_tag_2=
     {  9, 16,  0, 0},
     {  9, 18,  0, 0},
 };
-static int8u Mpeg_Descriptors_video_properties_tag_2_Size=sizeof(Mpeg_Descriptors_video_properties_tag_0)/sizeof(Mpeg_Descriptors_video_properties_tag_0[0]);
+static int8u Mpeg_Descriptors_video_properties_tag_2_Size=sizeof(Mpeg_Descriptors_video_properties_tag_2)/sizeof(Mpeg_Descriptors_video_properties_tag_2[0]);
 static int8u Mpeg_Descriptors_video_properties_tag_Sizes[]=
 {
     Mpeg_Descriptors_video_properties_tag_0_Size,

--- a/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp
@@ -3576,16 +3576,10 @@ void File_Mpeg_Descriptors::Descriptor_7F_06()
     Get_S1 (5, editorial_classification,                        "editorial_classification");
     Skip_SB(                                                    "reserved_future_use");
     Get_SB (language_code_present,                              "language_code_present");
-    if (language_code_present)
-    {
-        BS_End();
-        Get_Local (3, Language,                                 "ISO_639_language_code");
-        BS_Begin();
-    }
-    if (language_code_present)
-    if (Data_BS_Remain())
-        Skip_BS(Data_BS_Remain(),                               "private_data_bytes");
     BS_End();
+    if (language_code_present)
+        Get_Local (3, Language,                                 "ISO_639_language_code");
+    Skip_XX(Element_Size - Element_Offset,                      "private_data_bytes");
 
     FILLING_BEGIN();
         if (elementary_PID_IsValid)

--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -5035,8 +5035,7 @@ void File_Mxf::Read_Buffer_Unsynched()
         Partitions.erase(Partitions.end()-1);
         Partitions_IsCalculatingHeaderByteCount=false;
     }
-    if (Partitions_IsCalculatingSdtiByteCount)
-        Partitions_IsCalculatingSdtiByteCount=false;
+    Partitions_IsCalculatingSdtiByteCount=false;
 
     #if MEDIAINFO_SEEK
         IndexTables_Pos=0;

--- a/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Riff_Elements.cpp
@@ -3644,9 +3644,6 @@ struct profile_info
                         ToReturn+=',';
                         ToReturn+=' ';
                     }
-                }
-                if (i>=2)
-                {
                     ToReturn+=profile_names[i];
                     ToReturn+='=';
                 }

--- a/Source/MediaInfo/Text/File_Eia608.cpp
+++ b/Source/MediaInfo/Text/File_Eia608.cpp
@@ -1317,8 +1317,7 @@ void File_Eia608::Character_Fill(wchar_t Character)
     if (TextMode || !Stream.InBack)
         HasChanged();
 
-    if (!HasContent)
-        HasContent=true;
+    HasContent=true;
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Text/File_Eia708.cpp
+++ b/Source/MediaInfo/Text/File_Eia708.cpp
@@ -1488,8 +1488,7 @@ void File_Eia708::Character_Fill(wchar_t Character)
         Window->Minimal.x=x;
     }
 
-    if (!HasContent)
-        HasContent=true;
+    HasContent=true;
     if (!Streams[service_number]->HasContent)
         Streams[service_number]->HasContent=true;
 }

--- a/Source/MediaInfo/Text/File_Pac.cpp
+++ b/Source/MediaInfo/Text/File_Pac.cpp
@@ -571,7 +571,7 @@ void File_Pac::Data_Parse()
                             if (Value == '<') {
                                 ItalicBeginFound = true;
                             }
-                            if (Value == '<') {
+                            if (ItalicBeginFound && Value == '>') {
                                 CountOfCharsPerLine -= 2; // < and > are markers of italic
                                 ItalicBeginFound = false;
                             }

--- a/Source/MediaInfo/Video/File_Ffv1.cpp
+++ b/Source/MediaInfo/Video/File_Ffv1.cpp
@@ -1270,8 +1270,7 @@ void File_Ffv1::SliceContent(states &States)
 
     #if MEDIAINFO_TRACE
         bool Trace_Activated_Save=Trace_Activated;
-        if (Trace_Activated)
-            Trace_Activated=false; // Trace is too huge, deactivating it during pixel decoding
+        Trace_Activated=false; // Trace is too huge, deactivating it during pixel decoding
     #endif //MEDIAINFO_TRACE
 
     if (!coder_type)

--- a/Source/MediaInfo/Video/File_Mpegv.cpp
+++ b/Source/MediaInfo/Video/File_Mpegv.cpp
@@ -3118,8 +3118,7 @@ void File_Mpegv::slice_start_macroblock_block(int8u i)
                     Element_Info1(Mpegv_dct_coefficients[dct_coefficient].mapped_to2);
                     Element_Info1(Mpegv_dct_coefficients[dct_coefficient].mapped_to3);
         }
-        if (IsFirst)
-            IsFirst=false;
+        IsFirst=false;
         Element_Trace_End0();
     }
 }
@@ -4068,8 +4067,7 @@ void File_Mpegv::group_start()
         Time_Current_Seconds=60*60*Hours+60*Minutes+Seconds;
         Time_Current_Frames =Frames;
 
-        if (!group_start_IsParsed)
-            group_start_IsParsed=true;
+        group_start_IsParsed=true;
         if (!group_start_FirstPass)
         {
             group_start_FirstPass=true;


### PR DESCRIPTION
Improve integrity for parsing MP4 (codes I wrote previously).

Restore integrity check for `Skip_XX` and slightly improve it. I asked @JeromeMartinez at https://github.com/MediaArea/MediaInfoLib/pull/1922#discussion_r3054231681 previously about why it was removed but no reply so I just assume it was unintentionally removed for now.

Fix some issues found by static analysis.

Also fix https://github.com/MediaArea/MediaInfoLib/issues/2519 since it is still not fixed by @JeromeMartinez after almost 3 months.
