### PR TITLE
XMP: Rework trace

### DIFF
--- a/Source/MediaInfo/Image/File_Jpeg.cpp
+++ b/Source/MediaInfo/Image/File_Jpeg.cpp
@@ -1624,9 +1624,7 @@ void File_Jpeg::APP1_XMP()
     GainMap_metadata_Adobe.reset(new gm_data());
     MI.GainMapData = static_cast<gm_data*>(GainMap_metadata_Adobe.get());
     Open_Buffer_Init(&MI);
-    auto Element_Offset_Sav = Element_Offset;
     Open_Buffer_Continue(&MI);
-    Element_Offset = Element_Offset_Sav;
     Open_Buffer_Finalize(&MI);
     if (!GContainerItems.empty()) {
         int64u ImgOffset = 0;
@@ -1647,10 +1645,10 @@ void File_Jpeg::APP1_XMP()
             ImgOffset += Entry.Padding;
         }
     }
-    Element_Show(); //TODO: why is it needed?
     Merge(MI, Stream_General, 0, 0, false);
+    #else
+        Skip_UTF8(Element_Size - Element_Offset,                "XMP metadata");
     #endif
-    Skip_UTF8(Element_Size - Element_Offset,                    "XMP metadata");
 }
 
 //---------------------------------------------------------------------------
@@ -1684,7 +1682,6 @@ void File_Jpeg::APP1_XMP_Extension()
     Item->second.LastOffset += (int32u)(Element_Size - Element_Offset);
     auto& MI = *(File_Xmp*)Item->second.Parser.get();
     MI.Wait = Item->second.LastOffset < Size;
-    auto Element_Offset_Sav = Element_Offset;
     gc_items GContainerItems;
     MI.GContainerItems = &GContainerItems;
     Open_Buffer_Continue(&MI);
@@ -1708,10 +1705,9 @@ void File_Jpeg::APP1_XMP_Extension()
             ImgOffset += Entry.Padding;
         }
     }
-    Element_Offset = Element_Offset_Sav;
-    Element_Show();
+    #else
+        Skip_UTF8(Element_Size - Element_Offset,                "XMP metadata");
     #endif
-    Skip_UTF8(Element_Size - Element_Offset,                    "XMP metadata");
     return;
 }
 

--- a/Source/MediaInfo/Image/File_Png.cpp
+++ b/Source/MediaInfo/Image/File_Png.cpp
@@ -1024,10 +1024,11 @@ void File_Png::Textual(bitset8 Method)
             #if defined(MEDIAINFO_XMP_YES)
             auto Text_UTF8=Text.To_UTF8();
             File_Xmp MI;
+            MI.NoTrace = true; //Already have trace (Text string) from above
             Open_Buffer_Init(&MI, Text_UTF8.size());
             Open_Buffer_Continue(&MI, (const int8u*)Text_UTF8.c_str(), Text_UTF8.size());
             Open_Buffer_Finalize(&MI);
-            Element_Show(); //TODO: why is it needed?
+            Element_Show(); //Needed since element (including the previous trace) will be removed if sub parser has no trace output
             Merge(MI, Stream_General, 0, 0, false);
             Text.clear();
             #endif

--- a/Source/MediaInfo/Tag/File_Exif.cpp
+++ b/Source/MediaInfo/Tag/File_Exif.cpp
@@ -2472,14 +2472,12 @@ void File_Exif::XMP()
     #if defined(MEDIAINFO_XMP_YES)
     File_Xmp MI{};
     Open_Buffer_Init(&MI);
-    auto Element_Offset_Sav = Element_Offset;
     Open_Buffer_Continue(&MI);
-    Element_Offset = Element_Offset_Sav;
     Open_Buffer_Finalize(&MI);
-    Element_Show(); //TODO: why is it needed?
     Merge(MI, Stream_General, 0, 0, false);
-    #endif
+    #else
     Skip_UTF8(Element_Size - Element_Offset,                    "XMP metadata");
+    #endif
 }
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Tag/File_Exif.cpp
+++ b/Source/MediaInfo/Tag/File_Exif.cpp
@@ -2463,6 +2463,8 @@ void File_Exif::ICC_Profile()
     Open_Buffer_Init(ICC_Parser.get());
     Open_Buffer_Continue(ICC_Parser.get());
     Open_Buffer_Finalize(ICC_Parser.get());
+    #else
+    Skip_XX(Element_Size - Element_Offset,                      "ICC Profile");
     #endif
 }
 
@@ -2491,7 +2493,7 @@ void File_Exif::PhotoshopImageResources()
     Open_Buffer_Finalize(&MI);
     Merge(MI, Stream_General, 0, 0, false);
     #else
-    Skip_UTF8(Element_Size - Element_Offset,                    "Photoshop Tags");
+    Skip_XX(Element_Size - Element_Offset,                      "Photoshop Tags");
     #endif
 }
 
@@ -2506,7 +2508,7 @@ void File_Exif::IPTC_NAA()
     Open_Buffer_Finalize(&MI);
     Merge(MI, Stream_General, 0, 0, false);
     #else
-    Skip_UTF8(Element_Size - Element_Offset,                    "IPTC-NAA data");
+    Skip_XX(Element_Size - Element_Offset,                      "IPTC-NAA data");
     #endif
 }
 

--- a/Source/MediaInfo/Tag/File_Xmp.cpp
+++ b/Source/MediaInfo/Tag/File_Xmp.cpp
@@ -369,7 +369,6 @@ bool File_Xmp::FileHeader_Begin()
         Fill(Stream_General, 0, General_Format_Profile, Profile);
     }
 
-    Finish();
     return true;
 }
 
@@ -527,6 +526,17 @@ void File_Xmp::Iptc4xmpExt(const string& name, const string& value)
         Fill(Stream_General, 0, "DigitalSourceType/String", i < DigitalSourceTypes_size ? DigitalSourceTypes[i].Name : URI.c_str());
         Fill_SetOptions(Stream_General, 0, "DigitalSourceType/String", "Y NTN");
     }
+}
+
+//---------------------------------------------------------------------------
+void File_Xmp::Read_Buffer_Continue()
+{
+#if MEDIAINFO_TRACE
+    if (Trace_Activated && IsSub && !NoTrace) {
+        Skip_UTF8(Element_Size - Element_Offset,                "XMP metadata");
+    }
+#endif
+    Finish();
 }
 
 } //NameSpace

--- a/Source/MediaInfo/Tag/File_Xmp.h
+++ b/Source/MediaInfo/Tag/File_Xmp.h
@@ -57,12 +57,14 @@ class File_Xmp : public File__Analyze
 {
 public:
     bool Wait{ false };
+    bool NoTrace{ false };
     gc_items* GContainerItems{ nullptr };
     gm_data* GainMapData{ nullptr };
 
 private :
     //Buffer - File header
     bool FileHeader_Begin() override;
+    void Read_Buffer_Continue() override;
 
     //Element namespaces
     void dc(const string& name, const string& value);


### PR DESCRIPTION
Rework the XMP parser in regards to trace output. Now the trace output will be provided by XMP parser. This prevents the need of workarounds with manipulating `Element_Offset` and needing `Element_Show()`. Also enables trace output for ISOBMFF type of files.
