### PR TITLE
Matroska: support track flags from RFC 9559 (SDH, audio description, original, commentary)

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -127,6 +127,39 @@ namespace MediaInfoLib
 //***************************************************************************
 
 //---------------------------------------------------------------------------
+enum service_kind
+{
+    Service_HearingImpaired,
+    Service_VisuallyImpaired,
+    Service_TextDescriptions,
+    Service_Original,
+    Service_Commentary,
+    Service_Max,
+    Service_Default = Service_Max, // They are extra, actually not service
+    Service_Forced,
+};
+
+//---------------------------------------------------------------------------
+const char*  Matroska_ServiceKind[] =
+{
+    "HI",
+    "VI",
+    "TD",
+    "O",
+    "C",
+};
+
+//---------------------------------------------------------------------------
+const char* Matroska_ServiceKind_String[] =
+{
+    "Hearing Impaired",
+    "Visually Impaired",
+    "Text Descriptions",
+    "Original",
+    "Commentary",
+};
+
+//---------------------------------------------------------------------------
 #if MEDIAINFO_TRACE
     static const size_t MaxCountSameElementInTrace=10;
 #endif // MEDIAINFO_TRACE
@@ -241,6 +274,11 @@ namespace Elements
     const int64u Segment_Tracks_TrackEntry_FlagEnabled=0x39;
     const int64u Segment_Tracks_TrackEntry_FlagDefault=0x8;
     const int64u Segment_Tracks_TrackEntry_FlagForced=0x15AA;
+    const int64u Segment_Tracks_TrackEntry_FlagHearingImpaired=0x15AB;
+    const int64u Segment_Tracks_TrackEntry_FlagVisualImpaired=0x15AC;
+    const int64u Segment_Tracks_TrackEntry_FlagTextDescriptions=0x15AD;
+    const int64u Segment_Tracks_TrackEntry_FlagOriginal=0x15AE;
+    const int64u Segment_Tracks_TrackEntry_FlagCommentary=0x15AF;
     const int64u Segment_Tracks_TrackEntry_FlagLacing=0x1C;
     const int64u Segment_Tracks_TrackEntry_MinCache=0x2DE7;
     const int64u Segment_Tracks_TrackEntry_MaxCache=0x2DF8;
@@ -1411,8 +1449,14 @@ void File_Mk::Streams_Finish()
             Fill(Stream_Video, StreamPos_Last, Video_FrameRate, Temp->second.FrameRate, 3);
 
         //Flags
-        Fill(StreamKind_Last, StreamPos_Last, "Default", Temp->second.Default?"Yes":"No");
-        Fill(StreamKind_Last, StreamPos_Last, "Forced", Temp->second.Forced?"Yes":"No");
+        Fill(StreamKind_Last, StreamPos_Last, "Default", Temp->second.ServiceKind[Service_Default]?"Yes":"No");
+        Fill(StreamKind_Last, StreamPos_Last, "Forced", Temp->second.ServiceKind[Service_Forced]?"Yes":"No");
+        for (auto i = 0; i < Service_Max; i++) {
+            if (Temp->second.ServiceKind[i]) {
+                Fill(StreamKind_Last, StreamPos_Last, "ServiceKind", Matroska_ServiceKind[i]);
+                Fill(StreamKind_Last, StreamPos_Last, "ServiceKind/String", Matroska_ServiceKind_String[i]);
+            }
+        }
     }
 
     //Chapters
@@ -1894,6 +1938,11 @@ void File_Mk::Data_Parse()
                 ATO2(Segment_Tracks_TrackEntry_FlagEnabled, "FlagEnabled")
                 ATO2(Segment_Tracks_TrackEntry_FlagDefault, "FlagDefault")
                 ATO2(Segment_Tracks_TrackEntry_FlagForced, "FlagForced")
+                ATO2(Segment_Tracks_TrackEntry_FlagHearingImpaired, "FlagHearingImpaired")
+                ATO2(Segment_Tracks_TrackEntry_FlagVisualImpaired, "FlagVisualImpaired")
+                ATO2(Segment_Tracks_TrackEntry_FlagTextDescriptions, "FlagTextDescriptions")
+                ATO2(Segment_Tracks_TrackEntry_FlagOriginal, "FlagOriginal")
+                ATO2(Segment_Tracks_TrackEntry_FlagCommentary, "FlagCommentary")
                 ATO2(Segment_Tracks_TrackEntry_FlagLacing, "FlagLacing")
                 ATO2(Segment_Tracks_TrackEntry_MinCache, "MinCache")
                 ATO2(Segment_Tracks_TrackEntry_MaxCache, "MaxCache")
@@ -3508,6 +3557,7 @@ void File_Mk::Segment_Tracks_TrackEntry()
     Fill_Flush();
     Fill(StreamKind_Last, StreamPos_Last, "Language", "eng");
     Fill(StreamKind_Last, StreamPos_Last, General_StreamOrder, Stream.size());
+    Stream[(int64u)-1].ServiceKind[Service_Default] = true;
 }
 
 //---------------------------------------------------------------------------
@@ -4125,7 +4175,7 @@ void File_Mk::Segment_Tracks_TrackEntry_FlagDefault()
     FILLING_BEGIN();
         if (Segment_Info_Count>1)
             return; //First element has the priority
-        Stream[TrackNumber].Default=UInteger?true:false;
+        Stream[TrackNumber].ServiceKind[Service_Default]=UInteger?true:false;
     FILLING_END();
 }
 
@@ -4138,7 +4188,72 @@ void File_Mk::Segment_Tracks_TrackEntry_FlagForced()
     FILLING_BEGIN();
         if (Segment_Info_Count>1)
             return; //First element has the priority
-        Stream[TrackNumber].Forced=UInteger?true:false;
+        Stream[TrackNumber].ServiceKind[Service_Forced]=UInteger?true:false;
+    FILLING_END();
+}
+
+//---------------------------------------------------------------------------
+void File_Mk::Segment_Tracks_TrackEntry_FlagHearingImpaired()
+{
+    //Parsing
+    int64u UInteger=UInteger_Get();
+
+    FILLING_BEGIN();
+        if (Segment_Info_Count>1)
+            return; //First element has the priority
+        Stream[TrackNumber].ServiceKind[Service_HearingImpaired]=UInteger?true:false;
+    FILLING_END();
+}
+
+//---------------------------------------------------------------------------
+void File_Mk::Segment_Tracks_TrackEntry_FlagVisualImpaired()
+{
+    //Parsing
+    int64u UInteger=UInteger_Get();
+
+    FILLING_BEGIN();
+        if (Segment_Info_Count>1)
+            return; //First element has the priority
+        Stream[TrackNumber].ServiceKind[Service_VisuallyImpaired]=UInteger?true:false;
+    FILLING_END();
+}
+
+//---------------------------------------------------------------------------
+void File_Mk::Segment_Tracks_TrackEntry_FlagTextDescriptions()
+{
+    //Parsing
+    int64u UInteger=UInteger_Get();
+
+    FILLING_BEGIN();
+        if (Segment_Info_Count>1)
+            return; //First element has the priority
+        Stream[TrackNumber].ServiceKind[Service_TextDescriptions]=UInteger?true:false;
+    FILLING_END();
+}
+
+//---------------------------------------------------------------------------
+void File_Mk::Segment_Tracks_TrackEntry_FlagOriginal()
+{
+    //Parsing
+    int64u UInteger=UInteger_Get();
+
+    FILLING_BEGIN();
+        if (Segment_Info_Count>1)
+            return; //First element has the priority
+        Stream[TrackNumber].ServiceKind[Service_Original]=UInteger?true:false;
+    FILLING_END();
+}
+
+//---------------------------------------------------------------------------
+void File_Mk::Segment_Tracks_TrackEntry_FlagCommentary()
+{
+    //Parsing
+    int64u UInteger=UInteger_Get();
+
+    FILLING_BEGIN();
+        if (Segment_Info_Count>1)
+            return; //First element has the priority
+        Stream[TrackNumber].ServiceKind[Service_Commentary]=UInteger?true:false;
     FILLING_END();
 }
 

--- a/Source/MediaInfo/Multiple/File_Mk.h
+++ b/Source/MediaInfo/Multiple/File_Mk.h
@@ -17,6 +17,7 @@
 
 //---------------------------------------------------------------------------
 #include "MediaInfo/File__Analyze.h"
+#include <bitset>
 //---------------------------------------------------------------------------
 
 namespace MediaInfoLib
@@ -163,6 +164,11 @@ private :
     void Segment_Tracks_TrackEntry_FlagEnabled(){UInteger_Info();};
     void Segment_Tracks_TrackEntry_FlagDefault();
     void Segment_Tracks_TrackEntry_FlagForced();
+    void Segment_Tracks_TrackEntry_FlagHearingImpaired();
+    void Segment_Tracks_TrackEntry_FlagVisualImpaired();
+    void Segment_Tracks_TrackEntry_FlagTextDescriptions();
+    void Segment_Tracks_TrackEntry_FlagOriginal();
+    void Segment_Tracks_TrackEntry_FlagCommentary();
     void Segment_Tracks_TrackEntry_FlagLacing(){UInteger_Info();};
     void Segment_Tracks_TrackEntry_MinCache(){UInteger_Info();};
     void Segment_Tracks_TrackEntry_MaxCache(){UInteger_Info();};
@@ -387,8 +393,7 @@ private :
         bool                    Searching_Payload;
         bool                    Searching_TimeStamps;
         bool                    Searching_TimeStamp_Start;
-        bool                    Default;
-        bool                    Forced;
+        std::bitset<8>          ServiceKind;
         int64u                  ContentCompAlgo;
         size_t                  ContentCompSettings_Buffer_Size;
         int8u*                  ContentCompSettings_Buffer;
@@ -423,8 +428,6 @@ private :
             Searching_Payload=true;
             Searching_TimeStamps=false;
             Searching_TimeStamp_Start=false;
-            Default=true;
-            Forced=false;
             ContentCompAlgo=(int32u)-1;
             ContentCompSettings_Buffer_Size=0;
             ContentCompSettings_Buffer=NULL;


### PR DESCRIPTION
Implements the five track flags from [RFC 9559](https://www.rfc-editor.org/rfc/rfc9559#name-track-flags) that MediaInfo currently ignores: `HearingImpaired`, `VisualImpaired`, `TextDescriptions`, `Original`, `Commentary`.

Closes https://github.com/MediaArea/MediaInfo/issues/772

<img width="1057" height="597" alt="image" src="https://github.com/user-attachments/assets/69e70393-74ce-4134-8d46-2c3bd103b6e3" />

<img width="798" height="552" alt="image" src="https://github.com/user-attachments/assets/8f973b56-98be-4b3a-8d1e-c23e9b783870" />
