### PR TITLE
Improve reading of part title and position

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Mpeg4_Elements.cpp
@@ -4126,6 +4126,11 @@ void File_Mpeg4::moov_meta_ilst_xxxx_data()
                         else if (Value==__T("143583")) Value=__T("Fiji Islands");
                         else if (Value==__T("143597")) Value=__T("Papua New Guinea");
                     }
+                    if (Parameter=="DISCSUBTITLE")
+                    {
+                        Fill(Stream_General, 0, General_Part, Value);
+                        Parameter.clear(); //Set as already filled
+                    }
                     if (!Parameter.empty())
                     {
                         Element_Info1(Parameter.c_str());

--- a/Source/MediaInfo/Multiple/File_Wm_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Wm_Elements.cpp
@@ -1252,6 +1252,8 @@ void File_Wm::Header_ExtendedContentDescription()
                 else
                     Fill(Stream_General, 0, General_Part_Position, Value);
             }
+            else if (Name==__T("WM/SetSubTitle"))
+                Fill(Stream_General, 0, General_Part, Value);
             else if (Name==__T("WM/Provider"))
                 Fill(Stream_General, 0, "Provider", Value);
             else if (Name==__T("WM/Publisher"))

--- a/Source/MediaInfo/Multiple/File_Wm_Elements.cpp
+++ b/Source/MediaInfo/Multiple/File_Wm_Elements.cpp
@@ -1243,6 +1243,15 @@ void File_Wm::Header_ExtendedContentDescription()
                 Fill(Stream_General, 0, General_LawRating, Value);
             else if (Name==__T("WM/ParentalRatingReason"))
                 Fill(Stream_General, 0, General_LawRating_Reason, Value);
+            else if (Name==__T("WM/PartOfSet")) {
+                if (Value.find(__T('/'))!=Error)
+                {
+                    Fill(Stream_General, 0, General_Part_Position_Total, Value.SubString(__T("/"), __T("")));
+                    Fill(Stream_General, 0, General_Part_Position, Value.SubString(__T(""), __T("/")));
+                }
+                else
+                    Fill(Stream_General, 0, General_Part_Position, Value);
+            }
             else if (Name==__T("WM/Provider"))
                 Fill(Stream_General, 0, "Provider", Value);
             else if (Name==__T("WM/Publisher"))

--- a/Source/MediaInfo/Tag/File_ApeTag.cpp
+++ b/Source/MediaInfo/Tag/File_ApeTag.cpp
@@ -163,7 +163,7 @@ void File_ApeTag::Data_Parse()
                                         Fill(Stream_General, 0, General_Part_Position, Value.SubString(__T(""), __T("/")));
                                     }
                                     else
-                                        Fill(Stream_General, 0, General_Track_Position, Value);
+                                        Fill(Stream_General, 0, General_Part_Position, Value);
     }
     else if (Key=="ENCODEDBY")      Fill(Stream_General, 0, General_EncodedBy, Value);
     else if (Key=="GENRE")          Fill(Stream_General, 0, General_Genre, Value);

--- a/Source/MediaInfo/Tag/File_ApeTag.cpp
+++ b/Source/MediaInfo/Tag/File_ApeTag.cpp
@@ -155,7 +155,7 @@ void File_ApeTag::Data_Parse()
     else if (Key=="COMPOSER")       Fill(Stream_General, 0, General_Composer, Value);
     else if (Key=="CONTENTGROUP")   Fill(Stream_General, 0, General_Genre, Value);
     else if (Key=="COPYRIGHT")      Fill(Stream_General, 0, General_Copyright, Value);
-    else if (Key=="DISK")
+    else if (Key=="DISK" || Key=="DISC")
     {
                                     if (Value.find(__T('/'))!=Error)
                                     {

--- a/Source/MediaInfo/Tag/File_ApeTag.cpp
+++ b/Source/MediaInfo/Tag/File_ApeTag.cpp
@@ -165,6 +165,7 @@ void File_ApeTag::Data_Parse()
                                     else
                                         Fill(Stream_General, 0, General_Part_Position, Value);
     }
+    else if (Key=="DISCSUBTITLE")   Fill(Stream_General, 0, General_Part, Value);
     else if (Key=="ENCODEDBY")      Fill(Stream_General, 0, General_EncodedBy, Value);
     else if (Key=="GENRE")          Fill(Stream_General, 0, General_Genre, Value);
     else if (Key=="LYRICS")         Fill(Stream_General, 0, General_Lyrics, Value);

--- a/Source/MediaInfo/Tag/File_Id3v2.cpp
+++ b/Source/MediaInfo/Tag/File_Id3v2.cpp
@@ -1303,7 +1303,7 @@ void File_Id3v2::Fill_Name()
         case Elements::TSOT : Fill(Stream_General, 0, General_Track_Sort, Element_Value); break;
         case Elements::TSRC : Fill(Stream_General, 0, General_ISRC, Element_Value); break;
         case Elements::TSSE : Fill(Stream_General, 0, General_Encoded_Library, Element_Value); break;
-        case Elements::TSST : Fill(Stream_General, 0, "Set subtitle", Element_Value); break;
+        case Elements::TSST : Fill(Stream_General, 0, General_Part, Element_Value); break;
         case Elements::TXXX : if (Element_Values(0)==__T("AccurateRipResult"))      ;
                          else if (Element_Values(0)==__T("AccurateRipDiscID"))      ;
                          else if (Element_Values(0)==__T("CT_GAPLESS_DATA"))        ;

--- a/Source/MediaInfo/Tag/File_VorbisCom.cpp
+++ b/Source/MediaInfo/Tag/File_VorbisCom.cpp
@@ -265,9 +265,18 @@ void File_VorbisCom::Data_Parse()
                 Fill(StreamKind_Common, 0, "Encoded_Date", Encoded_Date+__T(' ')+Encoded_Time);
         }
         else if (Key==__T("DESCRIPTION"))            Fill(StreamKind_Common,   0, "Description", Value);
-        else if (Key==__T("DISC"))                   Fill(StreamKind_Common,   0, "Part", Value, true);
-        else if (Key==__T("DISCNUMBER"))             Fill(StreamKind_Common,   0, "Part", Value, true);
-        else if (Key==__T("DISCTOTAL"))              {if (Value!=Retrieve(StreamKind_Common, 0, "Part/Position_Total")) Fill(StreamKind_Common,   0, "Part/Position_Total", Value);}
+        else if (Key==__T("DISC"))
+        {
+            if (Value.find(__T('/'))!=Error)
+            {
+                Fill(Stream_General, 0, General_Part_Position_Total, Value.SubString(__T("/"), __T("")));
+                Fill(Stream_General, 0, General_Part_Position, Value.SubString(__T(""), __T("/")));
+            }
+            else
+                Fill(Stream_General, 0, General_Part_Position, Value);
+        }
+        else if (Key==__T("DISCNUMBER"))             Fill(StreamKind_Common,   0, General_Part_Position, Value, true);
+        else if (Key==__T("DISCTOTAL"))              {if (Value!=Retrieve(StreamKind_Common, 0, General_Part_Position_Total)) Fill(StreamKind_Common,   0, General_Part_Position_Total, Value);}
         else if (Key==__T("ENCODEDBY"))              Fill(StreamKind_Common,   0, "EncodedBy", Value);
         else if (Key==__T("ENCODED-BY"))             Fill(StreamKind_Common,   0, "EncodedBy", Value);
         else if (Key==__T("ENCODER"))                Fill(StreamKind_Common,   0, "Encoded_Application", Value);
@@ -327,7 +336,7 @@ void File_VorbisCom::Data_Parse()
             }
         }
         else if (Key==__T("TOTALTRACKS"))            {if (Value!=Retrieve(StreamKind_Common, 0, "Track/Position_Total")) Fill(StreamKind_Common,   0, "Track/Position_Total", Value);}
-        else if (Key==__T("TOTALDISCS"))             {if (Value!=Retrieve(StreamKind_Common, 0, "Part/Position_Total")) Fill(StreamKind_Common,   0, "Part/Position_Total", Value);}
+        else if (Key==__T("TOTALDISCS"))             {if (Value!=Retrieve(StreamKind_Common, 0, General_Part_Position_Total)) Fill(StreamKind_Common,   0, General_Part_Position_Total, Value);}
         else if (Key==__T("TRACK_COMMENT"))          Fill(StreamKind_Multiple, 0, "Comment", Value);
         else if (Key==__T("TRACKNUMBER"))            Fill(StreamKind_Multiple, 0, "Track/Position", Value);
         else if (Key==__T("TRACKTOTAL"))             {if (Value!=Retrieve(StreamKind_Common, 0, "Track/Position_Total")) Fill(StreamKind_Multiple, 0, "Track/Position_Total", Value);}

--- a/Source/MediaInfo/Tag/File_VorbisCom.cpp
+++ b/Source/MediaInfo/Tag/File_VorbisCom.cpp
@@ -276,6 +276,7 @@ void File_VorbisCom::Data_Parse()
                 Fill(Stream_General, 0, General_Part_Position, Value);
         }
         else if (Key==__T("DISCNUMBER"))             Fill(StreamKind_Common,   0, General_Part_Position, Value, true);
+        else if (Key==__T("DISCSUBTITLE"))           Fill(StreamKind_Common,   0, General_Part, Value, true);
         else if (Key==__T("DISCTOTAL"))              {if (Value!=Retrieve(StreamKind_Common, 0, General_Part_Position_Total)) Fill(StreamKind_Common,   0, General_Part_Position_Total, Value);}
         else if (Key==__T("ENCODEDBY"))              Fill(StreamKind_Common,   0, "EncodedBy", Value);
         else if (Key==__T("ENCODED-BY"))             Fill(StreamKind_Common,   0, "EncodedBy", Value);

--- a/Source/MediaInfo/Tag/File_VorbisCom.cpp
+++ b/Source/MediaInfo/Tag/File_VorbisCom.cpp
@@ -267,15 +267,18 @@ void File_VorbisCom::Data_Parse()
         else if (Key==__T("DESCRIPTION"))            Fill(StreamKind_Common,   0, "Description", Value);
         else if (Key==__T("DISC"))
         {
-            if (Value.find(__T('/'))!=Error)
+            auto SlashPos=Value.find(__T('/'));
+            if (SlashPos!=Error)
             {
-                Fill(Stream_General, 0, General_Part_Position_Total, Value.SubString(__T("/"), __T("")));
-                Fill(Stream_General, 0, General_Part_Position, Value.SubString(__T(""), __T("/")));
+                auto Position_Total=Value.substr(SlashPos + 1);
+                auto Position=Value.substr(0, SlashPos);
+                {if (Position_Total!=Retrieve(StreamKind_Common, 0, General_Part_Position_Total)) Fill(Stream_General, 0, General_Part_Position_Total, Position_Total);}
+                {if (Position!=Retrieve(StreamKind_Common, 0, General_Part_Position)) Fill(Stream_General, 0, General_Part_Position, Position);}
             }
             else
-                Fill(Stream_General, 0, General_Part_Position, Value);
+                {if (Value!=Retrieve(StreamKind_Common, 0, General_Part_Position)) Fill(Stream_General, 0, General_Part_Position, Value);}
         }
-        else if (Key==__T("DISCNUMBER"))             Fill(StreamKind_Common,   0, General_Part_Position, Value, true);
+        else if (Key==__T("DISCNUMBER"))             {if (Value!=Retrieve(StreamKind_Common, 0, General_Part_Position)) Fill(StreamKind_Common,   0, General_Part_Position, Value, true);}
         else if (Key==__T("DISCSUBTITLE"))           Fill(StreamKind_Common,   0, General_Part, Value, true);
         else if (Key==__T("DISCTOTAL"))              {if (Value!=Retrieve(StreamKind_Common, 0, General_Part_Position_Total)) Fill(StreamKind_Common,   0, General_Part_Position_Total, Value);}
         else if (Key==__T("ENCODEDBY"))              Fill(StreamKind_Common,   0, "EncodedBy", Value);


### PR DESCRIPTION
I noticed that the Part, Part/Position and Part/Position_Total fields were not consistently read across formats. This is my attempt of cleaning that up and extending support for Part (disc subtitle) to more formats.

Each commit has a description and links to relevant documentation.