### PR TITLE
VorbisCom/MKV: Map ENCODER_OPTIONS from opusenc

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -3436,6 +3436,7 @@ void File_Mk::Segment_Tags_Tag_SimpleTag_Assign()
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("ENCODED_BY")) Segment_Tag_SimpleTag_TagNames[0]=__T("EncodedBy");
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("ENCODER")) Segment_Tag_SimpleTag_TagNames[0]=__T("Encoded_Library");
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("ENCODER_SETTINGS")) Segment_Tag_SimpleTag_TagNames[0]=__T("Encoded_Library_Settings");
+    if (Segment_Tag_SimpleTag_TagNames[0]==__T("ENCODER_OPTIONS")) Segment_Tag_SimpleTag_TagNames[0]=__T("Encoded_Library_Settings");
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("FPS")) Segment_Tag_SimpleTag_TagNames[0].clear(); //Useless
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("GENRE")) Segment_Tag_SimpleTag_TagNames[0]=__T("Genre");
     if (Segment_Tag_SimpleTag_TagNames[0]==__T("HANDLER_NAME"))

--- a/Source/MediaInfo/Tag/File_VorbisCom.cpp
+++ b/Source/MediaInfo/Tag/File_VorbisCom.cpp
@@ -271,6 +271,7 @@ void File_VorbisCom::Data_Parse()
         else if (Key==__T("ENCODEDBY"))              Fill(StreamKind_Common,   0, "EncodedBy", Value);
         else if (Key==__T("ENCODED-BY"))             Fill(StreamKind_Common,   0, "EncodedBy", Value);
         else if (Key==__T("ENCODER"))                Fill(StreamKind_Common,   0, "Encoded_Application", Value);
+        else if (Key==__T("ENCODER_OPTIONS"))        Fill(StreamKind_Specific, 0, "Encoded_Library_Settings", Value);
         else if (Key==__T("ENCODED_USING"))          Fill(StreamKind_Common,   0, "Encoded_Application", Value);
         else if (Key==__T("ENCODER_URL"))            Fill(StreamKind_Common,   0, "Encoded_Application/Url", Value);
         else if (Key==__T("ENSEMBLE"))               Accompaniments.push_back(Value);


### PR DESCRIPTION
Not sure if this is completely accurate since the options may include options for container/tags and not only the audio bit-stream but there is no Encoded_Application_Settings or Encoded_Application_Options field. The English output of "Encoding settings" does look correct. After muxing to MKV, writing application became writing library anyway.

```
General
Complete name                            : output.opus
Format                                   : Ogg
File size                                : 34.7 KiB
Duration                                 : 1 s 7 ms
Overall bit rate                         : 282 kb/s
Writing application                      : opusenc from opus-tools 0.2-3-gf5f571b
Encoding settings                        : --bitrate 256

Audio
ID                                       : 14367 (0x381F)
Format                                   : Opus
Duration                                 : 1 s 7 ms
Channel(s)                               : 1 channel
Channel layout                           : M
Sampling rate                            : 44.1 kHz
Compression mode                         : Lossy
Writing library                          : libopus 1.3, libopusenc 0.2.1

General
Unique ID                                : 22595686730095185697598689122717531042 (0x10FFC55E35387461D96682E83A5BFBA2)
Complete name                            : output.mka
Format                                   : Matroska
Format version                           : Version 4
File size                                : 39.6 KiB
Duration                                 : 1 s 6 ms
Overall bit rate                         : 323 kb/s
Encoded date                             : 2026-05-09 07:49:25 UTC
Writing application                      : mkvmerge 95.0 ('Goodbye Stranger') 64-bit
Writing library                          : libebml v1.4.5 + libmatroska v1.7.1

Audio
ID                                       : 1
Format                                   : Opus
Codec ID                                 : A_OPUS
Duration                                 : 1 s 6 ms
Bit rate                                 : 274 kb/s
Channel(s)                               : 1 channel
Channel layout                           : M
Sampling rate                            : 44.1 kHz
Frame rate                               : 50.671 FPS (870 SPF)
Compression mode                         : Lossy
Stream size                              : 33.7 KiB (85%)
Writing library                          : opusenc from opus-tools 0.2-3-gf5f571b
Encoding settings                        : --bitrate 256
Default                                  : Yes
Forced                                   : No

```
