### PR TITLE
Fix missing const in buffer API

### DIFF
--- a/Source/MediaInfoDLL/MediaInfoDLL-rs/src/lib.rs
+++ b/Source/MediaInfoDLL/MediaInfoDLL-rs/src/lib.rs
@@ -87,15 +87,7 @@ impl MediaInfo {
     ) -> usize {
         let begin_ptr = begin.as_ptr();
         let end_ptr = end.as_ptr();
-        unsafe {
-            MediaInfoA_Open_Buffer(
-                self.handle,
-                begin_ptr as *mut MediaInfo_int8u,
-                begin_size,
-                end_ptr as *mut MediaInfo_int8u,
-                end_size,
-            )
-        }
+        unsafe { MediaInfoA_Open_Buffer(self.handle, begin_ptr, begin_size, end_ptr, end_size) }
     }
 
     /// Open a stream and collect information about it (technical information and tags)
@@ -130,13 +122,7 @@ impl MediaInfo {
     ///         bit 16-31: User defined
     pub fn open_buffer_continue(&self, buffer: &[u8], buffer_size: usize) -> usize {
         let buffer_ptr = buffer.as_ptr();
-        unsafe {
-            MediaInfoA_Open_Buffer_Continue(
-                self.handle,
-                buffer_ptr as *mut MediaInfo_int8u,
-                buffer_size,
-            )
-        }
+        unsafe { MediaInfoA_Open_Buffer_Continue(self.handle, buffer_ptr, buffer_size) }
     }
 
     /// Open a stream and collect information about it (technical information and tags)
@@ -409,15 +395,7 @@ impl MediaInfoList {
     ) -> usize {
         let begin_ptr = begin.as_ptr();
         let end_ptr = end.as_ptr();
-        unsafe {
-            MediaInfoListA_Open_Buffer(
-                self.handle,
-                begin_ptr as *mut MediaInfo_int8u,
-                begin_size,
-                end_ptr as *mut MediaInfo_int8u,
-                end_size,
-            )
-        }
+        unsafe { MediaInfoListA_Open_Buffer(self.handle, begin_ptr, begin_size, end_ptr, end_size) }
     }
 
     /// Close a file opened before with Open() (without saving)

--- a/Source/MediaInfoDLL/MediaInfoDLL.cpp
+++ b/Source/MediaInfoDLL/MediaInfoDLL.cpp
@@ -394,7 +394,7 @@ size_t          __stdcall MediaInfoA_Open_Buffer_Init (void* Handle, MediaInfo_i
     return MediaInfo_Open_Buffer_Init(Handle, File_Size, File_Offset);
 }
 
-size_t          __stdcall MediaInfoA_Open_Buffer_Continue (void* Handle, MediaInfo_int8u* Buffer, size_t Buffer_Size)
+size_t          __stdcall MediaInfoA_Open_Buffer_Continue (void* Handle, const MediaInfo_int8u* Buffer, size_t Buffer_Size)
 {
     return MediaInfo_Open_Buffer_Continue(Handle, Buffer, Buffer_Size);
 }
@@ -665,7 +665,7 @@ size_t          __stdcall MediaInfo_Open_Buffer_Init (void* Handle, MediaInfo_in
                     Debug+=", File_Size=";Debug+=Ztring::ToZtring(File_Size).To_UTF8();Debug+=", File_Offset=";Debug+=Ztring::ToZtring(File_Offset).To_UTF8();)
 }
 
-size_t          __stdcall MediaInfo_Open_Buffer_Continue (void* Handle, MediaInfo_int8u* Buffer, size_t Buffer_Size)
+size_t          __stdcall MediaInfo_Open_Buffer_Continue (void* Handle, const MediaInfo_int8u* Buffer, size_t Buffer_Size)
 {
     MANAGE_SIZE_T(  "Open_Buffer_Continue",
                     MediaInfo,

--- a/Source/MediaInfoDLL/MediaInfoDLL_Static.h
+++ b/Source/MediaInfoDLL/MediaInfoDLL_Static.h
@@ -246,7 +246,7 @@ MEDIAINFO_EXP size_t            __stdcall MediaInfo_Open_Buffer (void* Handle, c
 /** @brief Wrapper for MediaInfoLib::MediaInfo::Open (with a buffer, Init) */
 MEDIAINFO_EXP size_t            __stdcall MediaInfo_Open_Buffer_Init (void* Handle, MediaInfo_int64u File_Size, MediaInfo_int64u File_Offset);
 /** @brief Wrapper for MediaInfoLib::MediaInfo::Open (with a buffer, Continue) */
-MEDIAINFO_EXP size_t            __stdcall MediaInfo_Open_Buffer_Continue (void* Handle, MediaInfo_int8u* Buffer, size_t Buffer_Size);
+MEDIAINFO_EXP size_t            __stdcall MediaInfo_Open_Buffer_Continue (void* Handle, const MediaInfo_int8u* Buffer, size_t Buffer_Size);
 /** @brief Wrapper for MediaInfoLib::MediaInfo::Open (with a buffer, Continue_GoTo_Get) */
 MEDIAINFO_EXP MediaInfo_int64u  __stdcall MediaInfo_Open_Buffer_Continue_GoTo_Get (void* Handle);
 /** @brief Wrapper for MediaInfoLib::MediaInfo::Open (with a buffer, Finalize) */
@@ -315,7 +315,7 @@ MEDIAINFO_EXP size_t            __stdcall MediaInfoA_Open_Buffer (void* Handle, 
 /** @brief Wrapper for MediaInfoLib::MediaInfo::Open (with a buffer, Init) */
 MEDIAINFO_EXP size_t            __stdcall MediaInfoA_Open_Buffer_Init (void* Handle, MediaInfo_int64u File_Size, MediaInfo_int64u File_Offset);
 /** @brief Wrapper for MediaInfoLib::MediaInfo::Open (with a buffer, Continue) */
-MEDIAINFO_EXP size_t            __stdcall MediaInfoA_Open_Buffer_Continue (void* Handle, MediaInfo_int8u* Buffer, size_t Buffer_Size);
+MEDIAINFO_EXP size_t            __stdcall MediaInfoA_Open_Buffer_Continue (void* Handle, const MediaInfo_int8u* Buffer, size_t Buffer_Size);
 /** @brief Wrapper for MediaInfoLib::MediaInfo::Open (with a buffer, Continue_GoTo_Get) */
 MEDIAINFO_EXP MediaInfo_int64u  __stdcall MediaInfoA_Open_Buffer_Continue_GoTo_Get (void* Handle);
 /** @brief Wrapper for MediaInfoLib::MediaInfo::Open (with a buffer, Finalize) */


### PR DESCRIPTION
Should not break anything since it is C API. Passing non-const buffer to it will still work but now can pass const buffer to it without doing "dangerous" casting away of const and callers will know it is guaranteed not to modify the buffer.