### PR TITLE
JPEG: improve support of future content embedded in GContainer, update

### DIFF
--- a/Source/MediaInfo/Image/File_Jpeg.cpp
+++ b/Source/MediaInfo/Image/File_Jpeg.cpp
@@ -360,9 +360,9 @@ void File_Jpeg::Streams_Accept_PerImage(const seek_item& Item)
     Fill(StreamKind_Last, StreamPos_Last, Fill_Parameter(StreamKind_Last, Generic_Format), Format);
     Fill(StreamKind_Last, StreamPos_Last, "Type", Item.Type[0]);
     Fill(StreamKind_Last, StreamPos_Last, "Type", Item.Type[1]);
-    Fill(StreamKind_Last, StreamPos_Last, "MuxingMode", MuxingMode);
     Fill(StreamKind_Last, StreamPos_Last, "MuxingMode", Item.MuxingMode[0]);
     Fill(StreamKind_Last, StreamPos_Last, "MuxingMode", Item.MuxingMode[1]);
+    Fill(StreamKind_Last, StreamPos_Last, "MuxingMode", MuxingMode);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
video is in an MP4 then referenced by GContainer, so order should be:

```
Video
Muxing mode                              : GContainer XMP / MPEG-4
Stream size                              : 3.26 MiB (39%)
Type                                     : MotionPhoto
```