### PR TITLE
Vorbis: Call BS_End_LE before early returns

### DIFF
--- a/Source/MediaInfo/Audio/File_Vorbis.cpp
+++ b/Source/MediaInfo/Audio/File_Vorbis.cpp
@@ -135,8 +135,10 @@ void File_Vorbis::Setup()
     {
         Element_Begin1("codebook");
         Get_T4 (24, codebook,                                   "codebook");
-        if (codebook!=0x564342)
+        if (codebook!=0x564342) {
+            BS_End_LE();
             return;
+        }
         Get_BT (16, codebook_dimensions,                        "codebook_dimensions");
         Get_BT (24, codebook_entries,                           "codebook_entries");
         Get_BT (1, ordered,                                     "ordered");
@@ -172,8 +174,10 @@ void File_Vorbis::Setup()
             }
         }
         Get_BT (4, codebook_lookup_type,                        "codebook_lookup_type");
-        if (codebook_lookup_type>2)
+        if (codebook_lookup_type>2) {
+            BS_End_LE();
             return; //Not decodable
+        }
         if (codebook_lookup_type>0)
         {
             int8u codebook_value_bits;

--- a/Source/MediaInfo/File__Analyze.cpp
+++ b/Source/MediaInfo/File__Analyze.cpp
@@ -1972,6 +1972,7 @@ void File__Analyze::Buffer_Clear()
 {
     //Buffer
     BS->Attach(NULL, 0);
+    BT->Attach(NULL, 0);
     delete[] Buffer_Temp; Buffer_Temp=NULL;
     if (!Status[IsFinished])
         File_Offset+=Buffer_Size;
@@ -2857,6 +2858,7 @@ bool File__Analyze::Data_Manage()
         //size_t Element_Level_Save=Element_Level;
         Data_Parse();
         BS->Attach(NULL, 0); //Clear it
+        BT->Attach(NULL, 0); //Clear it
         //Element_Level=Element_Level_Save;
 
         if (Buffer_Offset+(Element_WantNextLevel?Element_Offset:Element_Size)>=FrameInfo.Buffer_Offset_End)

--- a/Source/MediaInfo/File__Analyze_Streams.cpp
+++ b/Source/MediaInfo/File__Analyze_Streams.cpp
@@ -3806,6 +3806,8 @@ void File__Analyze::FileSize_FileSize123(stream_t StreamKind, size_t StreamPos, 
         case  2 : Measure=__T(" MiB");  MeasureIsAlwaysSame=true;  break;
         case  3 : Measure=__T(" GiB");  MeasureIsAlwaysSame=true;  break;
         case  4 : Measure=__T(" TiB");  MeasureIsAlwaysSame=true;  break;
+        case  5 : Measure=__T(" PiB");  MeasureIsAlwaysSame=true;  break;
+        case  6 : Measure=__T(" EiB");  MeasureIsAlwaysSame=true;  break;
         default : Measure=__T(" ?iB");  MeasureIsAlwaysSame=true;
     }
     Fill(StreamKind, StreamPos, Parameter+2, MediaInfoLib::Config.Language_Get(Ztring::ToZtring(F1,  0), Measure, MeasureIsAlwaysSame), true); // /String1


### PR DESCRIPTION
Ensure the bitstream is properly ended before early returns in Vorbis parsing.

Fix https://github.com/MediaArea/MediaInfoLib/issues/2609
Fix https://github.com/MediaArea/MediaInfoLib/issues/2613
