### PR TITLE
AAC: fix undefined behavior in AAC teardown when parsing is aborted…

### DIFF
--- a/Source/MediaInfo/Audio/File_Aac.cpp
+++ b/Source/MediaInfo/Audio/File_Aac.cpp
@@ -97,6 +97,7 @@ File_Aac::File_Aac()
     audioMuxVersionA=false;
 
     //Temp - General Audio
+    num_window_groups=0;
     sbr=NULL;
     ps=NULL;
     raw_data_block_Pos=0;


### PR DESCRIPTION
# Summary
  
Initialize `num_window_groups` to 0 in the `File_Aac` constructor to prevent undefined behavior when teardown occurs before any AAC channel element has been parsed.

`num_window_groups` was left uninitialized, so the PNS detection loop in `Streams_Finish()` would read garbage indices into the `num_sec[]/sect_cb[]` arrays if reached before
`ics_info()/section_data()` had written those members. Depending on the garbage value, this ranges from a silent wrong result to an out-of-bounds read.

# Trigger

The buffer API (`Open_Buffer_Init / Open_Buffer_Continue / Open_Buffer_Finalize`) supplied with only a bounded prefix of an MP4+AAC file — a documented usage pattern for metadata
extraction without fetching the full asset. Truncated AAC files and any other early parse abort reach the same teardown state.

# Fix

Zero-initialize num_window_groups so the loop is a no-op when teardown precedes any channel element parse.