### PR TITLE
x DTS: fix infinite loop in Extensions() when handler overflows asset boundary

### DIFF
--- a/Source/MediaInfo/Audio/File_Dts.cpp
+++ b/Source/MediaInfo/Audio/File_Dts.cpp
@@ -1692,6 +1692,8 @@ void File_Dts::Extensions()
                 default:
                     Extensions_Resynch(false);
             }
+            if (Element_Offset>Element_Size)
+                Element_Offset=Element_Size; //Prevent unsigned underflow in loop condition if handler left offset past asset boundary
             Element_End0();
         }
         Element_Size=Element_Size_Save;

--- a/Source/MediaInfo/Audio/File_Dts.cpp
+++ b/Source/MediaInfo/Audio/File_Dts.cpp
@@ -1948,6 +1948,13 @@ void File_Dts::XLL()
         return;
     }
     auto Element_Size_Save=Element_Size;
+    if (Element_Offset_Start-3+LLFrameSize>Element_Size_Save)
+    {
+        BS_End();
+        Element_End0();
+        Skip_XX(Element_Size-Element_Offset,                    "(Unknown)");
+        return;
+    }
     Element_Size=Element_Offset_Start-3+LLFrameSize;
     Get_S1 (4, NumChSetsInFrame,                                "NumChSetsInFrame");
     NumChSetsInFrame++; Param_Info1(NumChSetsInFrame);


### PR DESCRIPTION
  ## Problem

  MediaInfo 26.05 hangs indefinitely when parsing the attached MKV file that contains both DTS-HD MA audio and an attachment (an SRT subtitle file). Version 26.01 handled this file without issue. Remuxing using mkvmerge does not help.

  ## Root Cause
  
  `Extensions()` iterates DTS extension assets with an **unsigned** while-loop condition:

  ```cpp
  while (Element_Size - Element_Offset >= 4)
  ```

  XLL() temporarily expands Element_Size to cover the full XLL frame. If parsing fails inside XLL() (e.g. a segment-size mismatch causes Trusted_IsNot() to fire), Element_Offset is set to the expanded Element_Size. XLL() then restores Element_Size = Element_Size_Save (the smaller outer asset boundary), leaving Element_Offset > Element_Size. The unsigned subtraction wraps to ~2^64, and the loop runs forever.
  
  This regression was introduced by commit 892a9a6, which restored the Skip_XX integrity check that calls Trusted_IsNot().

  ## Fix
  
  Clamp Element_Offset to Element_Size after each extension handler call, before Element_End0(). One line added.

  Reproduction

  I have an MKV with a DTS-HD MA audio track and an attached file (srt) that will reproduce the hang with mediainfo 26.05.

[Test.mkv.zip](https://github.com/user-attachments/files/28468713/Test.mkv.zip)