### PR TITLE
MP3: detect headerless VBR after parsing finishes

### DIFF
--- a/Source/MediaInfo/Audio/File_Mpega.cpp
+++ b/Source/MediaInfo/Audio/File_Mpega.cpp
@@ -458,6 +458,14 @@ void File_Mpega::Streams_Finish()
         }
     }
 
+    //VBR detection without header
+    //BitRate_Count may have changed after Streams_Fill() sampled the first frames.
+    if (VBR_Frames==0)
+    {
+        if (BitRate_Count.size()>1)
+            BitRate_Mode=__T("VBR");
+    }
+
     //Bitrate calculation if VBR
     int64u FrameCount=0;
     if (VBR_Frames>0)


### PR DESCRIPTION
## Headerless MP3 with late bitrate change is incorrectly reported as CBR

MediaInfoLib reports a headerless MP3 as CBR when its first frames use one bitrate but later frames use different bitrates.

This occurs with both the default `ParseSpeed` and `ParseSpeed=1.0`.

### Reproduction

Use an MP3 without Xing, Info, or VBRI metadata. The file should begin with CBR frames and switch to VBR frames later.

Example fixture structure:

- First 30 seconds: CBR MP3 at 128 kbps
- Final 30 seconds: VBR MP3
- No Xing, Info, or VBRI header

[kalimba_60s_cbr_then_vbr_no_xing.mp3](https://github.com/user-attachments/files/28491215/kalimba_60s_cbr_then_vbr_no_xing.mp3)

Run:

```bash
mediainfo --Output=JSON kalimba_60s_cbr_then_vbr_no_xing.mp3
```

The audio stream reports:
"BitRate_Mode": "CBR"

Expected result:
"BitRate_Mode": "VBR"


## Problem

`File_Mpega::Streams_Fill()` detects headerless VBR files by checking whether more than one bitrate has been observed:

```cpp
if (BitRate_Count.size()>1)
    BitRate_Mode=__T("VBR");
```

This check runs after the initial frames are parsed. If those frames all use the same bitrate, the stream is initially classified as CBR.

Later frames continue to update BitRate_Count, including frames inspected after the default tail seek. However, the bitrate mode is not re-evaluated during finalization.

As a result, a headerless MP3 that begins with CBR frames and changes bitrate later can incorrectly remain classified as CBR.