### PR TITLE
Configure: Missing D for FMT_UNICODE define

### DIFF
--- a/Project/GNU/Library/configure.ac
+++ b/Project/GNU/Library/configure.ac
@@ -981,7 +981,7 @@ dnl Unicode
 dnl
 if test "$enable_unicode" = "yes"; then
 	CXXFLAGS="$CXXFLAGS -DUNICODE"
-	MediaInfoLib_CXXFLAGS="$MediaInfoLib_CXXFLAGS -DUNICODE -FMT_UNICODE=0"
+	MediaInfoLib_CXXFLAGS="$MediaInfoLib_CXXFLAGS -DUNICODE -DFMT_UNICODE=0"
 	MediaInfoLib_Unicode="yes"
 else
 	MediaInfoLib_Unicode="no"


### PR DESCRIPTION
Causes `ld: warning: search path 'MT_UNICODE=0' not found` at MediaInfo CLI macOS CI build as well.
