### PR TITLE
Matroska: preserve LanguageIETF priority regardless of element order

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mk.cpp
+++ b/Source/MediaInfo/Multiple/File_Mk.cpp
@@ -3562,6 +3562,7 @@ void File_Mk::Segment_Tracks_TrackEntry()
     TrackType=(int64u)-1;
     TrackNumber=(int64u)-1;
     AudioBitDepth=(int64u)-1;
+    TrackHasLanguageIETF=false;
     TrackVideoDisplayWidth=0;
     TrackVideoDisplayHeight=0;
     AvgBytesPerSec=0;
@@ -4282,6 +4283,24 @@ void File_Mk::Segment_Tracks_TrackEntry_Language()
     FILLING_BEGIN();
         if (Segment_Info_Count>1)
             return; //First element has the priority
+        if (TrackHasLanguageIETF)
+            return;
+        Fill(StreamKind_Last, StreamPos_Last, "Language", Data, true);
+    FILLING_END();
+}
+
+//---------------------------------------------------------------------------
+void File_Mk::Segment_Tracks_TrackEntry_LanguageIETF()
+{
+    //Parsing
+    Ztring Data=String_Get();
+
+    FILLING_BEGIN();
+        if (Segment_Info_Count>1)
+            return; //First element has the priority
+        if (Data.empty())
+            return;
+        TrackHasLanguageIETF=true;
         Fill(StreamKind_Last, StreamPos_Last, "Language", Data, true);
     FILLING_END();
 }

--- a/Source/MediaInfo/Multiple/File_Mk.h
+++ b/Source/MediaInfo/Multiple/File_Mk.h
@@ -180,7 +180,7 @@ private :
     void Segment_Tracks_TrackEntry_MaxBlockAdditionID(){UInteger_Info();};
     void Segment_Tracks_TrackEntry_Name();
     void Segment_Tracks_TrackEntry_Language();
-    void Segment_Tracks_TrackEntry_LanguageIETF(){Segment_Tracks_TrackEntry_Language();};
+    void Segment_Tracks_TrackEntry_LanguageIETF();
     void Segment_Tracks_TrackEntry_CodecID();
     void Segment_Tracks_TrackEntry_CodecPrivate();
     void Segment_Tracks_TrackEntry_CodecName(){UTF8_Info();};
@@ -478,6 +478,7 @@ private :
     void     CodecID_Manage();
     int64u   TrackType{};
     int64u   AudioBitDepth{};
+    bool     TrackHasLanguageIETF{};
 
     //Temp - BlockAddition
     int64u  BlockAddIDType;


### PR DESCRIPTION
## Summary

Preserves a Matroska track's `LanguageIETF` value regardless of whether the legacy `Language` element appears before or after it.

`LanguageIETF` is now handled separately and takes precedence over `Language` for the current `TrackEntry`.

This applies consistently to video, audio and text tracks.

## Why

Previously, both elements used the same handler. When `LanguageIETF` appeared first, a later legacy `Language` element could overwrite a specific BCP 47 tag such as `en-US` with `eng` / `en`.

## Validation

- Confirmed the change is limited to the Matroska parser.
- Preserved the repository's CRLF line endings.
- `git diff --check` passes.

Related to MediaArea/MediaInfo#1295
