### PR TITLE
Fix trace for Extended XMP chunks

### DIFF
--- a/Source/MediaInfo/Image/File_Jpeg.cpp
+++ b/Source/MediaInfo/Image/File_Jpeg.cpp
@@ -1798,6 +1798,8 @@ void File_Jpeg::APP1_XMP_Extension()
     Item->second.LastOffset += (int32u)(Element_Size - Element_Offset);
     auto& MI = *(File_Xmp*)Item->second.Parser.get();
     MI.Wait = Item->second.LastOffset < Size;
+    auto Element_Offset_Sav = Element_Offset;
+    MI.NoTrace = true; // Handle trace here to see each chunk
     gc_items GContainerItems;
     MI.GContainerItems = &GContainerItems;
     Open_Buffer_Continue(&MI);
@@ -1821,9 +1823,10 @@ void File_Jpeg::APP1_XMP_Extension()
             ImgOffset += Entry.Padding;
         }
     }
-    #else
-        Skip_UTF8(Element_Size - Element_Offset,                "XMP metadata");
+    Element_Offset = Element_Offset_Sav;
+    Element_Show();
     #endif
+    Skip_UTF8(Element_Size - Element_Offset,                    "XMP metadata");
     return;
 }
 


### PR DESCRIPTION
Regression due to https://github.com/MediaArea/MediaInfoLib/pull/2571. For extended XMP we need to handle trace in JPEG. If we do it in XMP, will end up showing full assembled XMP in the last chunk and the other chunks are completely not shown due to empty trace from XMP parser. So revert to previous and add NoTrace = true to disable trace from XMP parser to show all chunks and actual contents on each chunk in Trace.