### PR TITLE
Mpega: use --lowpass in reconstructed LAME settings

### DIFF
--- a/Source/MediaInfo/Audio/File_Mpega.cpp
+++ b/Source/MediaInfo/Audio/File_Mpega.cpp
@@ -1559,7 +1559,7 @@ void File_Mpega::Header_Encoders_Lame()
                 Encoded_Library_Settings+=__T( " -q ")+Ztring::ToZtring((100-Xing_Scale)%10);
             }
             if (lowpass)
-                Encoded_Library_Settings+=(Encoded_Library_Settings.empty()?__T("-lowpass "):__T(" -lowpass "))+((lowpass%10)?Ztring::ToZtring(((float)lowpass)/10, 1):Ztring::ToZtring(lowpass/10));
+                Encoded_Library_Settings+=(Encoded_Library_Settings.empty()?__T("--lowpass "):__T(" --lowpass "))+((lowpass%10)?Ztring::ToZtring(((float)lowpass)/10, 1):Ztring::ToZtring(lowpass/10));
             switch (Flags&0x0F)
             {
                 case  2 :


### PR DESCRIPTION
Use --lowpass instead of -lowpass for consistency with other reconstructed long options such as --abr, --vbr-old and --vbr-new.

### Why?

The LAME Info tag stores only the numeric lowpass value (e.g., `205` for 20.5 kHz), not the original command-line string. MediaInfo synthesizes a human-readable representation of the encoder settings.

Other long options in the same function are already reconstructed with double dashes:
- `--abr`
- `--vbr-old`
- `--vbr-new`
- `--vbr-mt`

LAME uses `--lowpass` as the canonical long option name. Using `--lowpass` makes the reconstructed settings consistent with both LAME's current documentation and the other long options already present in this function.

### Important notes

- This field (`Encoded_Library_Settings`) is a **reconstructed** human-readable string, not the original command line used during encoding.
- Only the display format changes; no parsing logic or tag reading is modified.
- The change affects only files containing a LAME Info tag with a non-zero lowpass value.

### Compatibility

This changes the textual output of `Encoded_Library_Settings`. Tools that parse this exact string and expect `-lowpass` will need to be updated. However, since this field is documented as a reconstructed approximation rather than a verbatim CLI dump, the impact should be limited.

### Testing

Verified with LAME-encoded MP3 files containing lowpass values. The reconstructed settings now consistently use `--` for lowpass options.