### PR TITLE
PAC: Maximum count of characters per line, update

### DIFF
--- a/Source/MediaInfo/Text/File_Pac.cpp
+++ b/Source/MediaInfo/Text/File_Pac.cpp
@@ -159,18 +159,14 @@ void File_Pac::Streams_Finish()
         Fill(Stream_Text, 0, Text_Duration_Start2End, Start2End);
     }
     Fill(Stream_Text, 0, Text_Delay, (int64s)(Delay_TC.IsValid()?Delay_TC:Offset).ToMilliseconds());
-
-    if (Frame_Count) {
-        Fill(Stream_Text, 0, Text_Events_Total, Frame_Count - EmptyCount);
-    }
-    if (LineCount) {
+    const auto Events_Total = Frame_Count - EmptyCount;
+    Fill(Stream_Text, 0, Text_Events_Total, Events_Total);
+    if (Events_Total) {
         Fill(Stream_Text, 0, Text_Lines_Count, LineCount);
-    }
-    if (LineCount) {
-        Fill(Stream_Text, 0, Text_Lines_MaxCountPerEvent, MaxCountOfLinesPerFrame);
-    }
-    if (MaxCountOfCharsPerLine) {
-        Fill(Stream_Text, 0, Text_Lines_MaxCharacterCount, MaxCountOfCharsPerLine);
+        if (LineCount) {
+            Fill(Stream_Text, 0, Text_Lines_MaxCountPerEvent, MaxCountOfLinesPerFrame);
+            Fill(Stream_Text, 0, Text_Lines_MaxCharacterCount, MaxCountOfCharsPerLine);
+        }
     }
     if (Count_UTF8) {
         Fill(Stream_Text, 0, "CharacterSet", "UTF-8");


### PR DESCRIPTION
Coherency with other formats, we show event count even if lines are empty, and no line count if the line is empty.