### PR TITLE
Mpega: fix reconstructed settings for LAME CBR 256 and 320 kbps

### DIFF
--- a/Source/MediaInfo/Audio/File_Mpega.cpp
+++ b/Source/MediaInfo/Audio/File_Mpega.cpp
@@ -1555,7 +1555,8 @@ void File_Mpega::Header_Encoders_Lame()
             }
             if (Xing_Scale<=100) //Xing_Scale is used for LAME quality
             {
-                Encoded_Library_Settings+=__T( " -V ")+Ztring::ToZtring((100-Xing_Scale)/10);
+                if ((Flags & 0x0F) == 3 || (Flags & 0x0F) == 4 || (Flags & 0x0F) == 5 || (Flags & 0x0F) == 6 || (Flags & 0x0F) == 9) //VBR modes only
+                    Encoded_Library_Settings+=__T( " -V ")+Ztring::ToZtring((100-Xing_Scale)/10);
                 Encoded_Library_Settings+=__T( " -q ")+Ztring::ToZtring((100-Xing_Scale)%10);
             }
             if (lowpass)
@@ -1593,6 +1594,17 @@ void File_Mpega::Header_Encoders_Lame()
                         Encoded_Library_Settings+=__T(" -b ")+Ztring::ToZtring(BitRate);
                         break;
                     default : ;
+                }
+            }
+            else if (BitRate==0xFF) //Fallback for CBR bitrates that do not fit in the LAME tag byte (e.g. 256/320)
+            {
+                if ((Flags&0x0F)==1 || (Flags&0x0F)==8) //CBR mode only
+                {
+                    if (ID<4 && layer<4 && bitrate_index<16 && Mpega_BitRate[ID][layer][bitrate_index]!=0)
+                    {
+                        int16u FrameBitRate=Mpega_BitRate[ID][layer][bitrate_index];
+                        Encoded_Library_Settings+=__T(" -b ")+Ztring::ToZtring(FrameBitRate);
+                    }
                 }
             }
         FILLING_END();


### PR DESCRIPTION

Fixes #2518

### Description

This PR fixes two issues in `File_Mpega::Header_Encoders_Lame()` related to
the reconstructed `Encoded_Library_Settings` for CBR files encoded with LAME.

### Issue 1: `-V` is incorrectly added for CBR files

When `Xing_Scale <= 100`, MediaInfo always adds both `-V` and `-q`.
However, `-V` is a VBR quality setting and should not be added for CBR files.
The `-q` parameter (algorithmic quality) applies to all LAME encoding modes
and is kept.

**Fix:** only add `-V` for VBR methods (3, 4, 5, 6, 9).

### Issue 2: missing `-b 256` and `-b 320` for CBR files

The LAME Info Tag stores the bitrate in one byte (max 255). For CBR bitrates
above 255 kbps, LAME writes `0xFF` as a placeholder. MediaInfo explicitly
skips `0xFF`, so `-b 256` and `-b 320` disappear from the output.

**Fix:** fall back to `Mpega_BitRate[ID][layer][bitrate_index]` from the
MPEG frame header when the LAME Info Tag bitrate byte is `0xFF` and the
method is CBR.

This fallback is **not applied to ABR**, because the first frame of an ABR
file is an Info frame with a fixed dummy bitrate unrelated to the target ABR
value. Using the fallback for ABR would produce incorrect output such as
`--abr 128` instead of `--abr 320`. Therefore, ABR files with target bitrate
higher than 255 kbps remain a known limitation.

### Related: cosmetic fix already merged

The single-dash vs double-dash issue (`-lowpass` → `--lowpass`) was already
fixed in commit 4f2ea7db (PR #2658). The examples below reflect that fix.

### Before / After

For `lame -b 320 input.wav output.mp3`:

```text
Before: Encoding settings : -m j -V 4 -q 3 --lowpass 20.5
After:  Encoding settings : -m j -q 3 --lowpass 20.5 -b 320
```

For `lame -b 256 input.wav output.mp3`:

```text
Before: Encoding settings : -m j -V 4 -q 3 --lowpass 19.7
After:  Encoding settings : -m j -q 3 --lowpass 19.7 -b 256
```

For `lame -b 128 input.wav output.mp3` (unchanged):

```text
Before: Encoding settings : -m j -V 4 -q 3 --lowpass 17 -b 128
After:  Encoding settings : -m j -q 3 --lowpass 17 -b 128
```

VBR files are unaffected.