### PR TITLE
MXF: Fix OP47 Teletext not being probed as a Text track for short-duration files.

### DIFF
--- a/Source/MediaInfo/Multiple/File_Mxf.cpp
+++ b/Source/MediaInfo/Multiple/File_Mxf.cpp
@@ -16044,16 +16044,29 @@ bool File_Mxf::BookMark_Needed()
                 ProbeCaptionByteDur=ContentSize/100*Probe.Duration;
                 break;
         }
-        auto MaxOffset=ProbeCaptionBytePos+ProbeCaptionByteDur;
-        auto CurrentEnd=File_Offset+Buffer_Offset;
-        if (ProbeCaptionBytePos!=(int64u)-1 && ProbeCaptionByteDur!=(int64u)-1 && File_Size/2>ProbeCaptionByteDur)
+        if (ProbeCaptionBytePos!=(int64u)-1 && ProbeCaptionByteDur!=(int64u)-1)
         {
-            IsParsingMiddle_MaxOffset=MaxOffset;
-            GoTo(ProbeCaptionBytePos);
-            Open_Buffer_Unsynch();
-            IsParsingEnd=false;
-            IsCheckingRandomAccessTable=false;
-            Streams_Count=(size_t)-1;
+            if (File_Size/2<ProbeCaptionByteDur &&
+                HeaderSize+ContentSize-ProbeCaptionBytePos>0x4000000 && ContentSize/2>0x4000000)
+            {
+                // Clamp probe window to file size as long as it can be at least
+                // 64 MB. (For example, if a file is under 60 seconds total and
+                // is probed with the default duration window of 30 seconds,
+                // then there will be less than 30s of content after the halfway
+                // point of the file.)
+                ProbeCaptionByteDur=std::min(HeaderSize+ContentSize-ProbeCaptionBytePos, ContentSize/2);
+            }
+            auto MaxOffset=ProbeCaptionBytePos+ProbeCaptionByteDur;
+            auto CurrentEnd=File_Offset+Buffer_Offset;
+            if (File_Size/2>=ProbeCaptionByteDur)
+            {
+                IsParsingMiddle_MaxOffset=MaxOffset;
+                GoTo(ProbeCaptionBytePos);
+                Open_Buffer_Unsynch();
+                IsParsingEnd=false;
+                IsCheckingRandomAccessTable=false;
+                Streams_Count=(size_t)-1;
+            }
         }
     }
 


### PR DESCRIPTION
This fixes a regression from commit 6e03ccb27a293dc5. Prior to this commit, MXF would do a supplemental probe of 64 MiB at the midpoint of the file to identify captions. After this commit, the supplemental probe's start-point and window-size were made configurable, defaulting to a start-point of 50% by byte- offset and a window size of 30 seconds (extrapolated from average bitrate.)

However, for very short files, there may not _be_ 30 more seconds of content after the midpoint of the file. This commit handles that scenario by clamping the size of the probe window so it fits in the file, rather than skipping the probe altogether.

Symptom of the regression is that, for short duration MXF files containing OP47 Teletext, the "Text" track goes missing from the output after commit 6e03ccb27a293dc5. (Sometimes I have seen it still reported as an "Other" track, which I still consider regressed behavior; other times it's completely gone.)

I have created this test file to reproduce the bug; you are free to keep it and use it for regression testing or any other purpose.  
[op47_teletext_regression_for_mediainfo.mxf.gz](https://github.com/user-attachments/files/31496017/op47_teletext_regression_for_mediainfo.mxf.gz)  
Bad output (note, the `Text` track is missing)
```
~$ mediainfo /tmp/op47_teletext_regression_for_mediainfo.mxf 
General
Complete name                            : /tmp/op47_teletext_regression_for_mediainfo.mxf
Format                                   : MXF
Commercial name                          : AVC-Intra 100
Format version                           : 1.3
Format profile                           : OP-1a
Format settings                          : Closed / Complete
File size                                : 407 MiB
Duration                                 : 30 s 30 ms
Overall bit rate                         : 114 Mb/s
Frame rate                               : 29.970 FPS
Encoded date                             : 2026-08-27 01:54:45.188
Writing application                      : Elemental Server 2.18.0.0.1
Writing library                          : libMXF (Linux 64-bit) 1.1.0.0.0

Video
ID                                       : 1001
Format                                   : AVC
Format/Info                              : Advanced Video Codec
Commercial name                          : AVC-Intra 100
Format profile                           : High 4:2:2 Intra@L4.1
Format settings, CABAC                   : No
Format settings, GOP                     : N=1
Format settings, wrapping mode           : Frame
Format settings, Slice count             : 10 slices per frame
Codec ID                                 : 0D01030102106001-0401020201323103
Duration                                 : 30 s 30 ms
Bit rate mode                            : Constant
Bit rate                                 : 114 Mb/s
Width                                    : 1 920 pixels
Height                                   : 1 080 pixels
Display aspect ratio                     : 16:9
Frame rate                               : 29.970 (30000/1001) FPS
Standard                                 : Component
Color space                              : YUV
Chroma subsampling                       : 4:2:2
Bit depth                                : 10 bits
Scan type                                : Progressive
Bits/(Pixel*Frame)                       : 1.829
Stream size                              : 407 MiB
Title                                    : V1
Color range                              : Limited
Color primaries                          : BT.709
Transfer characteristics                 : BT.709
Matrix coefficients                      : BT.709

Other #1
ID                                       : 901-Material
Type                                     : Time code
Format                                   : MXF TC
Frame rate                               : 29.970 (30000/1001) FPS
Time code of first frame                 : 00:00:00;00
Time code of last frame                  : 00:00:29;29
Time code settings                       : Material Package
Time code, stripped                      : Yes
Title                                    : TC1

Other #2
ID                                       : 901-Source
Type                                     : Time code
Format                                   : MXF TC
Frame rate                               : 29.970 (30000/1001) FPS
Time code of first frame                 : 00:00:00;00
Time code of last frame                  : 00:00:29;29
Time code settings                       : Source Package
Time code, stripped                      : Yes
Title                                    : TC1
```
Good output (note, the `Text` track is now present)
```
~$ mediainfo /tmp/op47_teletext_regression_for_mediainfo.mxf 
General
Complete name                            : /tmp/op47_teletext_regression_for_mediainfo.mxf
Format                                   : MXF
Commercial name                          : AVC-Intra 100
Format version                           : 1.3
Format profile                           : OP-1a
Format settings                          : Closed / Complete
File size                                : 407 MiB
Duration                                 : 30 s 30 ms
Overall bit rate                         : 114 Mb/s
Frame rate                               : 29.970 FPS
Encoded date                             : 2026-08-27 01:54:45.188
Writing application                      : Elemental Server 2.18.0.0.1
Writing library                          : libMXF (Linux 64-bit) 1.1.0.0.0

Video
ID                                       : 1001
Format                                   : AVC
Format/Info                              : Advanced Video Codec
Commercial name                          : AVC-Intra 100
Format profile                           : High 4:2:2 Intra@L4.1
Format settings, CABAC                   : No
Format settings, GOP                     : N=1
Format settings, wrapping mode           : Frame
Format settings, Slice count             : 10 slices per frame
Codec ID                                 : 0D01030102106001-0401020201323103
Duration                                 : 30 s 30 ms
Bit rate mode                            : Constant
Bit rate                                 : 114 Mb/s
Width                                    : 1 920 pixels
Height                                   : 1 080 pixels
Display aspect ratio                     : 16:9
Frame rate                               : 29.970 (30000/1001) FPS
Standard                                 : Component
Color space                              : YUV
Chroma subsampling                       : 4:2:2
Bit depth                                : 10 bits
Scan type                                : Progressive
Bits/(Pixel*Frame)                       : 1.829
Stream size                              : 407 MiB
Title                                    : V1
Color range                              : Limited
Color primaries                          : BT.709
Transfer characteristics                 : BT.709
Matrix coefficients                      : BT.709

Text
ID                                       : 3001-888
Format                                   : Teletext Subtitle
Format settings, wrapping mode           : Frame
Muxing mode                              : Ancillary data / OP-47 / SDP
Codec ID                                 : 0D010301020E0000
Duration                                 : 30 s 30 ms
Frame rate                               : 29.970 FPS
Title                                    : D1

Other #1
ID                                       : 901-Material
Type                                     : Time code
Format                                   : MXF TC
Frame rate                               : 29.970 (30000/1001) FPS
Time code of first frame                 : 00:00:00;00
Time code of last frame                  : 00:00:29;29
Time code settings                       : Material Package
Time code, stripped                      : Yes
Title                                    : TC1

Other #2
ID                                       : 901-Source
Type                                     : Time code
Format                                   : MXF TC
Frame rate                               : 29.970 (30000/1001) FPS
Time code of first frame                 : 00:00:00;00
Time code of last frame                  : 00:00:29;29
Time code settings                       : Source Package
Time code, stripped                      : Yes
Title                                    : TC1
```