### PR TITLE
Recover ABR target bitrate >255 kbps from preset field

### DIFF
--- a/Source/MediaInfo/Audio/File_Mpega.cpp
+++ b/Source/MediaInfo/Audio/File_Mpega.cpp
@@ -1526,6 +1526,7 @@ void File_Mpega::Header_Encoders_Lame()
     if (HasInfoTag)
     {
         int8u Flags, lowpass, EncodingFlags, BitRate, StereoMode;
+        int16u PresetAndSurround;
         Param_Info1(Ztring(__T("V "))+Ztring::ToZtring((100-Xing_Scale)/10));
         Param_Info1(Ztring(__T("q "))+Ztring::ToZtring((100-Xing_Scale)%10));
         Get_String (9, Encoded_Library,                         "Encoded_Library");
@@ -1555,7 +1556,7 @@ void File_Mpega::Header_Encoders_Lame()
         Skip_S1(2,                                              "noise shapings");
         BS_End();
         Skip_B1(                                                "MP3 Gain");
-        Skip_B2(                                                "Preset and surround info");
+        Get_B2 (PresetAndSurround,                              "Preset and surround info");
         Skip_B4(                                                "MusicLength");
         Skip_B2(                                                "MusicCRC");
         Skip_B2(                                                "CRC-16 of Info Tag");
@@ -1575,7 +1576,7 @@ void File_Mpega::Header_Encoders_Lame()
             }
             if (Xing_Scale<=100) //Xing_Scale is used for LAME quality
             {
-                if ((Flags & 0x0F) == 3 || (Flags & 0x0F) == 4 || (Flags & 0x0F) == 5 || (Flags & 0x0F) == 6 || (Flags & 0x0F) == 9) //VBR modes only
+                if ((Flags&0x0F)==3 || (Flags&0x0F)==4 || (Flags&0x0F)==5 || (Flags&0x0F)==6) //VBR modes only
                     Encoded_Library_Settings+=__T( " -V ")+Ztring::ToZtring((100-Xing_Scale)/10);
                 Encoded_Library_Settings+=__T( " -q ")+Ztring::ToZtring((100-Xing_Scale)%10);
             }
@@ -1616,14 +1617,23 @@ void File_Mpega::Header_Encoders_Lame()
                     default : ;
                 }
             }
-            else if (BitRate==0xFF) //Fallback for CBR bitrates that do not fit in the LAME tag byte (e.g. 256/320)
+            else if (BitRate==0xFF) //Fallback for CBR and ABR bitrates that do not fit in the LAME tag byte (e.g. 256/320)
             {
-                if ((Flags&0x0F)==1 || (Flags&0x0F)==8) //CBR mode only
+                if ((Flags&0x0F)==1 || (Flags&0x0F)==8) //CBR modes only
                 {
                     if (ID<4 && layer<4 && bitrate_index<16 && Mpega_BitRate[ID][layer][bitrate_index]!=0)
                     {
                         int16u FrameBitRate=Mpega_BitRate[ID][layer][bitrate_index];
                         Encoded_Library_Settings+=__T(" -b ")+Ztring::ToZtring(FrameBitRate);
+                    }
+                }
+                else if ((Flags&0x0F)==2 || (Flags&0x0F)==9) // ABR modes only
+                {
+                    int16u PresetBitRate = PresetAndSurround&0x7FF;
+                    if (PresetBitRate>=8 && PresetBitRate<=320)
+                    {
+                        BitRate_Nominal.From_Number(PresetBitRate*1000);
+                        Encoded_Library_Settings+=__T(" ")+Ztring::ToZtring(PresetBitRate);
                     }
                 }
             }


### PR DESCRIPTION
Follow-up to #2668.

## Problem

For ABR files with a target bitrate > 255 kbps (e.g., `--abr 256` or `--abr 320`), LAME writes `0xFF` in the `BitRate` byte of the LAME Info Tag, since the value does not fit in a single byte. As a result, MediaInfo currently fails to show the target bitrate in `Encoded_Library_Settings` and the `Nominal bit rate` field remains empty.

The existing fallback to the MPEG frame header bitrate (added in #2668 for CBR) does not work for ABR, because the first frame of an ABR file is a tag-container frame with a fixed bitrate of 128 kbps (`XING_BITRATE1` in LAME source), which is unrelated to the actual target bitrate.

## Solution

According to the LAME Info Tag specification (http://gabriel.mp3-tech.org/mp3infotag.html) and LAME source code (`lame.h`):

```c
/*values from 8 to 320 should be reserved for abr bitrates*/
/*for abr I'd suggest to directly use the targeted bitrate as a value*/
```

The lower 11 bits of the "Preset and surround info" field (bytes $B6-$B7) reliably store the exact ABR target bitrate. This PR reads this field when `BitRate == 0xFF` and the method is ABR (2 or 9), restoring both the `Nominal bit rate` field and the correct value in `Encoded_Library_Settings`.

## Testing

Tested with LAME 3.100 and LAME 4.1a (alpha):

| Command | BitRate byte | Result |
|---|---|---|
| `lame --abr 192` | `0xC0` | `--abr 192`, Nominal: 192 kb/s (via main path) |
| `lame --abr 256` | `0xFF` | `--abr 256`, Nominal: 256 kb/s (via new fallback) |
| `lame --abr 320` | `0xFF` | `--abr 320`, Nominal: 320 kb/s (via new fallback) |

## Changes

- Changed `Skip_B2` to `Get_B2` for "Preset and surround info" field to enable reading the ABR target bitrate
- Removed method 9 (ABR 2-pass) from the `-V` output gate (follow-up to `#2668`): per LAME specification, methods 2 and 9 are both ABR variants, so `-V` (a pure VBR CLI flag) is not applicable to them. GitHub Copilot AI correctly flagged this inconsistency during the review of `#2668`.
- Added ABR >255 kbps recovery using the `PresetAndSurround & 0x7FF` field when `BitRate == 0xFF`

This completes the triad of LAME tag fixes:
`--lowpass` display (#2658)
CBR >255 fallback (#2668)
ABR >255 recovery (this PR)