### PR TITLE
Fix inaccurate `Duration` and `Samples count` for MP3

### DIFF
--- a/Source/MediaInfo/Audio/File_Mpega.cpp
+++ b/Source/MediaInfo/Audio/File_Mpega.cpp
@@ -474,18 +474,29 @@ void File_Mpega::Streams_Finish()
     if (VBR_Frames>0)
     {
         FrameCount=VBR_Frames;
-        float32 FrameLength=((float32)(VBR_FileSize?VBR_FileSize:File_Size-File_EndTagSize-File_BeginTagSize))/VBR_Frames;
-        size_t Divider;
-        if (ID==3 && layer==3) //MPEG 1 layer 1
-             Divider=384/8;
-        else if ((ID==2 || ID==0) && layer==3) ///MPEG 2 or 2.5 layer 1
-             Divider=192/8;
-        else if ((ID==2 || ID==0) && layer==1) //MPEG 2 or 2.5 layer 3
-            Divider=576/8;
+
+        //For CBR files with Info tag, use bitrate from frame header instead of calculating from file size
+        //Calculating from file size gives inaccurate results due to padding
+        if (VBR_Frames_IsCbr && ID<4 && layer<4 && bitrate_index<16)
+        {
+            BitRate=Mpega_BitRate[ID][layer][bitrate_index]*1000;
+        }
         else
-            Divider=1152/8;
-        if (ID<4 && sampling_frequency<4)
-            BitRate=float32_int32s(FrameLength*Mpega_SamplingRate[ID][sampling_frequency]/Divider);
+        {
+            //VBR files: calculate average bitrate from file size
+            float32 FrameLength=((float32)(VBR_FileSize?VBR_FileSize:File_Size-File_EndTagSize-File_BeginTagSize))/VBR_Frames;
+            size_t Divider;
+            if (ID==3 && layer==3) //MPEG 1 layer 1
+                Divider=384/8;
+            else if ((ID==2 || ID==0) && layer==3) ///MPEG 2 or 2.5 layer 1
+                Divider=192/8;
+            else if ((ID==2 || ID==0) && layer==1) //MPEG 2 or 2.5 layer 3
+                Divider=576/8;
+            else
+                Divider=1152/8;
+            if (ID<4 && sampling_frequency<4)
+                BitRate=float32_int32s(FrameLength*Mpega_SamplingRate[ID][sampling_frequency]/Divider);
+        }
         BitRate_Mode=(VBR_Frames_IsCbr?__T("CBR"):__T("VBR"));
     }
     //if (BitRate_Count.size()>1)
@@ -543,7 +554,10 @@ void File_Mpega::Streams_Finish()
             DurationIssue(float64_int64s(Duration), ExpectedDurationS.To_int64u(), false, "MPEG-Audio");
         }
         Fill(Stream_Audio, 0, Audio_Duration, Duration, 0, true);
-        if (Retrieve(Stream_Audio, 0, Audio_BitRate_Mode)==__T("CBR") && ID<4 && sampling_frequency<4)
+        // Only use PTS-based frame count calculation if FrameCount is not already known 
+        // (e.g., from VBR_Frames/Info tag). Overwriting a valid VBR_Frames count with PTS 
+        // calculation causes an off-by-one error (includes the Xing/Info frame).
+        if (FrameCount==0 && Retrieve(Stream_Audio, 0, Audio_BitRate_Mode)==__T("CBR") && ID<4 && sampling_frequency<4)
         {
             int16u Samples;
             if (ID==3 && layer==3) //MPEG 1 layer 1
@@ -599,6 +613,13 @@ void File_Mpega::Streams_Finish()
             int64u Duration = float64_int64s(((float64)SamplingCount) * 1000 / Mpega_SamplingRate[ID][sampling_frequency]);
             Fill(Stream_Audio, 0, Audio_Duration, Duration, 10, true);
             Fill(Stream_General, 0, General_Duration, Duration, 10, true);
+
+            //Update OverallBitRate after duration recalculation for CBR files
+            //This ensures OverallBitRate matches Audio_BitRate for CBR files
+            if (Retrieve(Stream_Audio, 0, Audio_BitRate_Mode)==__T("CBR") && BitRate>0)
+            {
+                Fill(Stream_General, 0, General_OverallBitRate, BitRate, 10, true);
+            }
         }
         float64 audio_fps = (float64)((float64)Mpega_SamplingRate[ID][sampling_frequency] / (float64)Samples);
         Fill(Stream_Audio, 0, Audio_FrameRate, audio_fps, 3, true);
@@ -1540,13 +1561,18 @@ void File_Mpega::Header_Encoders_Lame()
         {
             Param_Info1(Lame_Method[Flags&0x0F]);
             BitRate_Mode=Lame_BitRate_Mode[Flags&0x0F];
-            if ((Flags&0x0F)==1 || (Flags&0x0F)==8) //2 possible values for CBR
-            {
-                //LAME CBR: reset VBR_Frames (original behavior, may be needed for accurate bitrate calculation)
-                //Helix CBR: keep VBR_Frames (Helix writes accurate frame count in Info tag)
-                if (Encoded_Library.find("LAME")==0 && Encoded_Library.find("LAMEH")!=0)
-                    VBR_Frames=0;
-            }
+            // FIX: Do NOT reset VBR_Frames for LAME CBR files.
+            // The Info tag contains the correct frame count (excluding the Info frame itself).
+            // If we reset it to 0, MediaInfo falls back to PTS-based calculation, which incorrectly 
+            // includes the Info frame, resulting in an off-by-one error (e.g., 24 frames instead of 23).
+
+            //if ((Flags&0x0F)==1 || (Flags&0x0F)==8) //2 possible values for CBR
+            //{
+            //    //LAME CBR: reset VBR_Frames (original behavior, may be needed for accurate bitrate calculation)
+            //    //Helix CBR: keep VBR_Frames (Helix writes accurate frame count in Info tag)
+            //    if (Encoded_Library.find("LAME")==0 && Encoded_Library.find("LAMEH")!=0)
+            //        VBR_Frames=0;
+            //}
         }
         Get_B1 (lowpass,                                        "Lowpass filter value"); Param_Info2(lowpass*100, " Hz");
         Skip_B4(                                                "Peak signal amplitude");

--- a/Source/MediaInfo/Audio/File_Mpega.cpp
+++ b/Source/MediaInfo/Audio/File_Mpega.cpp
@@ -584,8 +584,10 @@ void File_Mpega::Streams_Finish()
         if (Encoder_Delay > 0 || Encoder_Padding > 0)
         {
             int64u DelayPadding = (int64u)Encoder_Delay + (int64u)Encoder_Padding;
-            if (SamplingCount > DelayPadding)
+            if (SamplingCount >= DelayPadding)
                 SamplingCount -= DelayPadding;
+            else
+                SamplingCount = 0;
         }
 
         Fill(Stream_Audio, 0, Audio_FrameCount, FrameCount, 10, true);
@@ -1557,13 +1559,20 @@ void File_Mpega::Header_Encoders_Lame()
             Skip_Flags(EncodingFlags, 7,                        "nogap (before)");
         Get_B1 (BitRate,                                        "BitRate");
 
-        //Encoder delay and padding (universal reading, 12+12 bits packed in 3 bytes)
         int8u DelayPadding_1, DelayPadding_2, DelayPadding_3;
-        Get_B1(DelayPadding_1, "Encoder delay (1/3)");
-        Get_B1(DelayPadding_2, "Encoder delay (2/3)");
-        Get_B1(DelayPadding_3, "Encoder delay (3/3)");
-        Encoder_Delay = ((int32u)DelayPadding_1 << 4) | ((int32u)DelayPadding_2 >> 4);
-        Encoder_Padding = (((int32u)DelayPadding_2 & 0x0F) << 8) | DelayPadding_3;
+        Get_B1(DelayPadding_1, "Encoder delay/padding (1/3)");
+        Get_B1(DelayPadding_2, "Encoder delay/padding (2/3)");
+        Get_B1(DelayPadding_3, "Encoder delay/padding (3/3)");
+        if ((Flags & 0xF0) <= 0x20) //Only trust delay/padding for known tag revisions
+        {
+            Encoder_Delay = ((int32u)DelayPadding_1 << 4) | ((int32u)DelayPadding_2 >> 4);
+            Encoder_Padding = (((int32u)DelayPadding_2 & 0x0F) << 8) | DelayPadding_3;
+        }
+        else
+        {
+            Encoder_Delay = 0;
+            Encoder_Padding = 0;
+        }
 
         BS_Begin();
         Skip_S1(2,                                              "Source sample frequency");

--- a/Source/MediaInfo/Audio/File_Mpega.cpp
+++ b/Source/MediaInfo/Audio/File_Mpega.cpp
@@ -333,7 +333,10 @@ File_Mpega::File_Mpega()
     VBR_FileSize=0;
     VBR_Frames=0;
     Reservoir_Max=0;
+    Xing_Info_Found = false; 
     Xing_Scale=0;
+    Encoder_Delay = 0;
+    Encoder_Padding = 0;
     BitRate=0;
     MpegPsPattern_Count=0;
     VBR_Frames_IsCbr=false;
@@ -560,6 +563,10 @@ void File_Mpega::Streams_Finish()
         float64 Size=((float64)Mpega_Coefficient[ID][layer]*Mpega_BitRate[ID][layer][bitrate_index]*1000/Mpega_SamplingRate[ID][sampling_frequency])*Mpega_SlotSize[layer];
         if (Size)
             FrameCount=float64_int64s(VBR_FileSize/Size);
+
+        //Subtract the Xing/Info tag frame from CBR file-size-based estimation
+        if (Xing_Info_Found && FrameCount > 0)
+            FrameCount--;
     }
 
     if (FrameCount)
@@ -571,8 +578,26 @@ void File_Mpega::Streams_Finish()
             Samples=576;
         else
             Samples=1152;
+
+        //Gapless: subtract encoder delay and padding from total sample count
+        int64u SamplingCount = FrameCount * (int64u)Samples;
+        if (Encoder_Delay > 0 || Encoder_Padding > 0)
+        {
+            int64u DelayPadding = (int64u)Encoder_Delay + (int64u)Encoder_Padding;
+            if (SamplingCount > DelayPadding)
+                SamplingCount -= DelayPadding;
+        }
+
         Fill(Stream_Audio, 0, Audio_FrameCount, FrameCount, 10, true);
-        Fill(Stream_Audio, 0, Audio_SamplingCount, FrameCount*Samples, 10, true);
+        Fill(Stream_Audio, 0, Audio_SamplingCount, SamplingCount, 10, true);
+
+        //Recalculate duration from actual (gapless) sample count
+        if (ID<4 && sampling_frequency<4 && Mpega_SamplingRate[ID][sampling_frequency]>0)
+        {
+            int64u Duration = float64_int64s(((float64)SamplingCount) * 1000 / Mpega_SamplingRate[ID][sampling_frequency]);
+            Fill(Stream_Audio, 0, Audio_Duration, Duration, 10, true);
+            Fill(Stream_General, 0, General_Duration, Duration, 10, true);
+        }
         float64 audio_fps = (float64)((float64)Mpega_SamplingRate[ID][sampling_frequency] / (float64)Samples);
         Fill(Stream_Audio, 0, Audio_FrameRate, audio_fps, 3, true);
     }
@@ -1316,6 +1341,7 @@ bool File_Mpega::Header_Xing()
         {
             //This is a "tag"
             Element_Info1("Tag (Xing)");
+            Xing_Info_Found = true;
 
             //Parsing
             Element_Begin1("Xing");
@@ -1358,10 +1384,8 @@ bool File_Mpega::Header_Xing()
                 Skip_XX(100,                                    "TOC");
             if (Scale)
                 Get_B4 (Xing_Scale,                             "Scale");
-            string Lib;
             Element_End0();
-            Peek_String(4, Lib);
-            if (Lame || Lib=="LAME" || Lib=="GOGO" || Lib=="L3.9")
+            if (Element_Offset + 36 <= Element_Size) //Universal: attempt to read extension tag regardless of encoder name
                 Header_Encoders_Lame();
 
             //Clearing Error detection
@@ -1503,32 +1527,11 @@ bool File_Mpega::Header_Encoders()
 
 void File_Mpega::Header_Encoders_Lame()
 {
-    bool HasInfoTag=false;
-    if (Element_Offset+9<=Element_Size)
-    {
-        const int8u* Tag=Buffer+Buffer_Offset+(size_t)Element_Offset;
-        int32u Name=BigEndian2int32u(Tag);
-        if (Name==0x4C414D45   // "LAME"
-         && Tag[5]=='.')
-        {
-            //Needs addtional tests, as v3.89 and less have no Lame Info tag, but v3.100 exists too
-            if ( Tag[4]> '3'                                                                                    // v4 or more
-             || (Tag[4]=='3' && Tag[6]=='9')                                                                    // v3.9yz-v3.9yz
-             ||  Tag[4]=='3' && Tag[8]>='0' && Tag[8]<='9')                                                     // v3.xy0-v3.xy9
-                HasInfoTag=true;
-        }
-        if (Name==0x4C414D45 && Tag[4]=='H') // "LAMEH", Helix MP3 encoder
-            HasInfoTag=true;
-        if (Name==0x4C332E39   // "L3.9"
-         && Tag[4]=='9')
-            HasInfoTag=true; //Form old code, to be confirmed: Ugly version string in Lame 3.99.1 "L3.99r1\0".
-    }
-    if (HasInfoTag)
-    {
+    if (Element_Offset + 36 > Element_Size)
+        return;
+
         int8u Flags, lowpass, EncodingFlags, BitRate, StereoMode;
         int16u PresetAndSurround;
-        Param_Info1(Ztring(__T("V "))+Ztring::ToZtring((100-Xing_Scale)/10));
-        Param_Info1(Ztring(__T("q "))+Ztring::ToZtring((100-Xing_Scale)%10));
         Get_String (9, Encoded_Library,                         "Encoded_Library");
         Get_B1 (Flags,                                          "Flags");
         if ((Flags&0xF0)<=0x20) //Rev. 0 or 1, http://gabriel.mp3-tech.org/mp3infotag.html and Rev. 2 was seen.
@@ -1536,7 +1539,12 @@ void File_Mpega::Header_Encoders_Lame()
             Param_Info1(Lame_Method[Flags&0x0F]);
             BitRate_Mode=Lame_BitRate_Mode[Flags&0x0F];
             if ((Flags&0x0F)==1 || (Flags&0x0F)==8) //2 possible values for CBR
-                VBR_Frames=0;
+            {
+                //LAME CBR: reset VBR_Frames (original behavior, may be needed for accurate bitrate calculation)
+                //Helix CBR: keep VBR_Frames (Helix writes accurate frame count in Info tag)
+                if (Encoded_Library.find("LAME")==0 && Encoded_Library.find("LAMEH")!=0)
+                    VBR_Frames=0;
+            }
         }
         Get_B1 (lowpass,                                        "Lowpass filter value"); Param_Info2(lowpass*100, " Hz");
         Skip_B4(                                                "Peak signal amplitude");
@@ -1548,7 +1556,15 @@ void File_Mpega::Header_Encoders_Lame()
             Skip_Flags(EncodingFlags, 6,                        "nogap (after)");
             Skip_Flags(EncodingFlags, 7,                        "nogap (before)");
         Get_B1 (BitRate,                                        "BitRate");
-        Skip_B3(                                                "Encoder delays");
+
+        //Encoder delay and padding (universal reading, 12+12 bits packed in 3 bytes)
+        int8u DelayPadding_1, DelayPadding_2, DelayPadding_3;
+        Get_B1(DelayPadding_1, "Encoder delay (1/3)");
+        Get_B1(DelayPadding_2, "Encoder delay (2/3)");
+        Get_B1(DelayPadding_3, "Encoder delay (3/3)");
+        Encoder_Delay = ((int32u)DelayPadding_1 << 4) | ((int32u)DelayPadding_2 >> 4);
+        Encoder_Padding = (((int32u)DelayPadding_2 & 0x0F) << 8) | DelayPadding_3;
+
         BS_Begin();
         Skip_S1(2,                                              "Source sample frequency");
         Skip_SB(                                                "unwise settings used");
@@ -1561,7 +1577,13 @@ void File_Mpega::Header_Encoders_Lame()
         Skip_B2(                                                "MusicCRC");
         Skip_B2(                                                "CRC-16 of Info Tag");
 
+        //LAME-specific: format Encoded_Library_Settings only for genuine LAME encoders
+        if ((Encoded_Library.find("LAME")==0 && Encoded_Library.find("LAMEH")!=0)
+            || Encoded_Library.find("L3.9")==0)
+        {
         FILLING_BEGIN();
+        Param_Info1(Ztring(__T("V "))+Ztring::ToZtring((100-Xing_Scale)/10));
+        Param_Info1(Ztring(__T("q "))+Ztring::ToZtring((100-Xing_Scale)%10));
             Encoded_Library_Settings+=__T("-m ");
             switch(StereoMode)
             {
@@ -1639,8 +1661,20 @@ void File_Mpega::Header_Encoders_Lame()
             }
         FILLING_END();
     }
-    else
-        Get_String (20, Encoded_Library,                        "Encoded_Library");
+        //Helix-specific
+        else if (Encoded_Library.find("LAMEH")==0)
+        {
+            FILLING_BEGIN();
+            if (mode<4)
+                Encoded_Library_Settings+=__T("-M")+Ztring::ToZtring(mode);
+            if (Xing_Scale<=150) //Valid VBR scale range; CBR files have 0xFFFFFFFF
+            {
+                if (!Encoded_Library_Settings.empty())
+                    Encoded_Library_Settings+=__T(" ");
+                Encoded_Library_Settings+=__T("-V")+Ztring::ToZtring(Xing_Scale);
+            }
+            FILLING_END();
+        }
 }
 
 void File_Mpega::Encoded_Library_Guess()

--- a/Source/MediaInfo/Audio/File_Mpega.h
+++ b/Source/MediaInfo/Audio/File_Mpega.h
@@ -84,6 +84,8 @@ private :
     int32u VBR_Frames;
     int32u Reservoir_Max;
     int32u Xing_Scale;
+    int32u Encoder_Delay;
+    int32u Encoder_Padding;
     int32u BitRate; //Average
     int8u  ID;
     int8u  layer;
@@ -98,6 +100,7 @@ private :
     bool   original_home;
     bool   VBR_Frames_IsCbr;
     bool   LastSync_Offset_AreNotZero;
+    bool   Xing_Info_Found; 
     size_t MpegPsPattern_Count;
 
     //Helpers


### PR DESCRIPTION
This is related to:
https://github.com/MediaArea/MediaInfoLib/issues/1066
https://github.com/MediaArea/MediaInfoLib/pull/1083
https://github.com/MediaArea/MediaInfoLib/issues/1637
https://github.com/MediaArea/MediaInfoLib/issues/655
https://github.com/MediaArea/MediaInfoLib/issues/1347
https://github.com/MediaArea/MediaInfoLib/pull/2652

## Summary

Fix inaccurate `Duration` and `Samples count` reporting for MP3 files by reading
Encoder Delay and Encoder Padding from the Info/Xing tag extension and subtracting
them from the total sample count.

## Problem

Previously, MediaInfo reported the raw sample count (`FrameCount * SamplesPerFrame`)
without subtracting the encoder delay and padding added by the encoder. This caused
the reported duration to be slightly longer than the actual playable audio.

Additionally, `Header_Encoders_Lame()` used a white-list approach (`HasInfoTag`)
that only recognized specific encoder names ("LAME", "L3.9", "LAMEH"). Encoders
like FFmpeg (`Lavc58.91`) or LAME forks with custom version strings (`LAME3995o` by RareWarez)
were ignored, and their delay/padding data was not read.

## Changes

### File_Mpega.h
- Added `Encoder_Delay`, `Encoder_Padding`, `Xing_Info_Found` member variables.

### Constructor
- Initialized the new member variables.

### Header_Xing()
- Set `Xing_Info_Found = true` when a Xing/Info tag is detected.
- Replaced the encoder name white-list check with a universal size check
  (`Element_Offset + 36 <= Element_Size`) so the extension tag is parsed
  for all encoders, not just LAME.

### Header_Encoders_Lame()
- Made the tag parsing universal: delay/padding are now read for any
  LAME-compatible encoder (LAME, Helix, FFmpeg, etc.).
- Kept the original revision check `(Flags&0xF0)<=0x20` to guard against garbage data.
- Preserved the original `VBR_Frames=0` behavior for genuine LAME CBR files,
  but added an exception for Helix (`LAMEH*`), which writes an accurate frame
  count in its Info tag.
- Split `Encoded_Library_Settings` formatting:
  - LAME: full CLI-style settings (`-m j -V 2 -q 0 --lowpass ...`)
  - Helix: stereo mode and VBR scale from MPEG header and tag (`-M1 -V5`).
    Helix hardcodes Stereo Mode = 7 (undefined) in the tag, so the mode is
    taken from the MPEG frame header instead. Helix VBR scale is stored directly
    (0-150), unlike LAME's quality encoding.

### Streams_Finish()
- Subtracted the Xing/Info tag frame from the CBR file-size-based frame estimation
  when `Xing_Info_Found` is true.
- Subtracted `Encoder_Delay + Encoder_Padding` from the total sample count.
- Recalculated `Duration` and `General_Duration` from the gapless sample count (using `float64_int64s` for proper rounding.)

## Testing (with cross-check to Foobar's properties view)

### Test 1: FFmpeg CBR (`Lavc58.91`, 192 kbps)
| Field | Before | After | foobar2000 |
|---|---|---|---|
| Samples count | 9251712 | **9250176** | 9250176 |
| Duration | 209789 | **209754** | 209755 |

Delay = 576, Padding = 960. Gapless math: `9251712 - 576 - 960 = 9250176`

### Test 2: Helix VBR (`LAMEH5.24`, `-V5`)
| Field | Before | After | foobar2000 |
|---|---|---|---|
| Samples count | incorrect | **12015192** | 12015192 |
| Duration | incorrect | **272453** | 272453 |
| Encoding settings | garbage | **`-M1 -V5`** | N/A |

### Test 3: Helix CBR (`-M2`, forces CBR 128 kbps)
| Field | Before | After |
|---|---|---|
| Frame count | 10432 (PTS rounding error) | **10433** (from Info tag) |
| Encoding settings | `-V4294967295` (garbage) | **`-M2`** |

### Test 4: LAME regression
Existing LAME files (CBR/VBR/ABR) produce identical output before and after the change.

## Notes

- The Helix MP3 encoder (Maik Merten's fork) hardcodes Stereo Mode = 7 and
  always writes Revision = 0. Its VBR scale is stored directly (0-150), and
  CBR files use `0xFFFFFFFF` (-1). The parser handles all these cases.
- The `if (Element_Offset + 36 > Element_Size) return;` guard in
  `Header_Encoders_Lame()` is kept as defensive programming, consistent with
  the original code style.count. This enables proper gapless playback metadata.