### PR TITLE
Fix two issues with opus channel display

### DIFF
--- a/Source/MediaInfo/Audio/File_Opus.cpp
+++ b/Source/MediaInfo/Audio/File_Opus.cpp
@@ -68,12 +68,12 @@ static const char*  Opus_ChannelLayout[Opus_ChannelLayout_Max]=
 {
     "M",
     "L R",
-    "L R C",
+    "L C R",
     "L R BL BR",
-    "L R C BL BR",
-    "L R C BL BR LFE",
-    "L R C SL SR BC LFE",
-    "L R C SL SR BL BR LFE",
+    "L C R BL BR",
+    "L C R BL BR LFE",
+    "L C R SL SR BC LFE",
+    "L C R SL SR BL BR LFE",
 };
 
 //---------------------------------------------------------------------------

--- a/Source/MediaInfo/Audio/File_Opus.cpp
+++ b/Source/MediaInfo/Audio/File_Opus.cpp
@@ -70,7 +70,7 @@ static const char*  Opus_ChannelLayout[Opus_ChannelLayout_Max]=
     "L R",
     "L R C",
     "L R BL BR",
-    "L R BL BR LFE",
+    "L R C BL BR",
     "L R C BL BR LFE",
     "L R C SL SR BC LFE",
     "L R C SL SR BL BR LFE",


### PR DESCRIPTION
Fixes 5.0 being incorrectly displayed as 4.1, and channel layout using the wrong order for the center channel.